### PR TITLE
fix: resource metadata public URL, HTTPS port, and CI cosign/helm fixes

### DIFF
--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -10,6 +10,7 @@ name: Publish Tagged Release
 
 env:
   COSIGN_VERSION: v3.0.2
+  HELM_VERSION: 4.0.4
 
 permissions:
   contents: read
@@ -75,7 +76,7 @@ jobs:
           echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: "${{ env.COSIGN_VERSION }}"
 
@@ -117,12 +118,13 @@ jobs:
           repository: ${{ github.repository }}/chart
           chart_version: ${{ needs.publish.outputs.chart_version }}
           app_version: ${{ needs.publish.outputs.app_version }}
+          helm_version: "${{ env.HELM_VERSION }}"
           registry: ghcr.io
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: "${{ env.COSIGN_VERSION }}"
 

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -51,8 +51,8 @@ gateway:
   # listeners is a map of listener configurations keyed by listener name.
   listeners:
     https:
-      # port is the listener port.
-      port: 443
+      # port is the listener port (8443 is Traefik's websecure entrypoint for HTTPS).
+      port: 8443
       # protocol is the listener protocol.
       protocol: HTTPS
       # hostname is the public DNS hostname for this listener (required).

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -301,7 +302,16 @@ func runHTTPServer(cfg Config) {
 	// Apply OAuth bearer token middleware if auth servers are configured.
 	var mcpHandler http.Handler = handler
 	if len(cfg.MCPAPI.AuthServers) > 0 {
-		resourceMetadataURL := fmt.Sprintf("http://%s:%d/.well-known/oauth-protected-resource", cfg.HTTP.Host, cfg.HTTP.Port)
+		// Use the public URL base for the resource metadata URL so that MCP clients
+		// outside the cluster can reach it via the WWW-Authenticate header.
+		resourceMetadataBase := cfg.MCPAPI.PublicURL
+		if resourceMetadataBase == "" {
+			resourceMetadataBase = fmt.Sprintf("http://%s:%d/mcp", cfg.HTTP.Host, cfg.HTTP.Port)
+		}
+		// Derive the well-known URL from the public MCP endpoint by replacing the path.
+		resourceMetadataBaseURL, _ := url.Parse(resourceMetadataBase)
+		resourceMetadataBaseURL.Path = "/.well-known/oauth-protected-resource"
+		resourceMetadataURL := resourceMetadataBaseURL.String()
 
 		// Determine the expected audience for JWT verification.
 		audience := cfg.MCPAPI.PublicURL


### PR DESCRIPTION
## Summary

Fixes a few issues found after the initial ARCH-332 release:

### `fix: use public URL for WWW-Authenticate resource_metadata`
The `WWW-Authenticate` header was returning an internal/relative URL for `resource_metadata` instead of the configured public URL, breaking OAuth client discovery.

### `fix: set default HTTPS listener port to 8443`
The default HTTPS listener port was incorrect; updated to 8443 to match the Gateway configuration.

### `ci: update cosign-installer to v4.0.0 and pin helm version`
The `v3.9.2` `cosign-installer` action pin was incompatible with `cosign-release: v3.0.2`, causing an HTTP exit code 22 (download failure) on the "Install Cosign" step (seen in [run #22661205204](https://github.com/linuxfoundation/lfx-mcp/actions/runs/22661205204/job/65681655281)). Updated to `v4.0.0`, matching the working pin used in `lfx-v1-sync-helper`. Also adds `HELM_VERSION` env var and passes it explicitly to the `helm-chart-oci-publisher` action for consistency.

Jira: ARCH-332