### PR TITLE
Add Docker build via ko following lfx-v2 patterns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+.git
+.gitignore
+.dockerignore
+**/bin
+
+# Local and temporary files
+**/.DS_Store
+.idea
+.vscode
+**/*.swp
+**/*.out
+**/*~
+**/*.pem
+**/.env
+**/*.env
+
+# MegaLinter reports
+/megalinter-reports/
+
+# Documentation
+**/README.md
+**/*.md
+LICENSE*
+
+# Test files
+**/*_test.go
+
+# Development files
+Makefile
+test_server.sh
+check-headers.sh
+
+# Build artifacts
+coverage.out
+coverage.html

--- a/.github/workflows/ko-build-main.yaml
+++ b/.github/workflows/ko-build-main.yaml
@@ -1,0 +1,36 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+name: Publish Main
+
+"on":
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish Main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+        with:
+          version: v0.18.0
+      - run: |
+          ko build github.com/linuxfoundation/lfx-mcp/cmd/lfx-mcp-server \
+            -B \
+            --platform linux/amd64,linux/arm64 \
+            -t ${{ github.sha }} \
+            -t development \
+            --sbom spdx

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -34,7 +34,7 @@ jobs:
         id: prepare
         run: |
           set -euo pipefail
-          APP_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//g')
+          APP_VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
           echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -1,0 +1,101 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+name: Publish Tagged Release
