### PR TITLE
Add membership (member) tools

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -76,7 +76,7 @@ func main() {
 	f.String("client_assertion_signing_key", "", "PEM-encoded RSA private key for client assertion (takes precedence over client_secret)")
 	f.String("token_endpoint", "", "OAuth2 token endpoint URL for token exchange")
 	f.String("lfx_api_url", "", "LFX API URL (used as token exchange audience)")
-	f.String("tools", "search_projects,get_project,search_committees,get_committee,get_committee_member,search_committee_members,get_mailing_list_service,get_mailing_list,get_mailing_list_member,search_mailing_lists,search_mailing_list_members", "Comma-separated list of tools to enable")
+	f.String("tools", "search_projects,get_project,search_committees,get_committee,get_committee_member,search_committee_members,get_mailing_list_service,get_mailing_list,get_mailing_list_member,search_mailing_lists,search_mailing_list_members,search_memberships,get_membership,get_membership_contacts", "Comma-separated list of tools to enable")
 	f.Bool("debug", false, "Enable debug logging")
 	f.Bool("debug_traffic", false, "Enable HTTP request/response debug logging for outbound LFX API calls")
 
@@ -186,6 +186,11 @@ func main() {
 				DebugLogger:         debugLogger,
 			})
 			tools.SetMailingListConfig(&tools.MailingListConfig{
+				LFXAPIURL:           cfg.LFXAPIURL,
+				TokenExchangeClient: tokenExchangeClient,
+				DebugLogger:         debugLogger,
+			})
+			tools.SetMembershipConfig(&tools.MembershipConfig{
 				LFXAPIURL:           cfg.LFXAPIURL,
 				TokenExchangeClient: tokenExchangeClient,
 				DebugLogger:         debugLogger,
@@ -303,6 +308,15 @@ func newServer(cfg Config) *mcp.Server {
 	}
 	if enabledTools["search_mailing_list_members"] {
 		tools.RegisterSearchMailingListMembers(server)
+	}
+	if enabledTools["search_memberships"] {
+		tools.RegisterSearchMemberships(server)
+	}
+	if enabledTools["get_membership"] {
+		tools.RegisterGetMembership(server)
+	}
+	if enabledTools["get_membership_contacts"] {
+		tools.RegisterGetMembershipContacts(server)
 	}
 
 	return server

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/linuxfoundation/lfx-v2-committee-service v0.2.19
 	github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10
+	github.com/linuxfoundation/lfx-v2-member-service v0.1.1
 	github.com/linuxfoundation/lfx-v2-project-service v0.5.7
 	github.com/linuxfoundation/lfx-v2-query-service v0.4.12
 	github.com/modelcontextprotocol/go-sdk v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/linuxfoundation/lfx-v2-committee-service v0.2.19 h1:xMeqXvf7NLk9JlfAE
 github.com/linuxfoundation/lfx-v2-committee-service v0.2.19/go.mod h1:vhFiTH/CEDcs2kHmDofKzJclW1ZtBlfaRH0brL6lfek=
 github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10 h1:OG+usJ9DZDMT5d9YZ+H53v0+BBTKsq7cqRAakLxlGvs=
 github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10/go.mod h1:d78d8z0Ll17hsRzKK3QtNj1ssMIDkJ5kgm5pV8KmB3Q=
+github.com/linuxfoundation/lfx-v2-member-service v0.1.1 h1:bQovD31ya/xK7c50kFE/RjBX+1QUD6bfDB3S3T/ZvSc=
+github.com/linuxfoundation/lfx-v2-member-service v0.1.1/go.mod h1:k4XZgotYmJmpL40V8Z/ZbVWGfJOgAl2MONYK9t+KJMc=
 github.com/linuxfoundation/lfx-v2-project-service v0.5.7 h1:qycjiPSogIIHhRXDFSa0Zxu5ZLb/4jt9I8/JJmAJ0M4=
 github.com/linuxfoundation/lfx-v2-project-service v0.5.7/go.mod h1:JCQZhtqf6lqxG0LA55qbQrTFwV3oSdAoLKn/1BvcMe4=
 github.com/linuxfoundation/lfx-v2-query-service v0.4.12 h1:2sp/7zyhzsq8slNTWefixzjAI88yBYGYPuOjcnGke7I=

--- a/internal/lfxv2/client.go
+++ b/internal/lfxv2/client.go
@@ -60,6 +60,8 @@ import (
 	committeehttpclient "github.com/linuxfoundation/lfx-v2-committee-service/gen/http/committee_service/client"
 	mailinglisthttpclient "github.com/linuxfoundation/lfx-v2-mailing-list-service/gen/http/mailing_list/client"
 	mailinglist "github.com/linuxfoundation/lfx-v2-mailing-list-service/gen/mailing_list"
+	membershiphttpclient "github.com/linuxfoundation/lfx-v2-member-service/gen/http/membership_service/client"
+	membershipservice "github.com/linuxfoundation/lfx-v2-member-service/gen/membership_service"
 	projecthttpclient "github.com/linuxfoundation/lfx-v2-project-service/api/project/v1/gen/http/project_service/client"
 	projectservice "github.com/linuxfoundation/lfx-v2-project-service/api/project/v1/gen/project_service"
 	queryhttpclient "github.com/linuxfoundation/lfx-v2-query-service/gen/http/query_svc/client"
@@ -123,6 +125,7 @@ type ClientConfig struct {
 type Clients struct {
 	Committee   *committeeservice.Client
 	MailingList *mailinglist.Client
+	Membership  *membershipservice.Client
 	Project     *projectservice.Client
 	QuerySvc    *querysvc.Client
 
@@ -232,6 +235,29 @@ func NewClients(_ context.Context, cfg ClientConfig) (*Clients, error) {
 		mlHTTPClient.UpdateGrpsioMailingListMember(),
 		mlHTTPClient.DeleteGrpsioMailingListMember(),
 		mlHTTPClient.GroupsioWebhook(),
+	)
+
+	// Initialize membership service client.
+	membershipURL, err := url.Parse(cfg.APIDomain + "/memberships")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse membership service URL: %w", err)
+	}
+
+	membershipHTTPClient := membershiphttpclient.NewClient(
+		membershipURL.Scheme,
+		membershipURL.Host,
+		httpClient,
+		goahttp.RequestEncoder,
+		goahttp.ResponseDecoder,
+		false,
+	)
+
+	clients.Membership = membershipservice.NewClient(
+		membershipHTTPClient.ListMemberships(),
+		membershipHTTPClient.GetMembership(),
+		membershipHTTPClient.ListMembershipContacts(),
+		membershipHTTPClient.Readyz(),
+		membershipHTTPClient.Livez(),
 	)
 
 	// Initialize project service client.

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -53,7 +53,8 @@ type GetMailingListMemberArgs struct {
 
 // SearchMailingListMembersArgs defines the input parameters for the search_mailing_list_members tool.
 type SearchMailingListMembersArgs struct {
-	MailingListUID string `json:"mailing_list_uid" jsonschema:"The v2 UID of the mailing list whose members to search"`
+	MailingListUID string `json:"mailing_list_uid,omitempty" jsonschema:"Optional v2 UID of the mailing list to filter members by"`
+	ProjectUID     string `json:"project_uid,omitempty" jsonschema:"Optional v2 project UID to filter mailing list members by project"`
 	Name           string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
 	PageSize       int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10)"`
 	PageToken      string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -95,7 +96,7 @@ func RegisterGetMailingListMember(server *mcp.Server) {
 func RegisterSearchMailingListMembers(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_mailing_list_members",
-		Description: "Search for members of a specific mailing list. Requires a mailing list UID. Optionally filter by name.",
+		Description: "Search for LFX mailing list members. Optionally filter by mailing list UID, project UID (v2), and/or name. At least one filter is recommended but not required.",
 	}, handleSearchMailingListMembers)
 }
 
@@ -508,6 +509,10 @@ func handleSearchMailingLists(ctx context.Context, req *mcp.CallToolRequest, arg
 		PageToken: result.PageToken,
 	}
 
+	if result.PageToken != nil && len(result.Resources) < pageSize {
+		logger.Warn("some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters")
+	}
+
 	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		logger.Error("failed to marshal search result", "error", err)
@@ -537,15 +542,6 @@ func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolReques
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: "Error: mailing list tools not configured"},
-			},
-			IsError: true,
-		}, nil, nil
-	}
-
-	if args.MailingListUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: mailing_list_uid is required"},
 			},
 			IsError: true,
 		}, nil, nil
