### PR TITLE
Add past meeting participant, transcript, and summary tools

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -78,6 +78,12 @@ var defaultTools = []string{
 	"get_meeting",
 	"search_meeting_registrants",
 	"get_meeting_registrant",
+	"search_past_meeting_participants",
+	"get_past_meeting_participant",
+	"search_past_meeting_transcripts",
+	"get_past_meeting_transcript",
+	"search_past_meeting_summaries",
+	"get_past_meeting_summary",
 }
 
 var logger *slog.Logger
@@ -356,6 +362,24 @@ func newServer(cfg Config) *mcp.Server {
 	}
 	if enabledTools["get_meeting_registrant"] {
 		tools.RegisterGetMeetingRegistrant(server)
+	}
+	if enabledTools["search_past_meeting_participants"] {
+		tools.RegisterSearchPastMeetingParticipants(server)
+	}
+	if enabledTools["get_past_meeting_participant"] {
+		tools.RegisterGetPastMeetingParticipant(server)
+	}
+	if enabledTools["search_past_meeting_transcripts"] {
+		tools.RegisterSearchPastMeetingTranscripts(server)
+	}
+	if enabledTools["get_past_meeting_transcript"] {
+		tools.RegisterGetPastMeetingTranscript(server)
+	}
+	if enabledTools["search_past_meeting_summaries"] {
+		tools.RegisterSearchPastMeetingSummaries(server)
+	}
+	if enabledTools["get_past_meeting_summary"] {
+		tools.RegisterGetPastMeetingSummary(server)
 	}
 
 	return server

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -21,6 +21,15 @@ const meetingResourceType = "v1_meeting"
 // meetingRegistrantResourceType is the resource type filter for meeting registrant queries.
 const meetingRegistrantResourceType = "v1_meeting_registrant"
 
+// pastMeetingParticipantResourceType is the resource type filter for past meeting participant queries.
+const pastMeetingParticipantResourceType = "v1_past_meeting_participant"
+
+// pastMeetingTranscriptResourceType is the resource type filter for past meeting transcript queries.
+const pastMeetingTranscriptResourceType = "v1_past_meeting_transcript"
+
+// pastMeetingSummaryResourceType is the resource type filter for past meeting summary queries.
+const pastMeetingSummaryResourceType = "v1_past_meeting_summary"
+
 // MeetingConfig holds configuration shared by meeting tools.
 type MeetingConfig struct {
 	LFXAPIURL           string
@@ -67,6 +76,54 @@ func RegisterGetMeetingRegistrant(server *mcp.Server) {
 	}, handleGetMeetingRegistrant)
 }
 
