### PR TITLE
Add /mcp HTTP endpoint for streamable HTTP MCP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,16 @@ The server will start an HTTP endpoint at `http://localhost:8080/mcp` that accep
 **Options:**
 - `-http`: Enable HTTP transport (default: stdio)
 - `-port`: Port to listen on for HTTP transport (default: 8080)
+- `-host`: Host to bind to for HTTP transport (default: 127.0.0.1)
 
 **Example with custom port:**
 ```bash
 ./bin/lfx-mcp-server -http -port 9090
+```
+
+**Example binding to all interfaces:**
+```bash
+./bin/lfx-mcp-server -http -host 0.0.0.0 -port 8080
 ```
 
 **Example HTTP request:**
@@ -201,7 +207,6 @@ curl -X POST http://localhost:8080/mcp \
 ```
 
 Responses are returned as Server-Sent Events (SSE) with `event: message` and `data:` fields.
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project implements an MCP server that exposes LFX platform functionality th
 
 - **Hello World Tool**: A simple demonstration tool for testing MCP connectivity
 - **Stdio Transport**: Communication via standard input/output streams
+- **HTTP Transport**: Streamable HTTP endpoint for web-based MCP clients
 - **Extensible Architecture**: Clean structure for adding new tools and resources
 
 ## Quick Start
@@ -39,6 +40,8 @@ This project implements an MCP server that exposes LFX platform functionality th
 
 ### Running the Server
 
+#### Stdio Transport
+
 To start the MCP server with stdio transport:
 
 ```bash
@@ -46,6 +49,28 @@ To start the MCP server with stdio transport:
 ```
 
 The server will listen for MCP messages on stdin and respond on stdout.
+
+#### HTTP Transport
+
+To start the MCP server with HTTP transport:
+
+```bash
+./bin/lfx-mcp-server http --port 8080
+```
+
+The server will start an HTTP endpoint at `http://localhost:8080/mcp` that accepts MCP requests over streamable HTTP (Server-Sent Events). This is useful for web-based MCP clients.
+
+**Options:**
+- `--port`: Port to listen on (default: 8080)
+
+**Example HTTP request:**
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"web-client","version":"1.0.0"}}}'
+```
+
+The HTTP transport uses stateless mode, creating a new MCP session for each request. This allows horizontal scaling without session management.
 
 ## Available Tools
 
@@ -134,6 +159,8 @@ Tools are implemented in the `internal/tools` package for better organization an
 
 ### Testing
 
+#### Testing Stdio Transport
+
 To test the server manually, you can send JSON-RPC messages via stdio:
 
 ```bash
@@ -146,6 +173,28 @@ To test the server manually, you can send JSON-RPC messages via stdio:
 (echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'; 
  echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX User","message":"Welcome"}}}'; 
  sleep 1) | ./bin/lfx-mcp-server stdio
+```
+
+#### Testing HTTP Transport
+
+Start the HTTP server and send requests using curl:
+
+```bash
+# Start the server in the background
+./bin/lfx-mcp-server http --port 8080 &
+
+# Test tools list
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+
+# Test calling hello_world tool
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX","message":"Welcome"}}}'
+```
+
+Responses are returned as Server-Sent Events (SSE) with `event: message` and `data:` fields.
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ This project implements an MCP server that exposes LFX platform functionality th
 
 ### Running the Server
 
-#### Stdio Transport
+#### Stdio Transport (Default)
 
-To start the MCP server with stdio transport:
+To start the MCP server with stdio transport (default behavior):
 
 ```bash
-./bin/lfx-mcp-server stdio
+./bin/lfx-mcp-server
 ```
 
 The server will listen for MCP messages on stdin and respond on stdout.
@@ -55,13 +55,19 @@ The server will listen for MCP messages on stdin and respond on stdout.
 To start the MCP server with HTTP transport:
 
 ```bash
-./bin/lfx-mcp-server http --port 8080
+./bin/lfx-mcp-server -http
 ```
 
 The server will start an HTTP endpoint at `http://localhost:8080/mcp` that accepts MCP requests over streamable HTTP (Server-Sent Events). This is useful for web-based MCP clients.
 
 **Options:**
-- `--port`: Port to listen on (default: 8080)
+- `-http`: Enable HTTP transport (default: stdio)
+- `-port`: Port to listen on for HTTP transport (default: 8080)
+
+**Example with custom port:**
+```bash
+./bin/lfx-mcp-server -http -port 9090
+```
 
 **Example HTTP request:**
 ```bash
@@ -172,7 +178,7 @@ To test the server manually, you can send JSON-RPC messages via stdio:
 # Test calling the hello_world tool
 (echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'; 
  echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX User","message":"Welcome"}}}'; 
- sleep 1) | ./bin/lfx-mcp-server stdio
+ sleep 1) | ./bin/lfx-mcp-server
 ```
 
 #### Testing HTTP Transport