@@ -585,14 +581,22 @@ func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolReques
 	}
 
 	resourceType := mailingListMemberResourceType
-	// Members are tagged with mailing_list_uid:<uid> by the mailing list service indexer.
-	mlTag := fmt.Sprintf("mailing_list_uid:%s", args.MailingListUID)
 	payload := &querysvc.QueryResourcesPayload{
 		Version:  "1",
 		Type:     &resourceType,
-		Tags:     []string{mlTag},
 		PageSize: pageSize,
 		Sort:     "name_asc",
+	}
+
+	var tags []string
+	if args.MailingListUID != "" {
+		tags = append(tags, fmt.Sprintf("mailing_list_uid:%s", args.MailingListUID))
+	}
+	if args.ProjectUID != "" {
+		tags = append(tags, fmt.Sprintf("project_uid:%s", args.ProjectUID))
+	}
+	if len(tags) > 0 {
+		payload.Tags = tags
 	}
 
 	if args.Name != "" {
@@ -603,7 +607,7 @@ func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolReques
 		payload.PageToken = &args.PageToken
 	}
 
-	logger.Info("searching mailing list members", "mailing_list_uid", args.MailingListUID, "name", args.Name, "page_size", pageSize)
+	logger.Info("searching mailing list members", "mailing_list_uid", args.MailingListUID, "project_uid", args.ProjectUID, "name", args.Name, "page_size", pageSize)
 
 	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {
@@ -626,6 +630,10 @@ func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolReques
 		PageToken: result.PageToken,
 	}
 
