### PR TITLE
Add Helm chart and health endpoints for gateway deployment

### DIFF
--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -24,6 +24,8 @@ jobs:
       id-token: write
     outputs:
       app_version: ${{ steps.prepare.outputs.app_version }}
+      chart_name: ${{ steps.prepare.outputs.chart_name }}
+      chart_version: ${{ steps.prepare.outputs.chart_version }}
       digest: ${{ steps.build.outputs.digest }}
       image_name: ${{ steps.build.outputs.image_name }}
     steps:
@@ -35,7 +37,13 @@ jobs:
         run: |
           set -euo pipefail
           APP_VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
-          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+          CHART_NAME="$(yq '.name' charts/*/Chart.yaml)"
+          CHART_VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          {
+            echo "app_version=$APP_VERSION"
+            echo "chart_name=$CHART_NAME"
+            echo "chart_version=$CHART_VERSION"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
@@ -84,6 +92,68 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign --yes '${{ steps.build.outputs.image_name }}@${{ steps.build.outputs.digest }}'
+
+  release-helm-chart:
+    needs:
+      - publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.publish-ghcr.outputs.digest }}
+      image_name: ${{ steps.publish-ghcr.outputs.image_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Publish Chart to GHCR
+        id: publish-ghcr
+        # yamllint disable-line rule:line-length
+        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@17e4144d7ba68f7c3e8c16eece5aed15fd7c2dc8 # main
+        with:
+          name: ${{ needs.publish.outputs.chart_name }}
+          repository: ${{ github.repository }}/chart
+          chart_version: ${{ needs.publish.outputs.chart_version }}
+          app_version: ${{ needs.publish.outputs.app_version }}
+          registry: ghcr.io
+          registry_username: ${{ github.actor }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        with:
+          cosign-release: "${{ env.COSIGN_VERSION }}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign the Helm chart in GHCR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes '${{ steps.publish-ghcr.outputs.image_name }}@${{ steps.publish-ghcr.outputs.digest }}'
+
+  create-ghcr-helm-provenance:
+    needs:
+      - release-helm-chart
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ needs.release-helm-chart.outputs.image_name }}
+      digest: ${{ needs.release-helm-chart.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
 
   create-provenance:
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 *.dll
 *.so
 *.dylib
-lfx-mcp
+/lfx-mcp
+/lfx-mcp-server
 
 # Go build artifacts
 *.test

--- a/charts/lfx-mcp/Chart.yaml
+++ b/charts/lfx-mcp/Chart.yaml
@@ -1,0 +1,11 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+apiVersion: v2
+name: lfx-mcp
+description: LFX MCP Server chart
+type: application
+# These versions should not be incremented, as there are dynamically replaced
+# with the release version during the chart build job.
+version: 0.0.1
+appVersion: latest

--- a/charts/lfx-mcp/templates/_helpers.tpl
+++ b/charts/lfx-mcp/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{- /*
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+*/ -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lfx-mcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lfx-mcp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lfx-mcp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "lfx-mcp.labels" -}}
+helm.sh/chart: {{ include "lfx-mcp.chart" . }}
+{{ include "lfx-mcp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "lfx-mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lfx-mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Derive the public MCP URL from the default https listener hostname.
+*/}}
+{{- define "lfx-mcp.mcpPublicURL" -}}
+{{- printf "https://%s/mcp" .Values.gateway.listeners.https.hostname }}
+{{- end }}

--- a/charts/lfx-mcp/templates/_helpers.tpl
+++ b/charts/lfx-mcp/templates/_helpers.tpl
@@ -56,8 +56,30 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Derive the public MCP URL from the default https listener hostname.
+Determine the public MCP hostname.
+Prefer .Values.gateway.publicHostname if set; otherwise derive it
+from the first listener in .Values.gateway.listeners that has a hostname.
+*/}}
+{{- define "lfx-mcp.mcpPublicHostname" -}}
+{{- if .Values.gateway.publicHostname }}
+{{- .Values.gateway.publicHostname }}
+{{- else }}
+{{- $hostname := "" }}
+{{- range $name, $listener := .Values.gateway.listeners }}
+{{- if and (not $hostname) $listener.hostname }}
+{{- $hostname = $listener.hostname }}
+{{- end }}
+{{- end }}
+{{- $hostname }}
+{{- end }}
+{{- end }}
+
+{{/*
+Derive the public MCP URL from the public hostname.
 */}}
 {{- define "lfx-mcp.mcpPublicURL" -}}
