### PR TITLE
fix: add offline_access scope and improve chart configurability; optimize committee member search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,7 +423,7 @@ The server supports configuration via environment variables with the `LFXMCP_` p
 | `LFXMCP_TOOLS` | Comma-separated list of tools to enable | - | No |
 | `LFXMCP_MCP_API_AUTH_SERVERS` | Comma-separated list of authorization server URLs | - | No |
 | `LFXMCP_MCP_API_PUBLIC_URL` | Public URL for MCP API (for OAuth PRM) | - | No |
-| `LFXMCP_MCP_API_SCOPES` | OAuth scopes as comma-separated list | openid,profile | No |
+| `LFXMCP_MCP_API_SCOPES` | OAuth scopes as comma-separated list | - | No |
 | `LFXMCP_CLIENT_ID` | OAuth client ID for authentication | - | No |
 | `LFXMCP_CLIENT_SECRET` | OAuth client secret | - | No |
 | `LFXMCP_CLIENT_ASSERTION_SIGNING_KEY` | PEM-encoded RSA private key for client assertion | - | No |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+> **Note:** `CLAUDE.md` is a symlink to this file. Only `AGENTS.md` needs to be edited; changes are automatically reflected in `CLAUDE.md`.
+
 This file provides essential information for AI agents working on the LFX MCP Server codebase. It focuses on development workflows, architecture understanding, and build processes needed for making code changes.
 
 ## Repository Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The server supports configuration via both command-line flags and environment va
 - `-tools`: Comma-separated list of tools to enable (default: `search_projects,get_project`)
 - `-mcp_api.auth_servers`: Comma-separated list of authorization server URLs for OAuth PRM
 - `-mcp_api.public_url`: Public URL for the MCP API endpoint (for OAuth PRM)
-- `-mcp_api.scopes`: OAuth scopes as comma-separated list (default: `openid,profile`)
+- `-mcp_api.scopes`: OAuth scopes as comma-separated list (default: none; set to advertise scopes via OAuth PRM)
 - `-client_id`: OAuth client ID for token exchange
 - `-client_secret`: OAuth client secret (ignored if `client_assertion_signing_key` is set)
 - `-client_assertion_signing_key`: PEM-encoded RSA private key for client assertion (RFC 7523)
@@ -92,7 +92,7 @@ All environment variables use the `LFXMCP_` prefix. Variable names use underscor
 - `LFXMCP_TOOLS`: Comma-separated list of tools to enable
 - `LFXMCP_MCP_API_AUTH_SERVERS`: Comma-separated list of authorization server URLs
 - `LFXMCP_MCP_API_PUBLIC_URL`: Public URL for MCP API (for OAuth PRM)
-- `LFXMCP_MCP_API_SCOPES`: OAuth scopes as comma-separated list (default: `openid,profile`)
+- `LFXMCP_MCP_API_SCOPES`: OAuth scopes as comma-separated list (default: none; set to advertise scopes via OAuth PRM)
 - `LFXMCP_CLIENT_ID`: OAuth client ID for token exchange
 - `LFXMCP_CLIENT_SECRET`: OAuth client secret
 - `LFXMCP_CLIENT_ASSERTION_SIGNING_KEY`: PEM-encoded RSA private key for client assertion

--- a/charts/lfx-mcp/templates/deployment.yaml
+++ b/charts/lfx-mcp/templates/deployment.yaml
@@ -37,8 +37,10 @@ spec:
               value: {{ .Values.app.mcpApiAuthServers | quote }}
             - name: LFXMCP_MCP_API_SCOPES
               value: {{ .Values.app.mcpApiScopes | quote }}
+            {{- if .Values.app.tools }}
             - name: LFXMCP_TOOLS
               value: {{ .Values.app.tools | quote }}
+            {{- end }}
             - name: LFXMCP_TOKEN_ENDPOINT
               value: {{ .Values.app.tokenEndpoint | quote }}
             - name: LFXMCP_LFX_API_URL

--- a/charts/lfx-mcp/templates/deployment.yaml
+++ b/charts/lfx-mcp/templates/deployment.yaml
@@ -35,8 +35,18 @@ spec:
               value: {{ include "lfx-mcp.mcpPublicURL" . | quote }}
             - name: LFXMCP_MCP_API_AUTH_SERVERS
               value: {{ .Values.app.mcpApiAuthServers | quote }}
