### PR TITLE
feat: add read-only mailing list service tools

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -76,7 +76,7 @@ func main() {
 	f.String("client_assertion_signing_key", "", "PEM-encoded RSA private key for client assertion (takes precedence over client_secret)")
 	f.String("token_endpoint", "", "OAuth2 token endpoint URL for token exchange")
 	f.String("lfx_api_url", "", "LFX API URL (used as token exchange audience)")
-	f.String("tools", "search_projects,get_project,search_committees,get_committee,get_committee_member,search_committee_members,get_mailing_list_service,get_mailing_list,get_mailing_list_member,search_mailing_lists", "Comma-separated list of tools to enable")
+	f.String("tools", "search_projects,get_project,search_committees,get_committee,get_committee_member,search_committee_members,get_mailing_list_service,get_mailing_list,get_mailing_list_member,search_mailing_lists,search_mailing_list_members", "Comma-separated list of tools to enable")
 	f.Bool("debug", false, "Enable debug logging")
 	f.Bool("debug_traffic", false, "Enable HTTP request/response debug logging for outbound LFX API calls")
 
@@ -300,6 +300,9 @@ func newServer(cfg Config) *mcp.Server {
 	}
 	if enabledTools["search_mailing_lists"] {
 		tools.RegisterSearchMailingLists(server)
+	}
+	if enabledTools["search_mailing_list_members"] {
+		tools.RegisterSearchMailingListMembers(server)
 	}
 
 	return server

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -290,13 +290,13 @@ func newServer(cfg Config) *mcp.Server {
 		tools.RegisterSearchCommitteeMembers(server)
 	}
 	if enabledTools["get_mailing_list_service"] {
-		tools.RegisterGetGrpsioService(server)
+		tools.RegisterGetMailingListService(server)
 	}
 	if enabledTools["get_mailing_list"] {
-		tools.RegisterGetGrpsioMailingList(server)
+		tools.RegisterGetMailingList(server)
 	}
 	if enabledTools["get_mailing_list_member"] {
-		tools.RegisterGetGrpsioMailingListMember(server)
+		tools.RegisterGetMailingListMember(server)
 	}
 	if enabledTools["search_mailing_lists"] {
 		tools.RegisterSearchMailingLists(server)

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -76,7 +76,7 @@ func main() {
 	f.String("client_assertion_signing_key", "", "PEM-encoded RSA private key for client assertion (takes precedence over client_secret)")
 	f.String("token_endpoint", "", "OAuth2 token endpoint URL for token exchange")
 	f.String("lfx_api_url", "", "LFX API URL (used as token exchange audience)")
-	f.String("tools", "search_projects,get_project,search_committees,get_committee,get_committee_member,search_committee_members", "Comma-separated list of tools to enable")
+	f.String("tools", "search_projects,get_project,search_committees,get_committee,get_committee_member,search_committee_members,get_mailing_list_service,get_mailing_list,get_mailing_list_member,search_mailing_lists", "Comma-separated list of tools to enable")
 	f.Bool("debug", false, "Enable debug logging")
 	f.Bool("debug_traffic", false, "Enable HTTP request/response debug logging for outbound LFX API calls")
 
@@ -185,6 +185,11 @@ func main() {
 				TokenExchangeClient: tokenExchangeClient,
 				DebugLogger:         debugLogger,
 			})
+			tools.SetMailingListConfig(&tools.MailingListConfig{
+				LFXAPIURL:           cfg.LFXAPIURL,
+				TokenExchangeClient: tokenExchangeClient,
+				DebugLogger:         debugLogger,
+			})
 		}
 	}
 