+// RegisterSearchPastMeetingParticipants registers the search_past_meeting_participants tool with the MCP server.
+func RegisterSearchPastMeetingParticipants(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "search_past_meeting_participants",
+		Description: "Search for LFX past meeting participants using the query service. Supports filtering by meeting, committee, project, and other fields.",
+	}, handleSearchPastMeetingParticipants)
+}
+
+// RegisterGetPastMeetingParticipant registers the get_past_meeting_participant tool with the MCP server.
+func RegisterGetPastMeetingParticipant(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_past_meeting_participant",
+		Description: "Get an LFX past meeting participant by its UID using the query service.",
+	}, handleGetPastMeetingParticipant)
+}
+
+// RegisterSearchPastMeetingTranscripts registers the search_past_meeting_transcripts tool with the MCP server.
+func RegisterSearchPastMeetingTranscripts(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "search_past_meeting_transcripts",
+		Description: "Search for LFX past meeting transcripts using the query service. Supports filtering by meeting, committee, project, and other fields.",
+	}, handleSearchPastMeetingTranscripts)
+}
+
+// RegisterGetPastMeetingTranscript registers the get_past_meeting_transcript tool with the MCP server.
+func RegisterGetPastMeetingTranscript(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_past_meeting_transcript",
+		Description: "Get an LFX past meeting transcript by its UID using the query service.",
+	}, handleGetPastMeetingTranscript)
+}
+
+// RegisterSearchPastMeetingSummaries registers the search_past_meeting_summaries tool with the MCP server.
+func RegisterSearchPastMeetingSummaries(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "search_past_meeting_summaries",
+		Description: "Search for LFX past meeting summaries using the query service. Supports filtering by meeting, committee, project, and other fields.",
+	}, handleSearchPastMeetingSummaries)
+}
+
+// RegisterGetPastMeetingSummary registers the get_past_meeting_summary tool with the MCP server.
+func RegisterGetPastMeetingSummary(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_past_meeting_summary",
+		Description: "Get an LFX past meeting summary by its UID using the query service.",
+	}, handleGetPastMeetingSummary)
+}
+
 // SearchMeetingsArgs defines the input parameters for the search_meetings tool.
 type SearchMeetingsArgs struct {
 	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the meeting to search for"`
@@ -101,6 +158,57 @@ type SearchMeetingRegistrantsArgs struct {
 // GetMeetingRegistrantArgs defines the input parameters for the get_meeting_registrant tool.
 type GetMeetingRegistrantArgs struct {
 	UID string `json:"uid" jsonschema:"The UID of the meeting registrant to retrieve"`
+}
+
+// SearchPastMeetingParticipantsArgs defines the input parameters for the search_past_meeting_participants tool.
+type SearchPastMeetingParticipantsArgs struct {
+	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter participants by meeting ID"`
+	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter participants by committee UID"`
+	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter participants by project UID"`
+	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the participant to search for"`
+	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
+// GetPastMeetingParticipantArgs defines the input parameters for the get_past_meeting_participant tool.
+type GetPastMeetingParticipantArgs struct {
+	UID string `json:"uid" jsonschema:"The UID of the past meeting participant to retrieve"`
+}
+
+// SearchPastMeetingTranscriptsArgs defines the input parameters for the search_past_meeting_transcripts tool.
+type SearchPastMeetingTranscriptsArgs struct {
+	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter transcripts by meeting ID"`
+	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter transcripts by committee UID"`
+	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter transcripts by project UID"`
+	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the transcript to search for"`
+	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
+// GetPastMeetingTranscriptArgs defines the input parameters for the get_past_meeting_transcript tool.
+type GetPastMeetingTranscriptArgs struct {
+	UID string `json:"uid" jsonschema:"The UID of the past meeting transcript to retrieve"`
+}
+
+// SearchPastMeetingSummariesArgs defines the input parameters for the search_past_meeting_summaries tool.
+type SearchPastMeetingSummariesArgs struct {
+	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter summaries by meeting ID"`
+	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter summaries by committee UID"`
+	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter summaries by project UID"`
+	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the summary to search for"`
+	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
+// GetPastMeetingSummaryArgs defines the input parameters for the get_past_meeting_summary tool.
+type GetPastMeetingSummaryArgs struct {
+	UID string `json:"uid" jsonschema:"The UID of the past meeting summary to retrieve"`
 }
 
 // handleSearchMeetings implements the search_meetings tool logic.
@@ -578,6 +686,267 @@ func handleGetMeetingRegistrant(ctx context.Context, req *mcp.CallToolRequest, a
 	}
 
 	logger.Info("get_meeting_registrant succeeded", "uid", args.UID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleSearchPastMeetingParticipants implements the search_past_meeting_participants tool logic.
+func handleSearchPastMeetingParticipants(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingParticipantsArgs) (*mcp.CallToolResult, any, error) {
+	return handleSearchPastMeetingResource(ctx, req, pastMeetingParticipantResourceType, "past meeting participants", args.MeetingID, args.CommitteeUID, args.ProjectUID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
+}
+
+// handleGetPastMeetingParticipant implements the get_past_meeting_participant tool logic.
+func handleGetPastMeetingParticipant(ctx context.Context, req *mcp.CallToolRequest, args GetPastMeetingParticipantArgs) (*mcp.CallToolResult, any, error) {
+	return handleGetPastMeetingResource(ctx, req, pastMeetingParticipantResourceType, "past meeting participant", args.UID)
+}
+
+// handleSearchPastMeetingTranscripts implements the search_past_meeting_transcripts tool logic.
+func handleSearchPastMeetingTranscripts(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingTranscriptsArgs) (*mcp.CallToolResult, any, error) {
+	return handleSearchPastMeetingResource(ctx, req, pastMeetingTranscriptResourceType, "past meeting transcripts", args.MeetingID, args.CommitteeUID, args.ProjectUID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
+}
+
+// handleGetPastMeetingTranscript implements the get_past_meeting_transcript tool logic.
+func handleGetPastMeetingTranscript(ctx context.Context, req *mcp.CallToolRequest, args GetPastMeetingTranscriptArgs) (*mcp.CallToolResult, any, error) {
+	return handleGetPastMeetingResource(ctx, req, pastMeetingTranscriptResourceType, "past meeting transcript", args.UID)
+}
+
+// handleSearchPastMeetingSummaries implements the search_past_meeting_summaries tool logic.
+func handleSearchPastMeetingSummaries(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingSummariesArgs) (*mcp.CallToolResult, any, error) {
+	return handleSearchPastMeetingResource(ctx, req, pastMeetingSummaryResourceType, "past meeting summaries", args.MeetingID, args.CommitteeUID, args.ProjectUID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
+}
+
+// handleGetPastMeetingSummary implements the get_past_meeting_summary tool logic.
+func handleGetPastMeetingSummary(ctx context.Context, req *mcp.CallToolRequest, args GetPastMeetingSummaryArgs) (*mcp.CallToolResult, any, error) {
+	return handleGetPastMeetingResource(ctx, req, pastMeetingSummaryResourceType, "past meeting summary", args.UID)
+}
+
+// handleSearchPastMeetingResource is a shared implementation for searching past meeting resource types.
+func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest, resourceType, resourceLabel, meetingID, committeeUID, projectUID, name string, filters []string, sort string, pageSize int, pageToken string) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if meetingConfig == nil {
+		logger.Error("meeting tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: meeting tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           meetingConfig.LFXAPIURL,
+		TokenExchangeClient: meetingConfig.TokenExchangeClient,
+		DebugLogger:         meetingConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	if sort == "" {
+		sort = "name_asc"
+	}
+
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
+		PageSize: pageSize,
+		Sort:     sort,
+	}
+
+	var tags []string
+	if meetingID != "" {
+		tags = append(tags, fmt.Sprintf("meeting_id:%s", meetingID))
+	}
+	if committeeUID != "" {
+		tags = append(tags, fmt.Sprintf("committee_uid:%s", committeeUID))
+	}
+	if projectUID != "" {
+		tags = append(tags, fmt.Sprintf("project_uid:%s", projectUID))
+	}
+	if len(tags) > 0 {
+		payload.Tags = tags
+	}
+
+	if name != "" {
+		payload.Name = &name
+	}
+
+	if len(filters) > 0 {
+		payload.Filters = filters
+	}
+
+	if pageToken != "" {
+		payload.PageToken = &pageToken
+	}
+
+	logger.Info("searching "+resourceLabel, "meeting_id", meetingID, "committee_uid", committeeUID, "project_uid", projectUID, "name", name, "page_size", pageSize)
+
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
+	if err != nil {
+		logger.Error("QueryResources failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search %s: %s", resourceLabel, lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	type searchResult struct {
+		Resources []*querysvc.Resource `json:"resources"`
+		PageToken *string              `json:"page_token,omitempty"`
+	}
+
+	out := searchResult{
+		Resources: result.Resources,
+		PageToken: result.PageToken,
+	}
+
+	if result.PageToken != nil && len(result.Resources) < pageSize {
+		logger.Warn("some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters")
+	}
+
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal search result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("search "+resourceLabel+" succeeded", "count", len(result.Resources))
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleGetPastMeetingResource is a shared implementation for getting a past meeting resource by UID.
+func handleGetPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest, resourceType, resourceLabel, uid string) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if meetingConfig == nil {
+		logger.Error("meeting tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: meeting tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if uid == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           meetingConfig.LFXAPIURL,
+		TokenExchangeClient: meetingConfig.TokenExchangeClient,
+		DebugLogger:         meetingConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("fetching "+resourceLabel, "uid", uid)
+
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
+		Filters:  []string{fmt.Sprintf("uid:%s", uid)},
+		PageSize: 1,
+		Sort:     "name_asc",
+	}
+
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
+	if err != nil {
+		logger.Error("QueryResources failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get %s: %s", resourceLabel, lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if len(result.Resources) == 0 {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: %s not found with UID: %s", resourceLabel, uid)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result.Resources[0], "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("get "+resourceLabel+" succeeded", "uid", uid)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{


### PR DESCRIPTION
## Summary
- Add 6 new MCP tools for three past meeting resource types: `v1_past_meeting_participant`, `v1_past_meeting_transcript`, and `v1_past_meeting_summary`
- Each resource type gets a search + get tool pair following the existing `SearchMeetingRegistrants`/`GetMeetingRegistrant` pattern
- Uses shared helper functions (`handleSearchPastMeetingResource`, `handleGetPastMeetingResource`) to avoid duplicating QueryResources boilerplate

## New Tools
| Tool | Description |
|------|-------------|
| `search_past_meeting_participants` | Search for past meeting participants |
| `get_past_meeting_participant` | Get a past meeting participant by UID |
| `search_past_meeting_transcripts` | Search for past meeting transcripts |
| `get_past_meeting_transcript` | Get a past meeting transcript by UID |
| `search_past_meeting_summaries` | Search for past meeting summaries |
| `get_past_meeting_summary` | Get a past meeting summary by UID |

## Test plan
- [x] `make build` passes
- [x] `make check` (fmt, vet) passes
- [ ] Verify new tools appear in `tools/list` response
- [ ] Test search/get for each new resource type against LFX API