+            {{- if .Values.app.debug }}
+            - name: LFXMCP_DEBUG
+              value: "true"
+            {{- end }}
+            {{- if .Values.app.debugTraffic }}
+            - name: LFXMCP_DEBUG_TRAFFIC
+              value: "true"
+            {{- end }}
+            {{- if .Values.app.mcpApiScopes }}
             - name: LFXMCP_MCP_API_SCOPES
               value: {{ .Values.app.mcpApiScopes | quote }}
+            {{- end }}
             {{- if .Values.app.tools }}
             - name: LFXMCP_TOOLS
               value: {{ .Values.app.tools | quote }}

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -77,9 +77,9 @@ app:
   debugTraffic: false
   # mcpApiAuthServers is the space-separated list of OAuth2 authorization server URLs.
   mcpApiAuthServers: ""
-  # mcpApiScopes is the comma-separated list of OAuth2 scopes to request.
+  # mcpApiScopes is the comma-separated list of OAuth2 scopes to advertise via OAuth PRM (empty advertises no scopes).
   mcpApiScopes: ""
-  # tools is the comma-separated list of tools to enable (empty enables all tools).
+  # tools is the comma-separated list of tools to enable (empty uses the server default tool set).
   tools: ""
   # lfxAPIURL is the base URL of the LFX API.
   lfxAPIURL: ""

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -71,10 +71,14 @@ gateway:
 
 # app is the configuration for the application.
 app:
+  # debug enables debug logging.
+  debug: false
+  # debugTraffic enables HTTP request/response wire logging for outbound LFX API calls.
+  debugTraffic: false
   # mcpApiAuthServers is the space-separated list of OAuth2 authorization server URLs.
   mcpApiAuthServers: ""
   # mcpApiScopes is the comma-separated list of OAuth2 scopes to request.
-  mcpApiScopes: "openid,profile"
+  mcpApiScopes: ""
   # tools is the comma-separated list of tools to enable (empty enables all tools).
   tools: ""
   # lfxAPIURL is the base URL of the LFX API.

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -75,7 +75,7 @@ app:
   mcpApiAuthServers: ""
   # mcpApiScopes is the comma-separated list of OAuth2 scopes to request.
   mcpApiScopes: "openid,profile"