@@ -283,6 +288,18 @@ func newServer(cfg Config) *mcp.Server {
 	}
 	if enabledTools["search_committee_members"] {
 		tools.RegisterSearchCommitteeMembers(server)
+	}
+	if enabledTools["get_mailing_list_service"] {
+		tools.RegisterGetGrpsioService(server)
+	}
+	if enabledTools["get_mailing_list"] {
+		tools.RegisterGetGrpsioMailingList(server)
+	}
+	if enabledTools["get_mailing_list_member"] {
+		tools.RegisterGetGrpsioMailingListMember(server)
+	}
+	if enabledTools["search_mailing_lists"] {
+		tools.RegisterSearchMailingLists(server)
 	}
 
 	return server

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/knadh/koanf/v2 v2.3.2
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/linuxfoundation/lfx-v2-committee-service v0.2.19
+	github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10
 	github.com/linuxfoundation/lfx-v2-project-service v0.5.7
 	github.com/linuxfoundation/lfx-v2-query-service v0.4.12
 	github.com/modelcontextprotocol/go-sdk v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/linuxfoundation/lfx-v2-committee-service v0.2.19 h1:xMeqXvf7NLk9JlfAEpNHBpwFtvtNTnwR/bOjxY/5Fa4=
 github.com/linuxfoundation/lfx-v2-committee-service v0.2.19/go.mod h1:vhFiTH/CEDcs2kHmDofKzJclW1ZtBlfaRH0brL6lfek=
+github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10 h1:OG+usJ9DZDMT5d9YZ+H53v0+BBTKsq7cqRAakLxlGvs=
+github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10/go.mod h1:d78d8z0Ll17hsRzKK3QtNj1ssMIDkJ5kgm5pV8KmB3Q=
 github.com/linuxfoundation/lfx-v2-project-service v0.5.7 h1:qycjiPSogIIHhRXDFSa0Zxu5ZLb/4jt9I8/JJmAJ0M4=
 github.com/linuxfoundation/lfx-v2-project-service v0.5.7/go.mod h1:JCQZhtqf6lqxG0LA55qbQrTFwV3oSdAoLKn/1BvcMe4=
 github.com/linuxfoundation/lfx-v2-query-service v0.4.12 h1:2sp/7zyhzsq8slNTWefixzjAI88yBYGYPuOjcnGke7I=

