### PR TITLE
Fix meeting resource type filters

### DIFF
--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -16,10 +16,10 @@ import (
 )
 
 // meetingResourceType is the resource type filter for meeting queries.
-const meetingResourceType = "meeting"
+const meetingResourceType = "v1_meeting"
 
 // meetingRegistrantResourceType is the resource type filter for meeting registrant queries.
-const meetingRegistrantResourceType = "meeting_registrant"
+const meetingRegistrantResourceType = "v1_meeting_registrant"
 
 // MeetingConfig holds configuration shared by meeting tools.
 type MeetingConfig struct {


### PR DESCRIPTION
## Summary
- Update `meetingResourceType` from `"meeting"` to `"v1_meeting"`
- Update `meetingRegistrantResourceType` from `"meeting_registrant"` to `"v1_meeting_registrant"`

## Test plan
- [ ] Verify meeting search/get tools return correct results with updated resource types
- [ ] Verify meeting registrant search/get tools return correct results with updated resource types