+
+"on":
+  push:
+    tags:
+      - v*
+
+env:
+  COSIGN_VERSION: v3.0.2
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish Tagged Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      app_version: ${{ steps.prepare.outputs.app_version }}
+      digest: ${{ steps.build.outputs.digest }}
+      image_name: ${{ steps.build.outputs.image_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Prepare versions
+        id: prepare
+        run: |
+          set -euo pipefail
+          APP_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//g')
+          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Ko
+        uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+        with:
+          version: v0.18.0
+
+      - name: Build and publish lfx-mcp-server image
+        id: build
+        run: |
+          set -euo pipefail
+          IMAGE_REF=$(ko build github.com/linuxfoundation/lfx-mcp/cmd/lfx-mcp-server \
+            -B \
+            --platform linux/amd64,linux/arm64 \
+            -t ${{ github.ref_name }} \
+            -t ${{ steps.prepare.outputs.app_version }} \
+            -t latest \
+            --sbom spdx \
+            --image-refs /tmp/image-refs.txt)
+
+          DIGEST=$(cat /tmp/image-refs.txt | cut -d'@' -f2)
+          IMAGE_NAME=$(cat /tmp/image-refs.txt | cut -d'@' -f1)
+
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        with:
+          cosign-release: "${{ env.COSIGN_VERSION }}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign the container image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes '${{ steps.build.outputs.image_name }}@${{ steps.build.outputs.digest }}'
+
+  create-provenance:
+    needs:
+      - publish
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ needs.publish.outputs.image_name }}
+      digest: ${{ needs.publish.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -51,14 +51,14 @@ jobs:
         id: build
         run: |
           set -euo pipefail
-          IMAGE_REF=$(ko build github.com/linuxfoundation/lfx-mcp/cmd/lfx-mcp-server \
+          ko build github.com/linuxfoundation/lfx-mcp/cmd/lfx-mcp-server \
             -B \
             --platform linux/amd64,linux/arm64 \
             -t ${{ github.ref_name }} \
             -t ${{ steps.prepare.outputs.app_version }} \
             -t latest \
             --sbom spdx \
-            --image-refs /tmp/image-refs.txt)
+            --image-refs /tmp/image-refs.txt
 
           DIGEST=$(cat /tmp/image-refs.txt | cut -d'@' -f2)
           IMAGE_NAME=$(cat /tmp/image-refs.txt | cut -d'@' -f1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,20 +265,20 @@ This tests:
 
 ### Available Targets
 
-| Target | Description |
-|--------|-------------|
-| `all` | Clean, check, and build (default) |
-| `build` | Compile the binary |
-| `clean` | Remove build artifacts |
-| `fmt` | Format Go code |
-| `vet` | Run go vet |
-| `lint` | Run golangci-lint |
-| `check` | Run fmt, vet, and lint |
-| `run` | Build and run in stdio mode |
-| `test` | Run Go tests |
-| `test-coverage` | Run tests with coverage |
-| `deps` | Download and tidy dependencies |
-| `install-tools` | Install development tools |
+| Target          | Description                       |
+|-----------------|-----------------------------------|
+| `all`           | Clean, check, and build (default) |
+| `build`         | Compile the binary                |
+| `clean`         | Remove build artifacts            |
+| `fmt`           | Format Go code                    |
+| `vet`           | Run go vet                        |
+| `lint`          | Run golangci-lint                 |
+| `check`         | Run fmt, vet, and lint            |
+| `run`           | Build and run in stdio mode       |
+| `test`          | Run Go tests                      |
+| `test-coverage` | Run tests with coverage           |
+| `deps`          | Download and tidy dependencies    |
+| `install-tools` | Install development tools         |
 
 ### Build Flags
 
@@ -290,10 +290,10 @@ The Makefile uses optimized build flags:
 
 Currently, the server doesn't require environment variables, but future LFX integrations may add:
 
-| Variable | Description | Default | Required |
-|----------|-------------|---------|----------|
-| `LFX_API_URL` | LFX API base URL | - | Future |
-| `DEBUG` | Enable debug logging | false | No |
+| Variable      | Description          | Default | Required |
+|---------------|----------------------|---------|----------|
+| `LFX_API_URL` | LFX API base URL     | -       | Future   |
+| `DEBUG`       | Enable debug logging | false   | No       |
 
 ...and various other parameters needed to configure OAuth2 authentication.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+# checkov:skip=CKV_DOCKER_7:No free access to Chainguard versioned labels.
+# hadolint global ignore=DL3007
+
+FROM cgr.dev/chainguard/go:latest AS builder
+
+# Set necessary environment variables needed for our image. Allow building to
+# other architectures via cross-compilation build-arg.
+ARG TARGETARCH
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH
+
+# Move to working directory /build
+WORKDIR /build
+
+# Download dependencies to go modules cache
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the packages
+RUN go build -o /go/bin/lfx-mcp-server -trimpath -ldflags="-w -s" github.com/linuxfoundation/lfx-mcp/cmd/lfx-mcp-server
+
+# Run our go binary standalone
+FROM cgr.dev/chainguard/static:latest
+
+# Implicit with base image; setting explicitly for linters.
+USER nonroot
+
+COPY --from=builder /go/bin/lfx-mcp-server /cmd/lfx-mcp-server
+
+ENTRYPOINT ["/cmd/lfx-mcp-server"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# Copyright The Linux Foundation and contributors.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
 
-.PHONY: all build clean check fmt vet lint test run help
+.PHONY: all build clean check fmt vet lint test run help docker-build
 
 # Build variables
 BINARY_NAME=lfx-mcp-server
@@ -11,6 +11,10 @@ GO_FILES=$(shell find . -name "*.go" -type f)
 
 # Build flags
 LDFLAGS=-ldflags="-s -w"
+
+# Docker variables
+DOCKER_IMAGE=linuxfoundation/lfx-mcp
+DOCKER_TAG=latest
 
 # Default target
 all: clean check build
@@ -77,6 +81,12 @@ install-tools:
 	@echo "Installing development tools..."
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
+# Build Docker image
+docker-build:
+	@echo "Building Docker image..."
+	docker build -t $(DOCKER_IMAGE):$(DOCKER_TAG) -f Dockerfile .
+	@echo "Docker image built: $(DOCKER_IMAGE):$(DOCKER_TAG)"
+
 # Show help
 help:
 	@echo "Available targets:"
@@ -92,4 +102,5 @@ help:
 	@echo "  run            - Build and run the server"
 	@echo "  deps           - Download and tidy dependencies"
 	@echo "  install-tools  - Install development tools"
+	@echo "  docker-build   - Build Docker image"
 	@echo "  help           - Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 
-.PHONY: all build clean check fmt vet lint test run help docker-build
+.PHONY: all build clean check fmt vet lint test test-coverage run help deps install-tools docker-build
 
 # Build variables
 BINARY_NAME=lfx-mcp-server

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A simple greeting tool that demonstrates the MCP tool interface.
 
 ### Project Structure
 
-```
+```text
 lfx-mcp/
 ├── cmd/
 │   └── lfx-mcp-server/     # Main application entry point

--- a/test_server.sh
+++ b/test_server.sh
@@ -9,61 +9,74 @@ echo "Testing LFX MCP Server..."
 
 # Build the server if needed
 if [ ! -f "./bin/lfx-mcp-server" ]; then
-    echo "Building server..."
-    make build
+	echo "Building server..."
+	make build
 fi
 
 echo ""
 echo "=== Test 1: Server initialization and capabilities ==="
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}'; sleep 0.5) | \
-    ./bin/lfx-mcp-server stdio | \
-    head -1 | \
-    jq '.'
+(
+	echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}'
+	sleep 0.5
+) |
+	./bin/lfx-mcp-server stdio |
+	head -1 |
+	jq '.'
 
 echo ""
 echo "=== Test 2: List available tools ==="
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}';
- echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}';
- sleep 0.5) | \
-    ./bin/lfx-mcp-server stdio | \
-    grep -E '"result".*"tools"' | \
-    jq '.result.tools'
+(
+	echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}'
+	echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+	sleep 0.5
+) |
+	./bin/lfx-mcp-server stdio |
+	grep -E '"result".*"tools"' |
+	jq '.result.tools'
 
 echo ""
 echo "=== Test 3: Call hello_world tool (default greeting) ==="
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}';
- echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{}}}';
- sleep 0.5) | \
-    ./bin/lfx-mcp-server stdio | \
-    grep '"result".*"content"' | \
-    jq '.result.content[0].text'
+(
+	echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}'
+	echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{}}}'
+	sleep 0.5
+) |
+	./bin/lfx-mcp-server stdio |
+	grep '"result".*"content"' |
+	jq '.result.content[0].text'
 
 echo ""
 echo "=== Test 4: Call hello_world tool (with name) ==="
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}';
- echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX Developer"}}}';
- sleep 0.5) | \
-    ./bin/lfx-mcp-server stdio | \
-    grep '"result".*"content"' | \
-    jq '.result.content[0].text'
+(
+	echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}'
+	echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX Developer"}}}'
+	sleep 0.5
+) |
+	./bin/lfx-mcp-server stdio |
+	grep '"result".*"content"' |
+	jq '.result.content[0].text'
 
 echo ""
 echo "=== Test 5: Call hello_world tool (with custom message) ==="
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}';
- echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX Team","message":"Welcome to the platform"}}}';
- sleep 0.5) | \
-    ./bin/lfx-mcp-server stdio | \
-    grep '"result".*"content"' | \
-    jq '.result.content[0].text'
+(
+	echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}'
+	echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX Team","message":"Welcome to the platform"}}}'
+	sleep 0.5
+) |
+	./bin/lfx-mcp-server stdio |
+	grep '"result".*"content"' |
+	jq '.result.content[0].text'
 
 echo ""
 echo "=== Test 6: Error handling (invalid tool name) ==="
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}';
- echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"invalid_tool","arguments":{}}}';
- sleep 0.5) | \
-    ./bin/lfx-mcp-server stdio | \
-    grep '"error"' | \
-    jq '.error.message' || echo "\"Tool not found error handled correctly\""
+(
+	echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}'
+	echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"invalid_tool","arguments":{}}}'
+	sleep 0.5
+) |
+	./bin/lfx-mcp-server stdio |
+	grep '"error"' |
+	jq '.error.message' || echo "\"Tool not found error handled correctly\""
 
 echo ""
 echo "All tests completed successfully! 🎉"


### PR DESCRIPTION
## Description

Adds Docker build support via ko following the patterns established in lfx-v2-project-service and lfx-v1-sync-helper repositories.

## Changes

- **Dockerfile**: Multi-stage build with Chainguard base images (go:latest builder, static runtime)
- **Makefile**: Added `docker-build` target for local Docker builds
- **.dockerignore**: Excludes unnecessary files from Docker build context
- **GitHub Actions Workflows**:
  - `ko-build-main.yaml`: Builds and publishes container on main branch pushes (tags: SHA + "development")
  - `ko-build-tag.yaml`: Builds and publishes container on version tags with SLSA provenance (tags: version + "latest")

## Technical Details

- Uses ko v0.18.0 for efficient Go container builds
- Uses Cosign v3.0.2 for container image signing
- Multi-architecture builds: linux/amd64 and linux/arm64
- Generates SBOM with SPDX format
- SLSA provenance generation for tagged releases
- Non-root container execution for security

## Testing

- [x] `make check` passes
- [x] Workflows validated against lfx-v2-project-service and lfx-v1-sync-helper patterns

## Related

Jira: ARCH-324