### PR TITLE
Add ToolAnnotations metadata to all tool registrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,11 +322,13 @@ return &mcp.CallToolResult{
 All tools should include a `mcp.ToolAnnotations` struct to provide metadata hints to MCP clients (e.g., Claude). Annotations help clients decide how to present tools and whether to confirm before calling them.
 
 ```go
-Annotations: mcp.ToolAnnotations{
+boolPtr := func(v bool) *bool { return &v }
+
+Annotations: &mcp.ToolAnnotations{
     Title:        "Human Readable Title",
-    ReadOnlyHint: true,               // True if the tool makes no mutations.
-    // DestructiveHint: mcp.Ptr(false), // Set when ReadOnlyHint is false and the tool is non-destructive.
-    // OpenWorldHint: mcp.Ptr(false),   // Override only for truly closed-world tools (see below).
+    ReadOnlyHint: true,                // True if the tool makes no mutations.
+    // DestructiveHint: boolPtr(false), // Set when ReadOnlyHint is false and the tool is non-destructive.
+    // OpenWorldHint:  boolPtr(false),  // Override only for truly closed-world tools (see below).
 },
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,10 @@ func RegisterMyTool(server *mcp.Server) {
     mcp.AddTool(server, &mcp.Tool{
         Name:        "my_tool",
         Description: "Brief description of what the tool does",
+        Annotations: mcp.ToolAnnotations{
+            Title:        "My Tool",
+            ReadOnlyHint: true,
+        },
     }, handleMyTool)
 }
 
@@ -312,6 +316,31 @@ return &mcp.CallToolResult{
     },
 }, nil, nil
 ```
+
+### Tool Annotations
+
+All tools should include a `mcp.ToolAnnotations` struct to provide metadata hints to MCP clients (e.g., Claude). Annotations help clients decide how to present tools and whether to confirm before calling them.
+
+```go
+Annotations: mcp.ToolAnnotations{
+    Title:        "Human Readable Title",
+    ReadOnlyHint: true,               // True if the tool makes no mutations.
+    // DestructiveHint: mcp.Ptr(false), // Set when ReadOnlyHint is false and the tool is non-destructive.
+    // OpenWorldHint: mcp.Ptr(false),   // Override only for truly closed-world tools (see below).
+},
+```
+
+**`ReadOnlyHint`** (bool, default `false`) is the most impactful annotation — clients use it to decide whether to auto-confirm tool calls. Set it to `true` for any tool that only reads data and has no side effects.
+
+**`DestructiveHint`** (`*bool`, default `true`) is only meaningful when `ReadOnlyHint` is `false`. Set it to `false` for write tools that are additive or non-destructive (e.g., creating a new resource vs. deleting one).
+
+**`OpenWorldHint`** (`*bool`, default `true`) signals whether the tool interacts with an external, stateful system. The key distinction is not whether you own the API — it's whether the environment is fully controlled and deterministic:
+
+- **Set to `true` (or omit, since it's the default)** for any tool that calls an external API, including LFX's own services. Even for APIs we own, results can change between calls as data mutates on the server, network failures are possible, and write operations have real-world side effects. The tool doesn't fully control what it's reading or modifying, so the world is open.
+
+- **Set to `false` only** for tools that are genuinely closed-world: pure in-process computations, static config lookups that never change, or in-memory operations with no network calls. These are the exception, not the rule.
+
+Focus annotation effort on `ReadOnlyHint` and `DestructiveHint` — those have the most impact on client behavior. For `OpenWorldHint`, the default of `true` is correct for virtually all LFX API tools; only override it when you are certain the tool has zero external interaction.
 
 ## Testing Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ func RegisterMyTool(server *mcp.Server) {
     mcp.AddTool(server, &mcp.Tool{
         Name:        "my_tool",
         Description: "Brief description of what the tool does",
-        Annotations: mcp.ToolAnnotations{
+        Annotations: &mcp.ToolAnnotations{
             Title:        "My Tool",
             ReadOnlyHint: true,
         },

--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -41,6 +41,10 @@ func RegisterSearchCommittees(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_committees",
 		Description: "Search for LFX committees by name using the LFX query service. Optionally filter by project UID.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Committees",
+			ReadOnlyHint: true,
+		},
 	}, handleSearchCommittees)
 }
 
@@ -49,6 +53,10 @@ func RegisterGetCommittee(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_committee",
 		Description: "Get an LFX committee's base info and settings by its UID. Privileged committee settings may be omitted if the caller lacks sufficient permissions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Committee",
+			ReadOnlyHint: true,
+		},
 	}, handleGetCommittee)
 }
 
