### PR TITLE
Overhaul README for end-user clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,363 +1,148 @@
 # LFX MCP Server
 
-A Model Context Protocol (MCP) server for the Linux Foundation's LFX platform, providing tools and resources for interacting with LFX services.
+A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that connects AI assistants to the Linux Foundation's LFX platform.
 
-## Overview
+## What You Can Do
 
-This project implements an MCP server that exposes LFX platform functionality through standardized tools and resources. It's built using the [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk) and follows the Model Context Protocol specification.
-
-## Features
-
-- **Hello World Tool**: A simple demonstration tool for testing MCP connectivity
-- **Stdio Transport**: Communication via standard input/output streams
-- **HTTP Transport**: Streamable HTTP endpoint for web-based MCP clients
-- **Extensible Architecture**: Clean structure for adding new tools and resources
+- **Explore projects** — Search and retrieve details for any LFX project
+- **Manage committees** — Look up committees, their members, and roles across projects
+- **Work with mailing lists** — Search mailing lists and their subscribers
+- **Query members** — Search memberships by tier, status, organization, and more; get key contacts
+- **Track meetings** — Find upcoming meetings, registrants, past participants, transcripts, and AI-generated summaries
 
 ## Quick Start
 
 ### Prerequisites
 
-- Go 1.26.0 or later
-- Git
+- Go 1.26.0+
 
