### PR TITLE
Fix multi-arch digest extraction in tag release workflow

### DIFF
--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -68,8 +68,8 @@ jobs:
             --sbom spdx \
             --image-refs /tmp/image-refs.txt
 
-          DIGEST=$(cat /tmp/image-refs.txt | cut -d'@' -f2)
-          IMAGE_NAME=$(cat /tmp/image-refs.txt | cut -d'@' -f1)
+          DIGEST=$(tail -1 /tmp/image-refs.txt | cut -d'@' -f2)
+          IMAGE_NAME=$(tail -1 /tmp/image-refs.txt | cut -d'@' -f1)
 
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes the `Invalid format 'sha256:...'` error seen in the `v0.0.1` tag release run.

## Root Cause

`ko build -B --platform linux/amd64,linux/arm64 --image-refs` writes **three** refs to the file — one per architecture plus the multi-arch index manifest. The previous script used `cat` on the whole file, which produced a multi-line string. GitHub Actions rejected this when writing to `$GITHUB_OUTPUT` with:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'sha256:bd493615...'
```

## Fix

Use `tail -1` to capture only the last line (the index manifest ref), which is the correct digest to use for signing and provenance — it's the manifest list that users actually pull.

## Related

[ARCH-332](https://linuxfoundation.atlassian.net/browse/ARCH-332)

[ARCH-332]: https://linuxfoundation.atlassian.net/browse/ARCH-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