@@ -57,6 +65,10 @@ func RegisterGetCommitteeMember(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_committee_member",
 		Description: "Get a specific committee member by committee UID and member UID.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Committee Member",
+			ReadOnlyHint: true,
+		},
 	}, handleGetCommitteeMember)
 }
 
@@ -65,6 +77,10 @@ func RegisterSearchCommitteeMembers(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_committee_members",
 		Description: "Search for LFX committee members. Optionally filter by committee UID, project UID (v2), and/or name. At least one filter is recommended but not required.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Committee Members",
+			ReadOnlyHint: true,
+		},
 	}, handleSearchCommitteeMembers)
 }
 

--- a/internal/tools/hello_world.go
+++ b/internal/tools/hello_world.go
@@ -23,6 +23,11 @@ func RegisterHelloWorld(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "hello_world",
 		Description: "A simple hello world tool that greets the user with an optional custom message",
+		Annotations: &mcp.ToolAnnotations{
+			Title:         "Hello World",
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
 	}, handleHelloWorld)
 }
 

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+// Package tools provides MCP tool implementations for the LFX MCP server.
+package tools
+
+// boolPtr returns a pointer to the given bool value. Used for optional
+// annotation fields that distinguish between "unset" and "false".
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -74,6 +74,10 @@ func RegisterGetMailingListService(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_mailing_list_service",
 		Description: "Get a mailing list service's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Mailing List Service",
+			ReadOnlyHint: true,
+		},
 	}, handleGetMailingListService)
 }
 
@@ -82,6 +86,10 @@ func RegisterGetMailingList(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_mailing_list",
 		Description: "Get a mailing list's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Mailing List",
+			ReadOnlyHint: true,
+		},
 	}, handleGetMailingList)
 }
 
@@ -90,6 +98,10 @@ func RegisterGetMailingListMember(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_mailing_list_member",
 		Description: "Get a specific mailing list member by mailing list UID and member UID.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Mailing List Member",
+			ReadOnlyHint: true,
+		},
 	}, handleGetMailingListMember)
 }
 
@@ -98,6 +110,10 @@ func RegisterSearchMailingListMembers(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_mailing_list_members",
 		Description: "Search for LFX mailing list members. Optionally filter by mailing list UID, project UID (v2), and/or name. At least one filter is recommended but not required.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Mailing List Members",
+			ReadOnlyHint: true,
+		},
 	}, handleSearchMailingListMembers)
 }
 
@@ -106,6 +122,10 @@ func RegisterSearchMailingLists(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_mailing_lists",
 		Description: "Search for LFX mailing lists by name using the LFX query service. Optionally filter by project UID.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Mailing Lists",
+			ReadOnlyHint: true,
+		},
 	}, handleSearchMailingLists)
 }
 

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -40,6 +40,10 @@ func RegisterSearchMeetings(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_meetings",
 		Description: "Search for LFX meetings using the query service. Supports filtering by project, committee, date range, and other fields.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Meetings",
+			ReadOnlyHint: true,
+		},
 	}, handleSearchMeetings)
 }
 
@@ -48,6 +52,10 @@ func RegisterGetMeeting(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_meeting",
 		Description: "Get an LFX meeting by its UID using the query service.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Meeting",
+			ReadOnlyHint: true,
+		},
 	}, handleGetMeeting)
 }
 