-### Installation
+### Build & Run
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/linuxfoundation/lfx-mcp.git
-   cd lfx-mcp
-   ```
+```bash
+git clone https://github.com/linuxfoundation/lfx-mcp.git
+cd lfx-mcp
+make build
+```
 
-2. Install dependencies:
-   ```bash
-   go mod download
-   ```
-
-3. Build the server:
-   ```bash
-   go build -o bin/lfx-mcp-server ./cmd/lfx-mcp-server
-   ```
-
-### Running the Server
-
-#### Stdio Transport (Default)
-
-To start the MCP server with stdio transport (default behavior):
+**Stdio transport** (default — used by Claude Desktop, Claude Code, etc.):
 
 ```bash
 ./bin/lfx-mcp-server
 ```
 
-The server will listen for MCP messages on stdin and respond on stdout.
-
-#### HTTP Transport
-
-To start the MCP server with HTTP transport:
+**HTTP transport** (streamable HTTP with SSE):
 
 ```bash
 ./bin/lfx-mcp-server -mode=http
 ```
 
-The server will start an HTTP endpoint at `http://localhost:8080/mcp` that accepts MCP requests over streamable HTTP (Server-Sent Events). This is useful for web-based MCP clients.
-
-### Configuration
-
-The server supports configuration via both command-line flags and environment variables. Environment variables **override** command-line flags, allowing flags to provide defaults while environment variables can override them in containerized deployments.
-
-**Command-line Flags:**
-- `-mode`: Transport mode: `stdio` or `http` (default: `stdio`)
-- `-http.port`: Port to listen on for HTTP transport (default: `8080`)
-- `-http.host`: Host to bind to for HTTP transport (default: `127.0.0.1`)
-- `-http.public_url`: Public URL for HTTP transport (for reverse proxies, e.g., `https://example.com/mcp`)
-- `-debug`: Enable debug logging with source location tracking (default: `false`)
-- `-debug_traffic`: Enable HTTP request/response wire logging for outbound LFX API calls (default: `false`)
-- `-tools`: Comma-separated list of tools to enable (default: `search_projects,get_project`)
-- `-mcp_api.auth_servers`: Comma-separated list of authorization server URLs for OAuth PRM
-- `-mcp_api.public_url`: Public URL for the MCP API endpoint (for OAuth PRM)
-- `-mcp_api.scopes`: OAuth scopes as comma-separated list (default: none; set to advertise scopes via OAuth PRM)
-- `-client_id`: OAuth client ID for token exchange
-- `-client_secret`: OAuth client secret (ignored if `client_assertion_signing_key` is set)
-- `-client_assertion_signing_key`: PEM-encoded RSA private key for client assertion (RFC 7523)
-- `-token_endpoint`: OAuth2 token endpoint URL for RFC 8693 token exchange
-- `-lfx_api_url`: LFX API base URL (used as token exchange audience)
-
-**Environment Variables:**
-
-All environment variables use the `LFXMCP_` prefix. Variable names use underscores, which are automatically transformed to dots for nested configuration keys (e.g., `LFXMCP_HTTP_PORT` becomes `http.port`):
-- `LFXMCP_MODE`: Transport mode (`stdio` or `http`)
-- `LFXMCP_HTTP_HOST`: HTTP server host
-- `LFXMCP_HTTP_PORT`: HTTP server port
-- `LFXMCP_DEBUG`: Enable debug logging (`true` or `false`)
-- `LFXMCP_DEBUG_TRAFFIC`: Enable HTTP request/response wire logging for outbound LFX API calls (`true` or `false`)
-- `LFXMCP_TOOLS`: Comma-separated list of tools to enable
-- `LFXMCP_MCP_API_AUTH_SERVERS`: Comma-separated list of authorization server URLs
-- `LFXMCP_MCP_API_PUBLIC_URL`: Public URL for MCP API (for OAuth PRM)
-- `LFXMCP_MCP_API_SCOPES`: OAuth scopes as comma-separated list (default: none; set to advertise scopes via OAuth PRM)
-- `LFXMCP_CLIENT_ID`: OAuth client ID for token exchange
-- `LFXMCP_CLIENT_SECRET`: OAuth client secret
-- `LFXMCP_CLIENT_ASSERTION_SIGNING_KEY`: PEM-encoded RSA private key for client assertion
-- `LFXMCP_TOKEN_ENDPOINT`: OAuth2 token endpoint URL for token exchange
-- `LFXMCP_LFX_API_URL`: LFX API base URL (used as token exchange audience)
-
-**Examples:**
-
-With command-line flags:
-```bash
-# Custom HTTP port
-./bin/lfx-mcp-server -mode=http -http.port=9090
-
-# Bind to all interfaces
-./bin/lfx-mcp-server -mode=http -http.host=0.0.0.0 -http.port=8080
-```
-
-With environment variables:
-```bash
-# Start in HTTP mode on custom port
-LFXMCP_MODE=http LFXMCP_HTTP_PORT=9090 ./bin/lfx-mcp-server
-
-# Enable debug logging (env var overrides flag)
-LFXMCP_DEBUG=true ./bin/lfx-mcp-server
-
-# Environment variable overrides flag
-LFXMCP_HTTP_PORT=9090 ./bin/lfx-mcp-server -mode=http -http.port=8080
-# Result: Server runs on port 9090 (env var wins)
-```
-
-### Logging
-
-The server uses structured JSON logging via Go's `slog` package. All logs are written to stdout in JSON format for easy parsing and integration with log aggregation systems.
-
-**Log Levels:**
-- `INFO` (default): Standard operational messages
-- `DEBUG`: Detailed diagnostic information with source location tracking
-
-**Enabling Debug Logging:**
-
-Debug logging can be enabled via command-line flag or environment variable:
-
-```bash
-# Via command-line flag
-./bin/lfx-mcp-server -debug
-
-# Via environment variable
-LFXMCP_DEBUG=true ./bin/lfx-mcp-server
-```
-
-When debug logging is enabled, the following additional information is included:
-- Source file locations for each log statement
-- Detailed request/response information
-- Internal state transitions
-
-**Log Format:**
-
-All logs are emitted as JSON objects with the following structure:
-
-```json
-{"time":"2024-01-15T10:30:45.123Z","level":"INFO","msg":"Starting HTTP server","addr":"127.0.0.1:8080"}
-{"time":"2024-01-15T10:30:45.456Z","level":"ERROR","msg":"server failed","error":"connection refused"}
-```
-
-Debug logs include source information:
-
-```json
-{"time":"2024-01-15T10:30:45.789Z","level":"DEBUG","source":{"file":"main.go","line":150},"msg":"processing request"}
-```
-
-**Example HTTP request:**
-```bash
-curl -X POST http://localhost:8080/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"web-client","version":"1.0.0"}}}'
-```
-
-The HTTP transport uses stateless mode, creating a new MCP session for each request. This allows horizontal scaling without session management.
-
 ## Available Tools
 