--- a/internal/lfxv2/client.go
+++ b/internal/lfxv2/client.go
@@ -58,6 +58,8 @@ import (
 
 	committeeservice "github.com/linuxfoundation/lfx-v2-committee-service/gen/committee_service"
 	committeehttpclient "github.com/linuxfoundation/lfx-v2-committee-service/gen/http/committee_service/client"
+	mailinglisthttpclient "github.com/linuxfoundation/lfx-v2-mailing-list-service/gen/http/mailing_list/client"
+	mailinglist "github.com/linuxfoundation/lfx-v2-mailing-list-service/gen/mailing_list"
 	projecthttpclient "github.com/linuxfoundation/lfx-v2-project-service/api/project/v1/gen/http/project_service/client"
 	projectservice "github.com/linuxfoundation/lfx-v2-project-service/api/project/v1/gen/project_service"
 	queryhttpclient "github.com/linuxfoundation/lfx-v2-query-service/gen/http/query_svc/client"
@@ -119,9 +121,10 @@ type ClientConfig struct {
 
 // Clients holds initialized LFX v2 API service clients.
 type Clients struct {
-	Committee *committeeservice.Client
-	Project   *projectservice.Client
-	QuerySvc  *querysvc.Client
+	Committee   *committeeservice.Client
+	MailingList *mailinglist.Client
+	Project     *projectservice.Client
+	QuerySvc    *querysvc.Client
 
 	tokenExchangeClient *TokenExchangeClient
 
@@ -192,6 +195,43 @@ func NewClients(_ context.Context, cfg ClientConfig) (*Clients, error) {
 		committeeHTTPClient.GetCommitteeMember(),
 		committeeHTTPClient.UpdateCommitteeMember(),
 		committeeHTTPClient.DeleteCommitteeMember(),
+	)
+
+	// Initialize mailing list service client.
+	mailingListURL, err := url.Parse(cfg.APIDomain + "/mailing-lists")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse mailing list service URL: %w", err)
+	}
+
+	mlHTTPClient := mailinglisthttpclient.NewClient(
+		mailingListURL.Scheme,
+		mailingListURL.Host,
+		httpClient,
+		goahttp.RequestEncoder,
+		goahttp.ResponseDecoder,
+		false,
+	)
+
+	clients.MailingList = mailinglist.NewClient(
+		mlHTTPClient.Livez(),
+		mlHTTPClient.Readyz(),
+		mlHTTPClient.CreateGrpsioService(),
+		mlHTTPClient.GetGrpsioService(),
+		mlHTTPClient.UpdateGrpsioService(),
+		mlHTTPClient.DeleteGrpsioService(),
+		mlHTTPClient.GetGrpsioServiceSettings(),
+		mlHTTPClient.UpdateGrpsioServiceSettings(),
+		mlHTTPClient.CreateGrpsioMailingList(),
+		mlHTTPClient.GetGrpsioMailingList(),
+		mlHTTPClient.UpdateGrpsioMailingList(),
+		mlHTTPClient.DeleteGrpsioMailingList(),
+		mlHTTPClient.GetGrpsioMailingListSettings(),
+		mlHTTPClient.UpdateGrpsioMailingListSettings(),
+		mlHTTPClient.CreateGrpsioMailingListMember(),
+		mlHTTPClient.GetGrpsioMailingListMember(),
+		mlHTTPClient.UpdateGrpsioMailingListMember(),
+		mlHTTPClient.DeleteGrpsioMailingListMember(),
+		mlHTTPClient.GroupsioWebhook(),
 	)
 
 	// Initialize project service client.

--- a/internal/lfxv2/errors.go
+++ b/internal/lfxv2/errors.go
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and contributors.
 // SPDX-License-Identifier: MIT
 
+// Package lfxv2 provides client configuration for LFX v2 API services.
 package lfxv2
 
 import "fmt"

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -1,0 +1,510 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/linuxfoundation/lfx-mcp/internal/lfxv2"
+	mailinglist "github.com/linuxfoundation/lfx-v2-mailing-list-service/gen/mailing_list"
+	querysvc "github.com/linuxfoundation/lfx-v2-query-service/gen/query_svc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mailingListResourceType is the resource type filter for mailing list queries.
+const mailingListResourceType = "grpsio_mailing_list"
+
+// MailingListConfig holds configuration shared by mailing list tools.
+type MailingListConfig struct {
+	LFXAPIURL           string
+	TokenExchangeClient *lfxv2.TokenExchangeClient
+	DebugLogger         *slog.Logger
+}
+
+var mailingListConfig *MailingListConfig
+
+// SetMailingListConfig sets the configuration for mailing list tools.
+func SetMailingListConfig(cfg *MailingListConfig) {
+	mailingListConfig = cfg
+}
+
+// GetGrpsioServiceArgs defines the input parameters for the get_grpsio_service tool.
+type GetGrpsioServiceArgs struct {
+	UID string `json:"uid" jsonschema:"The v2 UID of the Groups.io service to retrieve"`
+}
+
+// GetGrpsioMailingListArgs defines the input parameters for the get_grpsio_mailing_list tool.
+type GetGrpsioMailingListArgs struct {
+	UID string `json:"uid" jsonschema:"The v2 UID of the mailing list to retrieve"`
+}
+
+// GetGrpsioMailingListMemberArgs defines the input parameters for the get_grpsio_mailing_list_member tool.
+type GetGrpsioMailingListMemberArgs struct {
+	MailingListUID string `json:"mailing_list_uid" jsonschema:"The v2 UID of the mailing list"`
+	MemberUID      string `json:"member_uid" jsonschema:"The v2 UID of the mailing list member"`
+}
+
+// SearchMailingListsArgs defines the input parameters for the search_mailing_lists tool.
+type SearchMailingListsArgs struct {
+	Name       string `json:"name,omitempty" jsonschema:"Name or partial name of the mailing list to search for"`
+	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional v2 project UID to filter mailing lists by project (e.g. a27394a3-7a6c-4d0f-9e0f-692d8753924f)"`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
+// RegisterGetGrpsioService registers the get_grpsio_service tool with the MCP server.
+func RegisterGetGrpsioService(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_mailing_list_service",
+		Description: "Get a Groups.io service's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
+	}, handleGetGrpsioService)
+}
+
+// RegisterGetGrpsioMailingList registers the get_grpsio_mailing_list tool with the MCP server.
+func RegisterGetGrpsioMailingList(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_mailing_list",
+		Description: "Get a Groups.io mailing list's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
+	}, handleGetGrpsioMailingList)
+}
+
+// RegisterGetGrpsioMailingListMember registers the get_grpsio_mailing_list_member tool with the MCP server.
+func RegisterGetGrpsioMailingListMember(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_mailing_list_member",
+		Description: "Get a specific mailing list member by mailing list UID and member UID.",
+	}, handleGetGrpsioMailingListMember)
+}
+
+// RegisterSearchMailingLists registers the search_mailing_lists tool with the MCP server.
+func RegisterSearchMailingLists(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "search_mailing_lists",
+		Description: "Search for LFX mailing lists by name using the LFX query service. Optionally filter by project UID.",
+	}, handleSearchMailingLists)
+}
+
+// handleGetGrpsioService implements the get_grpsio_service tool logic.
+func handleGetGrpsioService(ctx context.Context, req *mcp.CallToolRequest, args GetGrpsioServiceArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if mailingListConfig == nil {
+		logger.Error("mailing list tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: mailing list tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.UID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           mailingListConfig.LFXAPIURL,
+		TokenExchangeClient: mailingListConfig.TokenExchangeClient,
+		DebugLogger:         mailingListConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("fetching grpsio service", "uid", args.UID)
+
+	baseResult, err := clients.MailingList.GetGrpsioService(ctx, &mailinglist.GetGrpsioServicePayload{
+		UID: &args.UID,
+	})
+	if err != nil {
+		logger.Error("GetGrpsioService failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get grpsio service: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	var serviceSettings *mailinglist.GrpsIoServiceSettings
+	settingsResult, err := clients.MailingList.GetGrpsioServiceSettings(ctx, &mailinglist.GetGrpsioServiceSettingsPayload{
+		UID: &args.UID,
+	})
+	if err != nil {
+		logger.Warn("getting grpsio service settings failed, returning base only", "error", lfxv2.ErrorMessage(err), "uid", args.UID)
+	} else {
+		serviceSettings = settingsResult.ServiceSettings
+	}
+
+	type grpsioServiceResult struct {
+		Base     *mailinglist.GrpsIoServiceWithReadonlyAttributes `json:"base"`
+		Settings *mailinglist.GrpsIoServiceSettings               `json:"settings,omitempty"`
+	}
+
+	out := grpsioServiceResult{
+		Base:     baseResult.Service,
+		Settings: serviceSettings,
+	}
+
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal grpsio service result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("get_grpsio_service succeeded", "uid", args.UID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleGetGrpsioMailingList implements the get_grpsio_mailing_list tool logic.
+func handleGetGrpsioMailingList(ctx context.Context, req *mcp.CallToolRequest, args GetGrpsioMailingListArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if mailingListConfig == nil {
+		logger.Error("mailing list tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: mailing list tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.UID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           mailingListConfig.LFXAPIURL,
+		TokenExchangeClient: mailingListConfig.TokenExchangeClient,
+		DebugLogger:         mailingListConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("fetching grpsio mailing list", "uid", args.UID)
+
+	baseResult, err := clients.MailingList.GetGrpsioMailingList(ctx, &mailinglist.GetGrpsioMailingListPayload{
+		Version: "1",
+		UID:     &args.UID,
+	})
+	if err != nil {
+		logger.Error("GetGrpsioMailingList failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get mailing list: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	var mlSettings *mailinglist.GrpsIoMailingListSettings
+	settingsResult, err := clients.MailingList.GetGrpsioMailingListSettings(ctx, &mailinglist.GetGrpsioMailingListSettingsPayload{
+		UID: &args.UID,
+	})
+	if err != nil {
+		logger.Warn("getting mailing list settings failed, returning base only", "error", lfxv2.ErrorMessage(err), "uid", args.UID)
+	} else {
+		mlSettings = settingsResult.MailingListSettings
+	}
+
+	type mailingListResult struct {
+		Base     *mailinglist.GrpsIoMailingListWithReadonlyAttributes `json:"base"`
+		Settings *mailinglist.GrpsIoMailingListSettings               `json:"settings,omitempty"`
+	}
+
+	out := mailingListResult{
+		Base:     baseResult.MailingList,
+		Settings: mlSettings,
+	}
+
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal mailing list result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("get_grpsio_mailing_list succeeded", "uid", args.UID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleGetGrpsioMailingListMember implements the get_grpsio_mailing_list_member tool logic.
+func handleGetGrpsioMailingListMember(ctx context.Context, req *mcp.CallToolRequest, args GetGrpsioMailingListMemberArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if mailingListConfig == nil {
+		logger.Error("mailing list tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: mailing list tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.MailingListUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: mailing_list_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.MemberUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: member_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           mailingListConfig.LFXAPIURL,
+		TokenExchangeClient: mailingListConfig.TokenExchangeClient,
+		DebugLogger:         mailingListConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("fetching mailing list member", "mailing_list_uid", args.MailingListUID, "member_uid", args.MemberUID)
+
+	result, err := clients.MailingList.GetGrpsioMailingListMember(ctx, &mailinglist.GetGrpsioMailingListMemberPayload{
+		Version:   "1",
+		UID:       args.MailingListUID,
+		MemberUID: args.MemberUID,
+	})
+	if err != nil {
+		logger.Error("GetGrpsioMailingListMember failed", "error", err, "mailing_list_uid", args.MailingListUID, "member_uid", args.MemberUID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get mailing list member: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result.Member, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal mailing list member result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("get_grpsio_mailing_list_member succeeded", "mailing_list_uid", args.MailingListUID, "member_uid", args.MemberUID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleSearchMailingLists implements the search_mailing_lists tool logic.
+func handleSearchMailingLists(ctx context.Context, req *mcp.CallToolRequest, args SearchMailingListsArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if mailingListConfig == nil {
+		logger.Error("mailing list tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: mailing list tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           mailingListConfig.LFXAPIURL,
+		TokenExchangeClient: mailingListConfig.TokenExchangeClient,
+		DebugLogger:         mailingListConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	pageSize := args.PageSize
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	resourceType := mailingListResourceType
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
+		PageSize: pageSize,
+		Sort:     "name_asc",
+	}
+
+	if args.Name != "" {
+		payload.Name = &args.Name
+	}
+
+	if args.ProjectUID != "" {
+		parentRef := "project:" + args.ProjectUID
+		payload.Parent = &parentRef
+	}
+
+	if args.PageToken != "" {
+		payload.PageToken = &args.PageToken
+	}
+
+	logger.Info("searching mailing lists", "name", args.Name, "project_uid", args.ProjectUID, "page_size", pageSize)
+
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
+	if err != nil {
+		logger.Error("QueryResources failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search mailing lists: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	type searchResult struct {
+		Resources []*querysvc.Resource `json:"resources"`
+		PageToken *string              `json:"page_token,omitempty"`
+	}
+
+	out := searchResult{
+		Resources: result.Resources,
+		PageToken: result.PageToken,
+	}
+
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal search result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("search_mailing_lists succeeded", "count", len(result.Resources))
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -35,18 +35,18 @@ func SetMailingListConfig(cfg *MailingListConfig) {
 	mailingListConfig = cfg
 }
 
-// GetGrpsioServiceArgs defines the input parameters for the get_grpsio_service tool.
-type GetGrpsioServiceArgs struct {
-	UID string `json:"uid" jsonschema:"The v2 UID of the Groups.io service to retrieve"`
+// GetMailingListServiceArgs defines the input parameters for the get_mailing_list_service tool.
+type GetMailingListServiceArgs struct {
+	UID string `json:"uid" jsonschema:"The v2 UID of the mailing list service to retrieve"`
 }
 
-// GetGrpsioMailingListArgs defines the input parameters for the get_grpsio_mailing_list tool.
-type GetGrpsioMailingListArgs struct {
+// GetMailingListArgs defines the input parameters for the get_mailing_list tool.
+type GetMailingListArgs struct {
 	UID string `json:"uid" jsonschema:"The v2 UID of the mailing list to retrieve"`
 }
 
-// GetGrpsioMailingListMemberArgs defines the input parameters for the get_grpsio_mailing_list_member tool.
-type GetGrpsioMailingListMemberArgs struct {
+// GetMailingListMemberArgs defines the input parameters for the get_mailing_list_member tool.
+type GetMailingListMemberArgs struct {
 	MailingListUID string `json:"mailing_list_uid" jsonschema:"The v2 UID of the mailing list"`
 	MemberUID      string `json:"member_uid" jsonschema:"The v2 UID of the mailing list member"`
 }
@@ -67,28 +67,28 @@ type SearchMailingListsArgs struct {
 	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
-// RegisterGetGrpsioService registers the get_grpsio_service tool with the MCP server.
-func RegisterGetGrpsioService(server *mcp.Server) {
+// RegisterGetMailingListService registers the get_mailing_list_service tool with the MCP server.
+func RegisterGetMailingListService(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_mailing_list_service",
-		Description: "Get a Groups.io service's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
-	}, handleGetGrpsioService)
+		Description: "Get a mailing list service's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
+	}, handleGetMailingListService)
 }
 
-// RegisterGetGrpsioMailingList registers the get_grpsio_mailing_list tool with the MCP server.
-func RegisterGetGrpsioMailingList(server *mcp.Server) {
+// RegisterGetMailingList registers the get_mailing_list tool with the MCP server.
+func RegisterGetMailingList(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_mailing_list",
-		Description: "Get a Groups.io mailing list's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
-	}, handleGetGrpsioMailingList)
+		Description: "Get a mailing list's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
+	}, handleGetMailingList)
 }
 
-// RegisterGetGrpsioMailingListMember registers the get_grpsio_mailing_list_member tool with the MCP server.
-func RegisterGetGrpsioMailingListMember(server *mcp.Server) {
+// RegisterGetMailingListMember registers the get_mailing_list_member tool with the MCP server.
+func RegisterGetMailingListMember(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_mailing_list_member",
 		Description: "Get a specific mailing list member by mailing list UID and member UID.",
-	}, handleGetGrpsioMailingListMember)
+	}, handleGetMailingListMember)
 }
 
 // RegisterSearchMailingListMembers registers the search_mailing_list_members tool with the MCP server.
@@ -107,8 +107,8 @@ func RegisterSearchMailingLists(server *mcp.Server) {
 	}, handleSearchMailingLists)
 }
 
-// handleGetGrpsioService implements the get_grpsio_service tool logic.
-func handleGetGrpsioService(ctx context.Context, req *mcp.CallToolRequest, args GetGrpsioServiceArgs) (*mcp.CallToolResult, any, error) {
+// handleGetMailingListService implements the get_mailing_list_service tool logic.
+func handleGetMailingListService(ctx context.Context, req *mcp.CallToolRequest, args GetMailingListServiceArgs) (*mcp.CallToolResult, any, error) {
 	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
 
 	if mailingListConfig == nil {
@@ -158,7 +158,7 @@ func handleGetGrpsioService(ctx context.Context, req *mcp.CallToolRequest, args 
 		}, nil, nil
 	}
 
-	logger.Info("fetching grpsio service", "uid", args.UID)
+	logger.Info("fetching mailing list service", "uid", args.UID)
 
 	baseResult, err := clients.MailingList.GetGrpsioService(ctx, &mailinglist.GetGrpsioServicePayload{
 		UID: &args.UID,
@@ -167,7 +167,7 @@ func handleGetGrpsioService(ctx context.Context, req *mcp.CallToolRequest, args 
 		logger.Error("GetGrpsioService failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get grpsio service: %s", lfxv2.ErrorMessage(err))},
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get mailing list service: %s", lfxv2.ErrorMessage(err))},
 			},
 			IsError: true,
 		}, nil, nil
@@ -178,24 +178,24 @@ func handleGetGrpsioService(ctx context.Context, req *mcp.CallToolRequest, args 
 		UID: &args.UID,
 	})
 	if err != nil {
-		logger.Warn("getting grpsio service settings failed, returning base only", "error", lfxv2.ErrorMessage(err), "uid", args.UID)
+		logger.Warn("getting mailing list service settings failed, returning base only", "error", lfxv2.ErrorMessage(err), "uid", args.UID)
 	} else {
 		serviceSettings = settingsResult.ServiceSettings
 	}
 
-	type grpsioServiceResult struct {
+	type serviceResult struct {
 		Base     *mailinglist.GrpsIoServiceWithReadonlyAttributes `json:"base"`
 		Settings *mailinglist.GrpsIoServiceSettings               `json:"settings,omitempty"`
 	}
 
-	out := grpsioServiceResult{
+	out := serviceResult{
 		Base:     baseResult.Service,
 		Settings: serviceSettings,
 	}
 
 	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
-		logger.Error("failed to marshal grpsio service result", "error", err)
+		logger.Error("failed to marshal mailing list service result", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
@@ -204,7 +204,7 @@ func handleGetGrpsioService(ctx context.Context, req *mcp.CallToolRequest, args 
 		}, nil, nil
 	}
 
-	logger.Info("get_grpsio_service succeeded", "uid", args.UID)
+	logger.Info("get_mailing_list_service succeeded", "uid", args.UID)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -213,8 +213,8 @@ func handleGetGrpsioService(ctx context.Context, req *mcp.CallToolRequest, args 
 	}, nil, nil
 }
 
-// handleGetGrpsioMailingList implements the get_grpsio_mailing_list tool logic.
-func handleGetGrpsioMailingList(ctx context.Context, req *mcp.CallToolRequest, args GetGrpsioMailingListArgs) (*mcp.CallToolResult, any, error) {
+// handleGetMailingList implements the get_mailing_list tool logic.
+func handleGetMailingList(ctx context.Context, req *mcp.CallToolRequest, args GetMailingListArgs) (*mcp.CallToolResult, any, error) {
 	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
 
 	if mailingListConfig == nil {
@@ -264,7 +264,7 @@ func handleGetGrpsioMailingList(ctx context.Context, req *mcp.CallToolRequest, a
 		}, nil, nil
 	}
 
-	logger.Info("fetching grpsio mailing list", "uid", args.UID)
+	logger.Info("fetching mailing list", "uid", args.UID)
 
 	baseResult, err := clients.MailingList.GetGrpsioMailingList(ctx, &mailinglist.GetGrpsioMailingListPayload{
 		Version: "1",
@@ -311,7 +311,7 @@ func handleGetGrpsioMailingList(ctx context.Context, req *mcp.CallToolRequest, a
 		}, nil, nil
 	}
 
-	logger.Info("get_grpsio_mailing_list succeeded", "uid", args.UID)
+	logger.Info("get_mailing_list succeeded", "uid", args.UID)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -320,8 +320,8 @@ func handleGetGrpsioMailingList(ctx context.Context, req *mcp.CallToolRequest, a
 	}, nil, nil
 }
 
-// handleGetGrpsioMailingListMember implements the get_grpsio_mailing_list_member tool logic.
-func handleGetGrpsioMailingListMember(ctx context.Context, req *mcp.CallToolRequest, args GetGrpsioMailingListMemberArgs) (*mcp.CallToolResult, any, error) {
+// handleGetMailingListMember implements the get_mailing_list_member tool logic.
+func handleGetMailingListMember(ctx context.Context, req *mcp.CallToolRequest, args GetMailingListMemberArgs) (*mcp.CallToolResult, any, error) {
 	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
 
 	if mailingListConfig == nil {
@@ -408,7 +408,7 @@ func handleGetGrpsioMailingListMember(ctx context.Context, req *mcp.CallToolRequ
 		}, nil, nil
 	}
 
-	logger.Info("get_grpsio_mailing_list_member succeeded", "mailing_list_uid", args.MailingListUID, "member_uid", args.MemberUID)
+	logger.Info("get_mailing_list_member succeeded", "mailing_list_uid", args.MailingListUID, "member_uid", args.MemberUID)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -55,7 +55,7 @@ type GetMailingListMemberArgs struct {
 type SearchMailingListMembersArgs struct {
 	MailingListUID string `json:"mailing_list_uid" jsonschema:"The v2 UID of the mailing list whose members to search"`
 	Name           string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
-	PageSize       int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageSize       int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10)"`
 	PageToken      string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
@@ -63,7 +63,7 @@ type SearchMailingListMembersArgs struct {
 type SearchMailingListsArgs struct {
 	Name       string `json:"name,omitempty" jsonschema:"Name or partial name of the mailing list to search for"`
 	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional v2 project UID to filter mailing lists by project (e.g. a27394a3-7a6c-4d0f-9e0f-692d8753924f)"`
-	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10)"`
 	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -18,6 +18,9 @@ import (
 // mailingListResourceType is the resource type filter for mailing list queries.
 const mailingListResourceType = "grpsio_mailing_list"
 
+// mailingListMemberResourceType is the resource type filter for mailing list member queries.
+const mailingListMemberResourceType = "grpsio_mailing_list_member"
+
 // MailingListConfig holds configuration shared by mailing list tools.
 type MailingListConfig struct {
 	LFXAPIURL           string
@@ -46,6 +49,14 @@ type GetGrpsioMailingListArgs struct {
 type GetGrpsioMailingListMemberArgs struct {
 	MailingListUID string `json:"mailing_list_uid" jsonschema:"The v2 UID of the mailing list"`
 	MemberUID      string `json:"member_uid" jsonschema:"The v2 UID of the mailing list member"`
+}
+
+// SearchMailingListMembersArgs defines the input parameters for the search_mailing_list_members tool.
+type SearchMailingListMembersArgs struct {
+	MailingListUID string `json:"mailing_list_uid" jsonschema:"The v2 UID of the mailing list whose members to search"`
+	Name           string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
+	PageSize       int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken      string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // SearchMailingListsArgs defines the input parameters for the search_mailing_lists tool.
@@ -78,6 +89,14 @@ func RegisterGetGrpsioMailingListMember(server *mcp.Server) {
 		Name:        "get_mailing_list_member",
 		Description: "Get a specific mailing list member by mailing list UID and member UID.",
 	}, handleGetGrpsioMailingListMember)
+}
+
+// RegisterSearchMailingListMembers registers the search_mailing_list_members tool with the MCP server.
+func RegisterSearchMailingListMembers(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "search_mailing_list_members",
+		Description: "Search for members of a specific mailing list. Requires a mailing list UID. Optionally filter by name.",
+	}, handleSearchMailingListMembers)
 }
 
 // RegisterSearchMailingLists registers the search_mailing_lists tool with the MCP server.
@@ -501,6 +520,124 @@ func handleSearchMailingLists(ctx context.Context, req *mcp.CallToolRequest, arg
 	}
 
 	logger.Info("search_mailing_lists succeeded", "count", len(result.Resources))
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleSearchMailingListMembers implements the search_mailing_list_members tool logic.
+func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchMailingListMembersArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if mailingListConfig == nil {
+		logger.Error("mailing list tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: mailing list tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.MailingListUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: mailing_list_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           mailingListConfig.LFXAPIURL,
+		TokenExchangeClient: mailingListConfig.TokenExchangeClient,
+		DebugLogger:         mailingListConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	pageSize := args.PageSize
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	resourceType := mailingListMemberResourceType
+	// Members are tagged with mailing_list_uid:<uid> by the mailing list service indexer.
+	mlTag := fmt.Sprintf("mailing_list_uid:%s", args.MailingListUID)
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
+		Tags:     []string{mlTag},
+		PageSize: pageSize,
+		Sort:     "name_asc",
+	}
+
+	if args.Name != "" {
+		payload.Name = &args.Name
+	}
+
+	if args.PageToken != "" {
+		payload.PageToken = &args.PageToken
+	}
+
+	logger.Info("searching mailing list members", "mailing_list_uid", args.MailingListUID, "name", args.Name, "page_size", pageSize)
+
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
+	if err != nil {
+		logger.Error("QueryResources failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search mailing list members: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	type searchResult struct {
+		Resources []*querysvc.Resource `json:"resources"`
+		PageToken *string              `json:"page_token,omitempty"`
+	}
+
+	out := searchResult{
+		Resources: result.Resources,
+		PageToken: result.PageToken,
+	}
+
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal search result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("search_mailing_list_members succeeded", "mailing_list_uid", args.MailingListUID, "count", len(result.Resources))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{


### PR DESCRIPTION
## Summary
- Add `get_mailing_list_service`, `get_mailing_list`, `get_mailing_list_member`, `search_mailing_lists`, and `search_mailing_list_members` MCP tools
- Integrate `lfx-v2-mailing-list-service` client into the shared `lfxv2.Clients` struct
- Follow existing committee/project tool patterns (read-only, settings failure non-fatal)
- Fix pre-existing revive lint error in `errors.go` (missing package comment)

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Run MCP server with mailing list tools enabled and invoke each tool