@@ -56,6 +64,10 @@ func RegisterSearchMeetingRegistrants(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_meeting_registrants",
 		Description: "Search for LFX meeting registrants using the query service. Supports filtering by meeting, committee, project, date range, and other fields.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Meeting Registrants",
+			ReadOnlyHint: true,
+		},
 	}, handleSearchMeetingRegistrants)
 }
 
@@ -64,6 +76,10 @@ func RegisterGetMeetingRegistrant(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_meeting_registrant",
 		Description: "Get an LFX meeting registrant by its UID using the query service.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Meeting Registrant",
+			ReadOnlyHint: true,
+		},
 	}, handleGetMeetingRegistrant)
 }
 

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -63,6 +63,10 @@ func RegisterSearchMembers(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_members",
 		Description: "Search and filter members (memberships). Use this tool when users ask about members, memberships, or member organizations. Supports free-text search and filtering by status, membership_type, account_id, project_id, product_id, year, tier (e.g. gold, platinum, silver), contact_id, and auto_renew. Uses offset-based pagination.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Members",
+			ReadOnlyHint: true,
+		},
 	}, handleSearchMembers)
 }
 
@@ -71,6 +75,10 @@ func RegisterGetMemberMembership(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_member_membership",
 		Description: "Get a single member's membership by member ID and membership ID. Use this when users ask for details about a specific member or membership.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Member Membership",
+			ReadOnlyHint: true,
+		},
 	}, handleGetMemberMembership)
 }
 
@@ -79,6 +87,10 @@ func RegisterGetMembershipKeyContacts(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_membership_key_contacts",
 		Description: "Get key contacts for a member's membership by member ID and membership ID. Returns the people associated with a member such as primary contacts and board members.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Membership Key Contacts",
+			ReadOnlyHint: true,
+		},
 	}, handleGetMembershipKeyContacts)
 }
 

--- a/internal/tools/project.go
+++ b/internal/tools/project.go
@@ -38,6 +38,10 @@ func RegisterSearchProjects(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_projects",
 		Description: "Search for LFX projects by name using the LFX query service",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Projects",
+			ReadOnlyHint: true,
+		},
 	}, handleSearchProjects)
 }
 
@@ -46,6 +50,10 @@ func RegisterGetProject(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_project",
 		Description: "Get an LFX project's base info and settings by its UID. Privileged project settings may be omitted if the caller lacks sufficient permissions.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Project",
+			ReadOnlyHint: true,
+		},
 	}, handleGetProject)
 }
 

--- a/internal/tools/user_info.go
+++ b/internal/tools/user_info.go
@@ -38,6 +38,10 @@ func RegisterUserInfo(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "user_info",
 		Description: "Get the authenticated user's OpenID Connect profile by proxying to the /userinfo endpoint",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "User Info",
+			ReadOnlyHint: true,
+		},
 	}, handleUserInfo)
 }
 


### PR DESCRIPTION
## Summary

Adds `mcp.ToolAnnotations` to every tool registration, providing `Title` and `ReadOnlyHint` metadata so MCP clients (e.g. Claude) can make better decisions about tool presentation and confirmation behaviour.

## Changes

- **All 7 tool files** — every `mcp.AddTool` call now includes `&mcp.ToolAnnotations{Title: "...", ReadOnlyHint: true}`. All existing tools are read-only API calls.
- **`hello_world`** additionally sets `OpenWorldHint: boolPtr(false)` since it has no external API calls and is genuinely closed-world.
- **`internal/tools/helpers.go`** — new shared file with a `boolPtr` helper for constructing `*bool` annotation fields.
- **`AGENTS.md`** — new `### Tool Annotations` section documenting annotation conventions and the rationale for `OpenWorldHint` (LFX API tools are open-world even though we own the APIs, because data mutates on the server between calls).

## Jira

[ARCH-349](https://linuxfoundation.atlassian.net/browse/ARCH-349) — Add tools metadata (like "readonly")

[ARCH-349]: https://linuxfoundation.atlassian.net/browse/ARCH-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