-### search_projects
+### Projects
 
-Search for LFX projects by name. Supports typeahead (partial name matching) and pagination.
+| Tool | Description |
+|------|-------------|
+| `search_projects` | Search for LFX projects by name with typeahead and pagination |
+| `get_project` | Get a project's base info and settings by UID |
 
-**Parameters:**
-- `name` (string, optional): Name or partial name of the project to search for
-- `page_size` (integer, optional): Number of results per page (default: 10, max: 100)
-- `page_token` (string, optional): Opaque pagination token from a previous search response
+### Committees
 
-**Returns:** A JSON object with a `resources` array of matching projects and an optional `page_token` for retrieving the next page.
+| Tool | Description |
+|------|-------------|
+| `search_committees` | Search for committees by name; optionally filter by project |
+| `get_committee` | Get a committee's base info and settings by UID |
+| `search_committee_members` | Search committee members; filter by committee, project, or name |
+| `get_committee_member` | Get a specific committee member by committee and member UID |
 
-**Example usage:**
-```json
-{
-  "method": "tools/call",
-  "params": {
-    "name": "search_projects",
-    "arguments": {
-      "name": "kubernetes",
-      "page_size": 5
-    }
-  }
-}
-```
+### Mailing Lists
 
-### get_project
+| Tool | Description |
+|------|-------------|
+| `search_mailing_lists` | Search for mailing lists by name; optionally filter by project |
+| `get_mailing_list` | Get a mailing list's base info and settings by UID |
+| `get_mailing_list_service` | Get a mailing list service's base info and settings by UID |
+| `search_mailing_list_members` | Search mailing list members; filter by list, project, or name |
+| `get_mailing_list_member` | Get a specific mailing list member by list and member UID |
 
-Fetch an LFX project by its v2 UID. Returns base project information and, where the caller has sufficient permissions, privileged project settings. Settings are omitted gracefully rather than failing if permissions are insufficient.
+### Members
 
-**Parameters:**
-- `uid` (string, required): The v2 UID of the project to retrieve
+| Tool | Description |
+|------|-------------|
+| `search_members` | Search and filter members (memberships) by status, tier, organization, and more |
+| `get_member_membership` | Get a single member's membership details by member and membership ID |
+| `get_membership_key_contacts` | Get key contacts (primary contacts, board members) for a membership |
 
-**Returns:** A JSON object with a `base` field (always present) and an optional `settings` field (omitted if the caller lacks permissions).
+### Meetings
 
-**Example usage:**
-```json
-{
-  "method": "tools/call",
-  "params": {
-    "name": "get_project",
-    "arguments": {
-      "uid": "a09e35c2-98fb-4dc0-8e51-5578c59d5593"
-    }
-  }
-}
-```
+| Tool | Description |
+|------|-------------|
+| `search_meetings` | Search for meetings; filter by project, committee, date range |
+| `get_meeting` | Get a meeting by UID |
+| `search_meeting_registrants` | Search meeting registrants; filter by meeting, committee, project |
+| `get_meeting_registrant` | Get a meeting registrant by UID |
 
-### hello_world
+### Past Meeting Data
 