+	if result.PageToken != nil && len(result.Resources) < pageSize {
+		logger.Warn("some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters")
+	}
+
 	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		logger.Error("failed to marshal search result", "error", err)
@@ -637,7 +645,7 @@ func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolReques
 		}, nil, nil
 	}
 
-	logger.Info("search_mailing_list_members succeeded", "mailing_list_uid", args.MailingListUID, "count", len(result.Resources))
+	logger.Info("search_mailing_list_members succeeded", "mailing_list_uid", args.MailingListUID, "project_uid", args.ProjectUID, "count", len(result.Resources))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/internal/tools/membership.go
+++ b/internal/tools/membership.go
@@ -1,0 +1,377 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/linuxfoundation/lfx-mcp/internal/lfxv2"
+	membershipservice "github.com/linuxfoundation/lfx-v2-member-service/gen/membership_service"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// MembershipConfig holds configuration shared by membership tools.
+type MembershipConfig struct {
+	LFXAPIURL           string
+	TokenExchangeClient *lfxv2.TokenExchangeClient
+	DebugLogger         *slog.Logger
+}
+
+var membershipConfig *MembershipConfig
+
+// SetMembershipConfig sets the configuration for membership tools.
+func SetMembershipConfig(cfg *MembershipConfig) {
+	membershipConfig = cfg
+}
+
+// SearchMembershipsArgs defines the input parameters for the search_memberships tool.
+type SearchMembershipsArgs struct {
+	Status         string `json:"status,omitempty" jsonschema:"Filter by membership status (e.g. active, expired)"`
+	MembershipType string `json:"membership_type,omitempty" jsonschema:"Filter by membership type"`
+	AccountID      string `json:"account_id,omitempty" jsonschema:"Filter by account ID"`
+	ProjectID      string `json:"project_id,omitempty" jsonschema:"Filter by project ID"`
+	ProductID      string `json:"product_id,omitempty" jsonschema:"Filter by product ID"`
+	Year           string `json:"year,omitempty" jsonschema:"Filter by membership year"`
+	Tier           string `json:"tier,omitempty" jsonschema:"Filter by membership tier"`
+	ContactID      string `json:"contact_id,omitempty" jsonschema:"Filter by contact ID"`
+	AutoRenew      string `json:"auto_renew,omitempty" jsonschema:"Filter by auto-renew status (true or false)"`
+	PageSize       int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10)"`
+	Offset         int    `json:"offset,omitempty" jsonschema:"Offset into the total result list (default 0)"`
+}
+
+// GetMembershipArgs defines the input parameters for the get_membership tool.
+type GetMembershipArgs struct {
+	UID string `json:"uid" jsonschema:"The UID of the membership to retrieve"`
+}
+
+// GetMembershipContactsArgs defines the input parameters for the get_membership_contacts tool.
+type GetMembershipContactsArgs struct {
+	UID string `json:"uid" jsonschema:"The UID of the membership to get contacts for"`
+}
+
+// RegisterSearchMemberships registers the search_memberships tool with the MCP server.
+func RegisterSearchMemberships(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "search_memberships",
+		Description: "Search and filter members (memberships). Use this tool when users ask about members, memberships, or member organizations. Supports filtering by status, membership_type, account_id, project_id, product_id, year, tier (e.g. gold, platinum, silver), contact_id, and auto_renew. Uses offset-based pagination.",
+	}, handleSearchMemberships)
+}
+
+// RegisterGetMembership registers the get_membership tool with the MCP server.
+func RegisterGetMembership(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_membership",
+		Description: "Get a single member (membership) by its UID. Use this when users ask for details about a specific member or membership.",
+	}, handleGetMembership)
+}
+
+// RegisterGetMembershipContacts registers the get_membership_contacts tool with the MCP server.
+func RegisterGetMembershipContacts(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_membership_contacts",
+		Description: "Get key contacts for a member (membership) by its UID. Returns the people associated with a member such as primary contacts and board members.",
+	}, handleGetMembershipContacts)
+}
+
+// handleSearchMemberships implements the search_memberships tool logic.
+func handleSearchMemberships(ctx context.Context, req *mcp.CallToolRequest, args SearchMembershipsArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if membershipConfig == nil {
+		logger.Error("membership tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: membership tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           membershipConfig.LFXAPIURL,
+		TokenExchangeClient: membershipConfig.TokenExchangeClient,
+		DebugLogger:         membershipConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	pageSize := args.PageSize
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	// Build filter string from non-empty filter args.
+	var filters []string
+	if args.Status != "" {
+		filters = append(filters, "status="+args.Status)
+	}
+	if args.MembershipType != "" {
+		filters = append(filters, "membership_type="+args.MembershipType)
+	}
+	if args.AccountID != "" {
+		filters = append(filters, "account_id="+args.AccountID)
+	}
+	if args.ProjectID != "" {
+		filters = append(filters, "project_id="+args.ProjectID)
+	}
+	if args.ProductID != "" {
+		filters = append(filters, "product_id="+args.ProductID)
+	}
+	if args.Year != "" {
+		filters = append(filters, "year="+args.Year)
+	}
+	if args.Tier != "" {
+		filters = append(filters, "tier="+args.Tier)
+	}
+	if args.ContactID != "" {
+		filters = append(filters, "contact_id="+args.ContactID)
+	}
+	if args.AutoRenew != "" {
+		filters = append(filters, "auto_renew="+args.AutoRenew)
+	}
+
+	version := "1"
+	payload := &membershipservice.ListMembershipsPayload{
+		Version:  &version,
+		PageSize: pageSize,
+		Offset:   args.Offset,
+	}
+
+	if len(filters) > 0 {
+		filterStr := strings.Join(filters, ";")
+		payload.Filter = &filterStr
+	}
+
+	logger.Info("searching memberships", "filter_count", len(filters), "page_size", pageSize, "offset", args.Offset)
+
+	result, err := clients.Membership.ListMemberships(ctx, payload)
+	if err != nil {
+		logger.Error("ListMemberships failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search memberships: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal search result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("search_memberships succeeded", "count", len(result.Memberships))
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleGetMembership implements the get_membership tool logic.
+func handleGetMembership(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if membershipConfig == nil {
+		logger.Error("membership tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: membership tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.UID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           membershipConfig.LFXAPIURL,
+		TokenExchangeClient: membershipConfig.TokenExchangeClient,
+		DebugLogger:         membershipConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("fetching membership", "uid", args.UID)
+
+	version := "1"
+	result, err := clients.Membership.GetMembership(ctx, &membershipservice.GetMembershipPayload{
+		Version: &version,
+		UID:     &args.UID,
+	})
+	if err != nil {
+		logger.Error("GetMembership failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get membership: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result.Membership, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal membership result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("get_membership succeeded", "uid", args.UID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleGetMembershipContacts implements the get_membership_contacts tool logic.
+func handleGetMembershipContacts(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipContactsArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if membershipConfig == nil {
+		logger.Error("membership tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: membership tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.UID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           membershipConfig.LFXAPIURL,
+		TokenExchangeClient: membershipConfig.TokenExchangeClient,
+		DebugLogger:         membershipConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("fetching membership contacts", "uid", args.UID)
+
+	version := "1"
+	result, err := clients.Membership.ListMembershipContacts(ctx, &membershipservice.ListMembershipContactsPayload{
+		Version: &version,
+		UID:     &args.UID,
+	})
+	if err != nil {
+		logger.Error("ListMembershipContacts failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get membership contacts: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result.Contacts, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal membership contacts result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("get_membership_contacts succeeded", "uid", args.UID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}


### PR DESCRIPTION
## Summary
- Add three new MCP tools backed by `lfx-v2-member-service` (Goa-based, read-only API):
  - `search_memberships` — search/filter members with 9 domain-specific filters (status, membership_type, account_id, project_id, product_id, year, tier, contact_id, auto_renew) + offset-based pagination
  - `get_membership` — get a single member by UID
  - `get_membership_contacts` — get key contacts for a member (primary contacts, board members, etc.)
- Wire up membership service client in `internal/lfxv2/client.go`
- Improve mailing list member search to support optional filters (mailing_list_uid, project_uid)

## Test plan
- [x] `make build` compiles cleanly
- [x] `make check` (fmt + vet) passes
- [x] New tools appear in `tools/list` response
- [ ] Manual integration test: `search_memberships` with tier/project filters
- [ ] Manual integration test: `get_membership` with a known UID
- [ ] Manual integration test: `get_membership_contacts` with a known UID

Signed-off-by: Nirav Patel <npatel@linuxfoundation.org>