### PR TITLE
charts/lfx-mcp: add additionalHostnames to HTTPRoute listener config

### DIFF
--- a/charts/lfx-mcp/templates/httproute.yaml
+++ b/charts/lfx-mcp/templates/httproute.yaml
@@ -14,9 +14,14 @@ spec:
       kind: Gateway
       name: {{ .Values.gateway.name }}
       namespace: {{ .Values.gateway.namespace | default .Release.Namespace }}
-  {{- with .Values.gateway.listeners.https.hostname }}
+  {{- if or .Values.gateway.listeners.https.hostname .Values.gateway.listeners.https.additionalHostnames }}
   hostnames:
+    {{- with .Values.gateway.listeners.https.hostname }}
     - {{ . | quote }}
+    {{- end }}
+    {{- range .Values.gateway.listeners.https.additionalHostnames }}
+    - {{ . | quote }}
+    {{- end }}
   {{- end }}
   rules:
     - matches:

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -57,6 +57,9 @@ gateway:
       protocol: HTTPS
       # hostname is the public DNS hostname for this listener (required).
       hostname: ""
+      # additionalHostnames is an optional list of additional hostnames to include in the HTTPRoute.
+      # Useful when external-dns domain filters require a different hostname than the public-facing one.
+      additionalHostnames: []
       allowedRoutes:
         namespaces:
           from: Same


### PR DESCRIPTION
## Summary

Adds `gateway.listeners.https.additionalHostnames` — an optional list of extra hostnames included in the HTTPRoute spec alongside the primary listener hostname.

## Motivation

The `external-dns` deployment in the prod cluster uses `--domain-filter=prod.v2.cluster.linuxfound.info`, so it only manages records within that zone. The prod deployment uses `mcp.lfx.dev` as the primary hostname (a CNAME to `lfx-mcp.prod.v2.cluster.linuxfound.info`), but external-dns ignores it because it's outside the filter.

By adding `lfx-mcp.prod.v2.cluster.linuxfound.info` as an additional hostname in the HTTPRoute, external-dns will see it, create the A record pointing at the ELB, and the CNAME chain resolves — unblocking the cert-manager HTTP-01 ACME challenge for `mcp.lfx.dev`.

## Usage

```yaml
gateway:
  listeners:
    https:
      hostname: mcp.lfx.dev
      additionalHostnames:
        - "lfx-mcp.prod.v2.cluster.linuxfound.info"
```

Jira: [ARCH-339](https://linuxfoundation.atlassian.net/browse/ARCH-339)

[ARCH-339]: https://linuxfoundation.atlassian.net/browse/ARCH-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