-  # tools is the comma-separated list of tool groups to enable (empty enables all).
+  # tools is the comma-separated list of tools to enable (empty enables all tools).
   tools: ""
   # lfxAPIURL is the base URL of the LFX API.
   lfxAPIURL: ""

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -70,7 +70,7 @@ func main() {
 	f.Int("http.port", 8080, "Port to listen on for HTTP transport")
 	f.String("mcp_api.public_url", "", "Public URL for MCP API (for OAuth PRM; if not set, uses http://host:port/mcp)")
 	f.String("mcp_api.auth_servers", "", "Comma-separated list of authorization server URLs for OAuth PRM")
-	f.String("mcp_api.scopes", "openid,profile", "Comma-separated list of OAuth scopes for PRM")
+	f.String("mcp_api.scopes", "", "Comma-separated list of OAuth scopes for PRM")
 	f.String("client_id", "", "OAuth client ID for authentication")
 	f.String("client_secret", "", "OAuth client secret (ignored if client_assertion_signing_key is set)")
 	f.String("client_assertion_signing_key", "", "PEM-encoded RSA private key for client assertion (takes precedence over client_secret)")

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -389,9 +389,6 @@ func runHTTPServer(cfg Config) {
 		logger.Info("OAuth bearer token verification enabled for /mcp endpoint", "audience", audience)
 	}
 
-	// Apply HTTP request logging at debug level.
-	mcpHandler = httpDebugLogging(logger)(mcpHandler)
-
 	mux.Handle("/mcp", mcpHandler)
 
 	// Add Protected Resource Metadata endpoint if auth servers are configured.
@@ -421,7 +418,7 @@ func runHTTPServer(cfg Config) {
 	addr := fmt.Sprintf("%s:%d", cfg.HTTP.Host, cfg.HTTP.Port)
 	httpServer := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           httpDebugLogging(logger)(mux),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -461,7 +458,8 @@ func runHTTPServer(cfg Config) {
 	logger.Info("HTTP server stopped")
 }
 
-// httpDebugLogging returns HTTP middleware that logs requests at debug level.
+// httpDebugLogging returns middleware that logs all incoming HTTP requests and their
+// completion at DEBUG level, including paths not handled by any route (404s).
 func httpDebugLogging(logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -413,6 +413,13 @@ func runHTTPServer(cfg Config) {
 
 		mux.Handle("/.well-known/oauth-protected-resource", auth.ProtectedResourceMetadataHandler(metadata))
 		logger.With("url", fmt.Sprintf("http://%s:%d/.well-known/oauth-protected-resource", cfg.HTTP.Host, cfg.HTTP.Port)).Info("OAuth Protected Resource Metadata endpoint available")
+
+		// Redirect buggy MCP clients to the *correct* PRM endpoint.
+		redirectToPRM := func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/.well-known/oauth-protected-resource", http.StatusFound)
+		}
+		mux.HandleFunc("/.well-known/oauth-authorization-server/mcp", redirectToPRM)
+		mux.HandleFunc("/mcp/.well-known/oauth-authorization-server", redirectToPRM)
 	}
 
 	addr := fmt.Sprintf("%s:%d", cfg.HTTP.Host, cfg.HTTP.Port)

--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -64,7 +64,7 @@ func RegisterGetCommitteeMember(server *mcp.Server) {
 func RegisterSearchCommitteeMembers(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_committee_members",
-		Description: "Search for members of a specific LFX committee. Requires a committee UID. Optionally filter by name.",
+		Description: "Search for LFX committee members. Optionally filter by committee UID, project UID (v2), and/or name. At least one filter is recommended but not required.",
 	}, handleSearchCommitteeMembers)
 }
 
@@ -89,7 +89,8 @@ type GetCommitteeMemberArgs struct {
 
 // SearchCommitteeMembersArgs defines the input parameters for the search_committee_members tool.
 type SearchCommitteeMembersArgs struct {
-	CommitteeUID string `json:"committee_uid" jsonschema:"The v2 UID of the committee whose members to search"`
+	CommitteeUID string `json:"committee_uid,omitempty" jsonschema:"Optional v2 UID of the committee to filter members by"`
+	ProjectUID   string `json:"project_uid,omitempty" jsonschema:"Optional v2 project UID to filter committee members by project (e.g. a27394a3-7a6c-4d0f-9e0f-692d8753924f)"`
 	Name         string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
 	PageSize     int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -185,6 +186,12 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 	out := searchResult{
 		Resources: result.Resources,
 		PageToken: result.PageToken,
+	}
+
+	// Warn if fewer results than requested were returned but more pages exist.
+	// This indicates some results on this page were excluded due to access controls.
+	if result.PageToken != nil && len(result.Resources) < pageSize {
+		logger.Warn("some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters")
 	}
 
 	prettyJSON, err := json.MarshalIndent(out, "", "  ")
@@ -428,15 +435,6 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 		}, nil, nil
 	}
 
-	if args.CommitteeUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: committee_uid is required"},
-			},
-			IsError: true,
-		}, nil, nil
-	}
-
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
 	if err != nil {
 		logger.Error("failed to extract MCP token", "error", err)
@@ -471,14 +469,23 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	resourceType := committeeMemberResourceType
-	// Members are tagged with committee_uid:<uid> by the committee service indexer.
-	committeeTag := fmt.Sprintf("committee_uid:%s", args.CommitteeUID)
 	payload := &querysvc.QueryResourcesPayload{
 		Version:  "1",
 		Type:     &resourceType,
-		Tags:     []string{committeeTag},
 		PageSize: pageSize,
 		Sort:     "name_asc",
+	}
+
+	// Build tag filters: committee members are tagged by the committee service indexer.
+	var tags []string
+	if args.CommitteeUID != "" {
+		tags = append(tags, fmt.Sprintf("committee_uid:%s", args.CommitteeUID))
+	}
+	if args.ProjectUID != "" {
+		tags = append(tags, fmt.Sprintf("project_uid:%s", args.ProjectUID))
+	}
+	if len(tags) > 0 {
+		payload.Tags = tags
 	}
 
 	if args.Name != "" {
@@ -489,7 +496,7 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 		payload.PageToken = &args.PageToken
 	}
 
-	logger.Info("searching committee members", "committee_uid", args.CommitteeUID, "name", args.Name, "page_size", pageSize)
+	logger.Info("searching committee members", "committee_uid", args.CommitteeUID, "project_uid", args.ProjectUID, "name", args.Name, "page_size", pageSize)
 
 	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {
@@ -512,6 +519,12 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 		PageToken: result.PageToken,
 	}
 
+	// Warn if fewer results than requested were returned but more pages exist.
+	// This indicates some results on this page were excluded due to access controls.
+	if result.PageToken != nil && len(result.Resources) < pageSize {
+		logger.Warn("some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters")
+	}
+
 	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		logger.Error("failed to marshal search result", "error", err)
@@ -523,7 +536,7 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 		}, nil, nil
 	}
 