-A simple greeting tool that demonstrates the MCP tool interface.
+| Tool | Description |
+|------|-------------|
+| `search_past_meeting_participants` | Search past meeting participants; filter by meeting, committee, project |
+| `get_past_meeting_participant` | Get a past meeting participant by UID |
+| `search_past_meeting_transcripts` | Search past meeting transcripts; filter by meeting, committee, project |
+| `get_past_meeting_transcript` | Get a past meeting transcript by UID |
+| `search_past_meeting_summaries` | Search past meeting summaries; filter by meeting, committee, project |
+| `get_past_meeting_summary` | Get a past meeting summary by UID |
 
-**Parameters:**
-- `name` (string, optional): Name to greet (defaults to "World")
-- `message` (string, optional): Custom greeting message
+### Utility
 
-**Example usage:**
-```json
-{
-  "method": "tools/call",
-  "params": {
-    "name": "hello_world",
-    "arguments": {
-      "name": "LFX User",
-      "message": "Welcome"
-    }
-  }
-}
-```
+| Tool | Description |
+|------|-------------|
+| `hello_world` | Simple greeting tool for testing MCP connectivity |
+| `user_info` | Get the authenticated user's OpenID Connect profile |
+
+## Configuration
+
+<details>
+<summary>All flags and environment variables</summary>
+
+Environment variables use the `LFXMCP_` prefix and **override** their corresponding flags.
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `-mode` | `LFXMCP_MODE` | `stdio` | Transport mode: `stdio` or `http` |
+| `-http.host` | `LFXMCP_HTTP_HOST` | `127.0.0.1` | HTTP server bind address |
+| `-http.port` | `LFXMCP_HTTP_PORT` | `8080` | HTTP server port |
+| `-http.public_url` | `LFXMCP_HTTP_PUBLIC_URL` | — | Public URL for HTTP transport (reverse proxies) |
+| `-debug` | `LFXMCP_DEBUG` | `false` | Enable debug logging with source locations |
+| `-debug_traffic` | `LFXMCP_DEBUG_TRAFFIC` | `false` | Log outbound LFX API request/response bodies |
+| `-tools` | `LFXMCP_TOOLS` | — | Comma-separated list of tools to enable |
+| `-mcp_api.auth_servers` | `LFXMCP_MCP_API_AUTH_SERVERS` | — | OAuth authorization server URLs (comma-separated) |
+| `-mcp_api.public_url` | `LFXMCP_MCP_API_PUBLIC_URL` | — | Public URL for MCP API (OAuth PRM) |
+| `-mcp_api.scopes` | `LFXMCP_MCP_API_SCOPES` | — | OAuth scopes (comma-separated) |
+| `-client_id` | `LFXMCP_CLIENT_ID` | — | OAuth client ID for token exchange |
+| `-client_secret` | `LFXMCP_CLIENT_SECRET` | — | OAuth client secret |
+| `-client_assertion_signing_key` | `LFXMCP_CLIENT_ASSERTION_SIGNING_KEY` | — | PEM-encoded RSA private key for client assertion |
+| `-token_endpoint` | `LFXMCP_TOKEN_ENDPOINT` | — | OAuth2 token endpoint URL (RFC 8693) |
+| `-lfx_api_url` | `LFXMCP_LFX_API_URL` | — | LFX API base URL (token exchange audience) |
+
+</details>
 
 ## Development
 