-{{- printf "https://%s/mcp" .Values.gateway.listeners.https.hostname }}
+{{- $hostname := include "lfx-mcp.mcpPublicHostname" . | trim }}
+{{- if $hostname }}
+{{- printf "https://%s/mcp" $hostname }}
+{{- end }}
 {{- end }}

--- a/charts/lfx-mcp/templates/deployment.yaml
+++ b/charts/lfx-mcp/templates/deployment.yaml
@@ -1,0 +1,85 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lfx-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lfx-mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lfx-mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lfx-mcp.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+            - name: LFXMCP_MODE
+              value: http
+            - name: LFXMCP_HTTP_HOST
+              value: "0.0.0.0"
+            - name: LFXMCP_HTTP_PORT
+              value: {{ .Values.service.port | quote }}
+            - name: LFXMCP_MCP_API_PUBLIC_URL
+              value: {{ include "lfx-mcp.mcpPublicURL" . | quote }}
+            - name: LFXMCP_MCP_API_AUTH_SERVERS
+              value: {{ .Values.app.mcpApiAuthServers | quote }}
+            - name: LFXMCP_MCP_API_SCOPES
+              value: {{ .Values.app.mcpApiScopes | quote }}
+            - name: LFXMCP_TOOLS
+              value: {{ .Values.app.tools | quote }}
+            - name: LFXMCP_TOKEN_ENDPOINT
+              value: {{ .Values.app.tokenEndpoint | quote }}
+            - name: LFXMCP_LFX_API_URL
+              value: {{ .Values.app.lfxAPIURL | quote }}
+            - name: LFXMCP_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.name }}
+                  key: {{ .Values.secrets.keys.clientID }}
+            - name: LFXMCP_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.name }}
+                  key: {{ .Values.secrets.keys.clientSecret }}
+                  optional: true
+            - name: LFXMCP_CLIENT_ASSERTION_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.name }}
+                  key: {{ .Values.secrets.keys.clientAssertionSigningKey }}
+                  optional: true
+          ports:
+            - name: web
+              containerPort: {{ .Values.service.port }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: web
+            failureThreshold: 3
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: web
+            failureThreshold: 1
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: web
+            failureThreshold: 30
+            periodSeconds: 1

--- a/charts/lfx-mcp/templates/gateway.yaml
+++ b/charts/lfx-mcp/templates/gateway.yaml
@@ -1,0 +1,70 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.gateway.name }}
+  namespace: {{ .Values.gateway.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "lfx-mcp.labels" . | nindent 4 }}
+    {{- with .Values.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.gateway.certIssuer }}
+    {{- range $name, $listener := .Values.gateway.listeners }}
+    {{- if $listener.hostname }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $listener.hostname }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.gateway.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+    {{- range $name, $listener := .Values.gateway.listeners }}
+    - name: {{ $name }}
+      port: {{ $listener.port | int }}
+      protocol: {{ $listener.protocol }}
+      {{- if $listener.hostname }}
+      hostname: {{ $listener.hostname | quote }}
+      {{- end }}
+      {{- if $listener.allowedRoutes }}
+      allowedRoutes:
+        {{- if $listener.allowedRoutes.namespaces }}
+        namespaces:
+          {{- if $listener.allowedRoutes.namespaces.from }}
+          from: {{ $listener.allowedRoutes.namespaces.from }}
+          {{- end }}
+          {{- if $listener.allowedRoutes.namespaces.selector }}
+          selector:
+            {{- toYaml $listener.allowedRoutes.namespaces.selector | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if $listener.allowedRoutes.kinds }}
+        kinds:
+          {{- toYaml $listener.allowedRoutes.kinds | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- if and (eq $listener.protocol "HTTPS") $listener.tls }}
+      tls:
+        mode: {{ $listener.tls.mode | default "Terminate" }}
+        {{- if $listener.tls.certificateRefs }}
+        certificateRefs:
+          {{- range $listener.tls.certificateRefs }}
+          - group: {{ .group | default "" | quote }}
+            kind: {{ .kind | default "Secret" }}
+            name: {{ .name }}
+            {{- if .namespace }}
+            namespace: {{ .namespace }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- if $listener.tls.options }}
+        options:
+          {{- toYaml $listener.tls.options | nindent 10 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}

--- a/charts/lfx-mcp/templates/httproute.yaml
+++ b/charts/lfx-mcp/templates/httproute.yaml
@@ -13,9 +13,11 @@ spec:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: {{ .Values.gateway.name }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ .Values.gateway.namespace | default .Release.Namespace }}
+  {{- with .Values.gateway.listeners.https.hostname }}
   hostnames:
-    - {{ .Values.gateway.listeners.https.hostname | quote }}
+    - {{ . | quote }}
+  {{- end }}
   rules:
     - matches:
         - path:

--- a/charts/lfx-mcp/templates/httproute.yaml
+++ b/charts/lfx-mcp/templates/httproute.yaml
@@ -1,0 +1,29 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "lfx-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lfx-mcp.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.gateway.name }}
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+    - {{ .Values.gateway.listeners.https.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ include "lfx-mcp.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1

--- a/charts/lfx-mcp/templates/service.yaml
+++ b/charts/lfx-mcp/templates/service.yaml
@@ -1,0 +1,18 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lfx-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lfx-mcp.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: web
+      port: {{ .Values.service.port }}
+      targetPort: web
+  selector:
+    {{- include "lfx-mcp.selectorLabels" . | nindent 4 }}

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -1,0 +1,97 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+# image is the configuration for the container image.
+image:
+  # repository is the container image repository.
+  repository: ghcr.io/linuxfoundation/lfx-mcp/lfx-mcp-server
+  # tag is the container image tag (overrides appVersion from Chart.yaml).
+  tag: ""
+  # pullPolicy is the image pull policy.
+  pullPolicy: IfNotPresent
+
+# replicaCount is the number of replicas for the deployment.
+replicaCount: 1
+
+# resources is the configuration for container resource limits and requests.
+resources:
+  # limits is the maximum amount of resources the container can use.
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  # requests is the amount of resources the container requests.
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+# service is the configuration for the Kubernetes service.
+service:
+  # port is the service port.
+  port: 8080
+
+# gateway is the configuration for the Gateway API resources.
+gateway:
+  # name is the name of the Gateway resource to create.
+  name: lfx-mcp-gateway
+  # namespace overrides the namespace for the Gateway resource (defaults to Release.Namespace).
+  namespace: ""
+  # gatewayClassName is the GatewayClass to use.
+  gatewayClassName: traefik
+  # annotations are additional annotations to add to the Gateway resource. The
+  # cert-manager.io/cluster-issuer and external-dns.alpha.kubernetes.io/hostname annotations
+  # are set automatically from certIssuer and the listener hostname, but can be overridden here.
+  annotations: {}
+  # labels are additional labels to add to the Gateway resource.
+  labels: {}
+  # certIssuer is the cert-manager ClusterIssuer annotation value for TLS certificate provisioning.
+  certIssuer: letsencrypt-prod
+  # listeners is a map of listener configurations keyed by listener name.
+  listeners:
+    https:
+      # port is the listener port.
+      port: 443
+      # protocol is the listener protocol.
+      protocol: HTTPS
+      # hostname is the public DNS hostname for this listener (required).
+      hostname: ""
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        # mode is the TLS termination mode.
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            # name is the name of the TLS Secret (managed by cert-manager).
+            name: lfx-mcp-tls
+
+# app is the configuration for the application.
+app:
+  # mcpApiAuthServers is the space-separated list of OAuth2 authorization server URLs.
+  mcpApiAuthServers: ""
+  # mcpApiScopes is the comma-separated list of OAuth2 scopes to request.
+  mcpApiScopes: "openid,profile"
+  # tools is the comma-separated list of tool groups to enable (empty enables all).
+  tools: ""
+  # lfxAPIURL is the base URL of the LFX API.
+  lfxAPIURL: ""
+  # tokenEndpoint is the OAuth2 token endpoint URL used for client credentials.
+  tokenEndpoint: ""
+
+# secrets contains the name of the pre-existing Kubernetes Secret created by the external
+# secrets operator, along with the keys under which each credential is stored.
+secrets:
+  # name is the name of the Kubernetes Secret.
+  name: lfx-mcp-secrets
+  # keys maps each credential to the key name used in the Secret.
+  keys:
+    # clientID is the key name for the OAuth2 client ID.
+    clientID: client_id
+    # clientSecret is the key name for the OAuth2 client secret (used when authenticating
+    # with a shared secret rather than a signed client assertion).
+    clientSecret: client_secret
+    # clientAssertionSigningKey is the key name for the private key used to sign client
+    # assertions (used when authenticating with a JWT client assertion instead of a
+    # client secret).
+    clientAssertionSigningKey: client_assertion_signing_key

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -35,6 +35,9 @@ gateway:
   name: lfx-mcp-gateway
   # namespace overrides the namespace for the Gateway resource (defaults to Release.Namespace).
   namespace: ""
+  # publicHostname overrides the public DNS hostname used to construct LFXMCP_MCP_API_PUBLIC_URL.
+  # When empty, the hostname is derived from the first listener that has a hostname set.
+  publicHostname: ""
   # gatewayClassName is the GatewayClass to use.
   gatewayClassName: traefik
   # annotations are additional annotations to add to the Gateway resource. The

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -288,6 +288,16 @@ func runHTTPServer(cfg Config) {
 	// Setup HTTP server with handler mounted on /mcp.
 	mux := http.NewServeMux()
 
+	// Register health endpoints unconditionally so probes work without auth.
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
 	// Apply OAuth bearer token middleware if auth servers are configured.
 	var mcpHandler http.Handler = handler
 	if len(cfg.MCPAPI.AuthServers) > 0 {


### PR DESCRIPTION
## Summary

Implements [ARCH-332](https://linuxfoundation.atlassian.net/browse/ARCH-332) — Helm chart for deployment as a new service via Gateway resource.

### Changes

**`cmd/lfx-mcp-server/main.go`**
- Add `GET /livez` and `GET /readyz` health endpoints to the HTTP mux, registered unconditionally outside any auth middleware so Kubernetes probes work without a bearer token.

**`charts/lfx-mcp/`** — new Helm chart
- `Chart.yaml` — standard metadata, `type: application`, `appVersion: latest` (overridden by CI at publish time).
- `values.yaml` — defaults for all knobs, including a `gateway.listeners` map (mirrors the lfx-platform pattern) so any listener property can be overridden; defaults to port 443 on the `https` listener. Secret key names for `clientID`, `clientSecret`, and `clientAssertionSigningKey` are all individually overridable; `clientSecret` and `clientAssertionSigningKey` are marked `optional: true` so either auth style works.
- `templates/_helpers.tpl` — `name`, `fullname`, `labels`, `selectorLabels`, and `lfx-mcp.mcpPublicURL` helpers.
- `templates/service.yaml` — `ClusterIP` Service on port 8080.
- `templates/gateway.yaml` — `gateway.networking.k8s.io/v1` `Gateway` with full listener override support (port, protocol, TLS mode, certificateRefs, allowedRoutes, extra annotations/labels).
- `templates/httproute.yaml` — `HTTPRoute` attached to the above Gateway, no Heimdall filter, forwarding all traffic to the Service.
- `templates/deployment.yaml` — `Deployment` with all `LFXMCP_*` env vars, liveness/readiness/startup probes on `/livez` and `/readyz`, and `allowPrivilegeEscalation: false`.

**`.github/workflows/ko-build-tag.yaml`**
- Add `release-helm-chart` job (needs: `publish`) — publishes and signs the chart to GHCR via `linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher`.
- Add `create-ghcr-helm-provenance` job (needs: `release-helm-chart`) — SLSA provenance for the chart artifact.
- Both follow the same pattern as `lfx-v2-project-service`.


[ARCH-332]: https://linuxfoundation.atlassian.net/browse/ARCH-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