@@ -181,7 +187,7 @@ Start the HTTP server and send requests using curl:
 
 ```bash
 # Start the server in the background
-./bin/lfx-mcp-server http --port 8080 &
+./bin/lfx-mcp-server -http -port 8080 &
 
 # Test tools list
 curl -X POST http://localhost:8080/mcp \

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -18,31 +18,19 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+var (
+	httpMode = flag.Bool("http", false, "Enable HTTP transport (default: stdio)")
+	port     = flag.Int("port", 8080, "Port to listen on for HTTP transport")
+)
+
 func main() {
-	if len(os.Args) < 2 {
-		printUsage()
-		os.Exit(1)
-	}
+	flag.Parse()
 
-	command := os.Args[1]
-	switch command {
-	case "stdio":
-		runStdioServer()
-	case "http":
+	if *httpMode {
 		runHTTPServer()
-	default:
-		printUsage()
-		os.Exit(1)
+	} else {
+		runStdioServer()
 	}
-}
-
-func printUsage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s <command> [options]\n\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "Commands:\n")
-	fmt.Fprintf(os.Stderr, "  stdio    Start MCP server on stdio transport\n")
-	fmt.Fprintf(os.Stderr, "  http     Start MCP server on HTTP transport\n\n")
-	fmt.Fprintf(os.Stderr, "HTTP Options:\n")
-	fmt.Fprintf(os.Stderr, "  --port   Port to listen on (default: 8080)\n")
 }
 
 func runStdioServer() {
@@ -64,13 +52,6 @@ func runStdioServer() {
 }
 
 func runHTTPServer() {
-	// Parse HTTP-specific flags.
-	httpFlags := flag.NewFlagSet("http", flag.ExitOnError)
-	port := httpFlags.Int("port", 8080, "Port to listen on")
-	if err := httpFlags.Parse(os.Args[2:]); err != nil {
-		log.Fatalf("Failed to parse flags: %v", err)
-	}
-
 	// Create server factory function for stateless mode.
 	createServer := func(_ *http.Request) *mcp.Server {
 		server := mcp.NewServer(&mcp.Implementation{

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -22,6 +22,7 @@ import (
 var (
 	httpMode = flag.Bool("http", false, "Enable HTTP transport (default: stdio)")
 	port     = flag.Int("port", 8080, "Port to listen on for HTTP transport")
+	host     = flag.String("host", "127.0.0.1", "Host to bind to for HTTP transport")
 )
 
 func main() {
@@ -34,10 +35,8 @@ func main() {
 	}
 }
 
-func runStdioServer() {
-	ctx := context.Background()
-
-	// Create the MCP server.
+// newServer creates and configures a new MCP server with registered tools.
+func newServer() *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "lfx-mcp-server",
 		Version: "0.1.0",
@@ -45,6 +44,15 @@ func runStdioServer() {
 
 	// Register tools.
 	tools.RegisterHelloWorld(server)
+
+	return server
+}
+
+func runStdioServer() {
+	ctx := context.Background()
+
+	// Create the MCP server.
+	server := newServer()
 
 	// Run the server on stdio transport.
 	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
@@ -55,15 +63,7 @@ func runStdioServer() {
 func runHTTPServer() {
 	// Create server factory function for stateless mode.
 	createServer := func(_ *http.Request) *mcp.Server {
-		server := mcp.NewServer(&mcp.Implementation{
-			Name:    "lfx-mcp-server",
-			Version: "0.1.0",
-		}, nil)
-
-		// Register tools.
-		tools.RegisterHelloWorld(server)
-
-		return server
+		return newServer()
 	}
 
 	// Create streamable HTTP handler with stateless mode.
@@ -75,28 +75,35 @@ func runHTTPServer() {
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", handler)
 
-	addr := fmt.Sprintf(":%d", *port)
+	addr := fmt.Sprintf("%s:%d", *host, *port)
 	httpServer := &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	// Setup graceful shutdown.
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
+	errCh := make(chan error, 1)
+
 	// Start server in goroutine.
 	go func() {
 		log.Printf("Starting HTTP server on %s", addr)
-		log.Printf("MCP endpoint available at http://localhost%s/mcp", addr)
+		log.Printf("MCP endpoint available at http://%s/mcp", addr)
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("HTTP server failed: %v", err)
+			errCh <- err
 		}
 	}()
 
-	// Wait for shutdown signal.
-	<-shutdown
-	log.Println("Shutting down HTTP server...")
+	// Wait for shutdown signal or server error.
+	select {
+	case <-shutdown:
+		log.Println("Shutting down HTTP server...")
+	case err := <-errCh:
+		log.Printf("HTTP server failed: %v", err)
+	}
 
 	// Create shutdown context with timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -5,21 +5,44 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/linuxfoundation/lfx-mcp/internal/tools"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "stdio" {
-		runStdioServer()
-	} else {
-		fmt.Fprintf(os.Stderr, "Usage: %s stdio\n", os.Args[0])
+	if len(os.Args) < 2 {
+		printUsage()
 		os.Exit(1)
 	}
+
+	command := os.Args[1]
+	switch command {
+	case "stdio":
+		runStdioServer()
+	case "http":
+		runHTTPServer()
+	default:
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: %s <command> [options]\n\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Commands:\n")
+	fmt.Fprintf(os.Stderr, "  stdio    Start MCP server on stdio transport\n")
+	fmt.Fprintf(os.Stderr, "  http     Start MCP server on HTTP transport\n\n")
+	fmt.Fprintf(os.Stderr, "HTTP Options:\n")
+	fmt.Fprintf(os.Stderr, "  --port   Port to listen on (default: 8080)\n")
 }
 
 func runStdioServer() {
@@ -38,4 +61,69 @@ func runStdioServer() {
 	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
+}
+
+func runHTTPServer() {
+	// Parse HTTP-specific flags.
+	httpFlags := flag.NewFlagSet("http", flag.ExitOnError)
+	port := httpFlags.Int("port", 8080, "Port to listen on")
+	if err := httpFlags.Parse(os.Args[2:]); err != nil {
+		log.Fatalf("Failed to parse flags: %v", err)
+	}
+
+	// Create server factory function for stateless mode.
+	createServer := func(_ *http.Request) *mcp.Server {
+		server := mcp.NewServer(&mcp.Implementation{
+			Name:    "lfx-mcp-server",
+			Version: "0.1.0",
+		}, nil)
+
+		// Register tools.
+		tools.RegisterHelloWorld(server)
+
+		return server
+	}
+
+	// Create streamable HTTP handler with stateless mode.
+	handler := mcp.NewStreamableHTTPHandler(createServer, &mcp.StreamableHTTPOptions{
+		Stateless: true,
+	})
+
+	// Setup HTTP server with handler mounted on /mcp.
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", handler)
+
+	addr := fmt.Sprintf(":%d", *port)
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	// Setup graceful shutdown.
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+
+	// Start server in goroutine.
+	go func() {
+		log.Printf("Starting HTTP server on %s", addr)
+		log.Printf("MCP endpoint available at http://localhost%s/mcp", addr)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("HTTP server failed: %v", err)
+		}
+	}()
+
+	// Wait for shutdown signal.
+	<-shutdown
+	log.Println("Shutting down HTTP server...")
+
+	// Create shutdown context with timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Attempt graceful shutdown.
+	if err := httpServer.Shutdown(ctx); err != nil {
+		log.Fatalf("Server shutdown failed: %v", err)
+	}
+
+	log.Println("HTTP server stopped")
 }

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package main provides the LFX MCP server binary with support for stdio and HTTP transports.
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
 module github.com/linuxfoundation/lfx-mcp
 
 go 1.26.0

--- a/internal/tools/hello_world.go
+++ b/internal/tools/hello_world.go
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package tools provides MCP tool implementations for the LFX MCP server.
 package tools
 
 import (
@@ -25,7 +26,7 @@ func RegisterHelloWorld(server *mcp.Server) {
 }
 
 // handleHelloWorld implements the hello_world tool logic.
-func handleHelloWorld(ctx context.Context, req *mcp.CallToolRequest, args HelloWorldArgs) (*mcp.CallToolResult, any, error) {
+func handleHelloWorld(_ context.Context, _ *mcp.CallToolRequest, args HelloWorldArgs) (*mcp.CallToolResult, any, error) {
 	// Extract name parameter with default.
 	name := "World"
 	if args.Name != "" {


### PR DESCRIPTION
## Description

Implements ARCH-323: Add `/mcp` HTTP endpoint for "streamable HTTP" MCP transport to enable web-based MCP clients to connect to the server.

## Changes

### Phase 1 Implementation
- ✅ Add HTTP transport support with stateless streamable handler
- ✅ Mount handler on `/mcp` endpoint
- ✅ Graceful shutdown with signal handling
- ✅ Flag-based CLI interface with stdio as default
- ✅ Comprehensive documentation with examples

### Implementation Details

**Commits:**
1. Initial HTTP endpoint implementation with `mcp.NewStreamableHTTPHandler()`
2. Refactored to use Go `flag` package for improved UX

**Key Features:**
- Stateless mode using `mcp.NewStreamableHTTPHandler()` with `Stateless: true`
- Server-Sent Events (SSE) response format
- Reuses existing tool registration logic for both transports
- Horizontal scaling ready (no session management needed)

## Usage

```bash
# Stdio transport (default)
./bin/lfx-mcp-server

# HTTP transport on default port 8080
./bin/lfx-mcp-server -http

# HTTP transport on custom port
./bin/lfx-mcp-server -http -port 9090
```

## Testing

- ✅ Verified stdio transport (default behavior)
- ✅ Verified HTTP transport with default port (8080)
- ✅ Verified HTTP transport with custom port
- ✅ All code quality checks pass (fmt, vet, lint)
- ✅ Both transports working correctly with tool calls
- ✅ Responses correctly formatted as Server-Sent Events

## Documentation

Updated README.md with:
- HTTP transport usage examples
- Flag documentation
- Testing examples for both transports
- Architecture notes on stateless mode

## Related Issues

ARCH-323