-### Project Structure
-
-```text
-lfx-mcp/
-├── cmd/
-│   └── lfx-mcp-server/     # Main application entry point
-├── internal/
-│   └── tools/              # MCP tool implementations
-├── bin/                    # Built binaries (created by make build)
-├── go.mod                  # Go module definition
-├── Makefile               # Build automation
-└── README.md              # This file
-```
-
-### Adding New Tools
-
-Tools are implemented in the `internal/tools` package for better organization and scalability.
-
-1. Create a new file in `internal/tools/` (e.g., `my_tool.go`):
-   ```go
-   package tools
-
-   import (
-       "context"
-       "github.com/modelcontextprotocol/go-sdk/mcp"
-   )
-
-   // MyToolArgs defines the input parameters.
-   type MyToolArgs struct {
-       Param1 string `json:"param1" jsonschema:"Description of parameter 1"`
-       Param2 int    `json:"param2,omitempty" jsonschema:"Optional parameter 2"`
-   }
-
-   // RegisterMyTool registers the tool with the MCP server.
-   func RegisterMyTool(server *mcp.Server) {
-       mcp.AddTool(server, &mcp.Tool{
-           Name:        "my_tool",
-           Description: "Description of what the tool does",
-       }, handleMyTool)
-   }
-
-   // handleMyTool implements the tool logic.
-   func handleMyTool(ctx context.Context, req *mcp.CallToolRequest, args MyToolArgs) (*mcp.CallToolResult, any, error) {
-       // Your tool implementation here
-       return &mcp.CallToolResult{
-           Content: []mcp.Content{
-               &mcp.TextContent{Text: "Tool result"},
-           },
-       }, nil, nil
-   }
-   ```
-
-2. Register your tool in `cmd/lfx-mcp-server/main.go`:
-   ```go
-   // Register tools.
-   tools.RegisterHelloWorld(server)
-   tools.RegisterMyTool(server)  // Add your new tool
-   ```
-
-### Testing
-
-#### Testing Stdio Transport
-
-To test the server manually, you can send JSON-RPC messages via stdio:
+See [AGENTS.md](AGENTS.md) for architecture details, adding tools, testing patterns, and coding guidelines.
 
 ```bash
-# Test server initialization and tool listing
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'; 
- echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'; 
- sleep 1) | ./bin/lfx-mcp-server
-
-# With debug logging enabled
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'; 
- echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'; 
- sleep 1) | ./bin/lfx-mcp-server -debug
-
-# Test calling the hello_world tool
-(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'; 
- echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX User","message":"Welcome"}}}'; 
- sleep 1) | ./bin/lfx-mcp-server
+make build    # Compile the binary
+make check    # Format, vet, and lint
+make test     # Run tests
 ```
-
-#### Testing HTTP Transport
-
-Start the HTTP server and send requests using curl:
-
-```bash
-# Start the server in the background
-./bin/lfx-mcp-server -mode=http -http.port=8080 &
-
-# Or with debug logging
-./bin/lfx-mcp-server -mode=http -http.port=8080 -debug &
-
-# Test tools list
-curl -X POST http://localhost:8080/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
-
-# Test calling hello_world tool
-curl -X POST http://localhost:8080/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX","message":"Welcome"}}}'
-```
-
-Responses are returned as Server-Sent Events (SSE) with `event: message` and `data:` fields.
 
 ## License
 
 Copyright The Linux Foundation and each contributor to LFX.
 
-This project’s source code is licensed under the MIT License. A copy of the
+This project's source code is licensed under the MIT License. A copy of the
 license is available in LICENSE.
 
-This project’s documentation is licensed under the Creative Commons Attribution
+This project's documentation is licensed under the Creative Commons Attribution
 4.0 International License \(CC-BY-4.0\). A copy of the license is available in
 LICENSE-docs.


### PR DESCRIPTION
## Summary
- Rewrites README to document all 26 registered tools in categorized tables (Projects, Committees, Mailing Lists, Members, Meetings, Past Meeting Data, Utility)
- Replaces verbose developer content (logging internals, JSON-RPC examples, project structure, adding-tools guide) that already lives in AGENTS.md
- Adds outcome-focused "What You Can Do" section and a collapsible configuration reference with a single merged flag/env-var table

## Test plan
- [ ] Verify all 26 tools appear in the tables
- [ ] Confirm markdown renders correctly on GitHub (tables, collapsible `<details>` section)
- [ ] `make check` passes (no code changes)

Signed-off-by: Nirav Patel <npatel@linuxfoundation.org>