-	logger.Info("search_committee_members succeeded", "committee_uid", args.CommitteeUID, "count", len(result.Resources))
+	logger.Info("search_committee_members succeeded", "committee_uid", args.CommitteeUID, "project_uid", args.ProjectUID, "count", len(result.Resources))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{


### PR DESCRIPTION
## Summary

### helm: omit LFXMCP_TOOLS when tools is empty

Conditionally omit the `LFXMCP_TOOLS` env var from the deployment when `app.tools` is empty in values, so the server&#39;s built-in default tool list applies rather than an empty string.

### tools: optimize committee member search (ARCH-331)

Previously `committee_uid` was required in `search_committee_members`. Now all filters are optional:
- `committee_uid` — filter by committee (tag: `committee_uid:`)
- `project_uid` — filter by v2 project (tag: `project_uid:`, same tag pattern used by the committee service indexer)
- Either, both, or neither can be provided alongside the existing `name` filter.

This allows callers to search across all committee members for a given project without knowing a specific committee UID first.

When a paginated search returns fewer items than the requested page size *and* includes a next-page token, both `search_committees` and `search_committee_members` now emit a `WARN`-level MCP client log advising the caller to paginate, increase page size, or narrow filters.

### fix: offline_access scope and chart configurability (ARCH-338)

Auth0 does not issue a refresh token unless `offline_access` is included in the requested scopes. The MCP Go SDK client uses `golang.org/x/oauth2`&#39;s `TokenSource`, which requires a refresh token to silently renew access tokens. Without it, sessions fail once the short-lived access token expires, producing a misleading `&#34;exp&#34; not satisfied` error.

- Add `offline_access`, `read:all`, and `manage:all` to each environment&#39;s values file (matching the scopes defined on the `lfx_mcp_api` Auth0 resource server).
- Change the default `mcpApiScopes` in `values.yaml` to empty and conditionally omit `LFXMCP_MCP_API_SCOPES` from the deployment when unset, mirroring the existing `LFXMCP_TOOLS` pattern.
- Add `debug` and `debugTraffic` app values and conditionally set `LFXMCP_DEBUG` / `LFXMCP_DEBUG_TRAFFIC` in the deployment when true.

### fix: HTTP request logging and OAuth well-known redirects

- Move `httpDebugLogging` middleware to wrap the entire `ServeMux` (previously only `/mcp`) so all inbound requests — `/.well-known` paths, `/livez`, `/readyz`, and unmatched 404s — are logged at DEBUG level.
- Register 302 redirects for `/.well-known/oauth-authorization-server/mcp` and `/mcp/.well-known/oauth-authorization-server` → `/.well-known/oauth-protected-resource` to handle buggy MCP clients that construct the well-known URL incorrectly.

## Jira

[ARCH-338](https://linuxfoundation.atlassian.net/browse/ARCH-338)
[ARCH-331](https://linuxfoundation.atlassian.net/browse/ARCH-331)

[ARCH-338]: https://linuxfoundation.atlassian.net/browse/ARCH-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARCH-331]: https://linuxfoundation.atlassian.net/browse/ARCH-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