### PR TITLE
Add committee write operation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ make build
 | `get_committee` | Get a committee's base info and settings by UID |
 | `create_committee` | Create a new committee under a project |
 | `update_committee` | Update a committee's base information |
-| `update_committee_settings` | Update a committee's settings (visibility, writers, auditors) |
+| `update_committee_settings` | Update a committee's settings (visibility, email requirements, meeting attendee defaults) |
 | `delete_committee` | Delete a committee by UID |
 | `search_committee_members` | Search committee members; filter by committee, project, or name |
 | `get_committee_member` | Get a specific committee member by committee and member UID |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that c
 ## What You Can Do
 
 - **Explore projects** — Search and retrieve details for any LFX project
-- **Manage committees** — Look up committees, their members, and roles across projects
+- **Manage committees** — Search, create, update, and delete committees and their members across projects
 - **Work with mailing lists** — Search mailing lists and their subscribers
 - **Query members** — Search memberships by tier, status, organization, and more; get key contacts
 - **Track meetings** — Find upcoming meetings, registrants, past participants, transcripts, and AI-generated summaries
@@ -51,8 +51,15 @@ make build
 |------|-------------|
 | `search_committees` | Search for committees by name; optionally filter by project |
 | `get_committee` | Get a committee's base info and settings by UID |
+| `create_committee` | Create a new committee under a project |
+| `update_committee` | Update a committee's base information |
+| `update_committee_settings` | Update a committee's settings (visibility, writers, auditors) |
+| `delete_committee` | Delete a committee by UID |
 | `search_committee_members` | Search committee members; filter by committee, project, or name |
 | `get_committee_member` | Get a specific committee member by committee and member UID |
+| `create_committee_member` | Add a new member to a committee |
+| `update_committee_member` | Update an existing committee member's information |
+| `delete_committee_member` | Remove a member from a committee |
 
 ### Mailing Lists
 

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -66,6 +66,13 @@ var defaultTools = []string{
 	"get_committee",
 	"get_committee_member",
 	"search_committee_members",
+	"create_committee",
+	"update_committee",
+	"update_committee_settings",
+	"delete_committee",
+	"create_committee_member",
+	"update_committee_member",
+	"delete_committee_member",
 	"get_mailing_list_service",
 	"get_mailing_list",
 	"get_mailing_list_member",
@@ -326,6 +333,27 @@ func newServer(cfg Config) *mcp.Server {
 	}
 	if enabledTools["search_committee_members"] {
 		tools.RegisterSearchCommitteeMembers(server)
+	}
+	if enabledTools["create_committee"] {
+		tools.RegisterCreateCommittee(server)
+	}
+	if enabledTools["update_committee"] {
+		tools.RegisterUpdateCommittee(server)
+	}
+	if enabledTools["update_committee_settings"] {
+		tools.RegisterUpdateCommitteeSettings(server)
+	}
+	if enabledTools["delete_committee"] {
+		tools.RegisterDeleteCommittee(server)
+	}
+	if enabledTools["create_committee_member"] {
+		tools.RegisterCreateCommitteeMember(server)
+	}
+	if enabledTools["update_committee_member"] {
+		tools.RegisterUpdateCommitteeMember(server)
+	}
+	if enabledTools["delete_committee_member"] {
+		tools.RegisterDeleteCommitteeMember(server)
 	}
 	if enabledTools["get_mailing_list_service"] {
 		tools.RegisterGetMailingListService(server)

--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -752,7 +752,3 @@ func handleDeleteCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 	}, nil, nil
 }
 
-// strPtr returns a pointer to the given string value.
-func strPtr(s string) *string {
-	return &s
-}

--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -1,0 +1,758 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+// Package tools provides MCP tool implementations for the LFX MCP server.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/linuxfoundation/lfx-mcp/internal/lfxv2"
+	committeeservice "github.com/linuxfoundation/lfx-v2-committee-service/gen/committee_service"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- Committee write args ---
+
+// CreateCommitteeArgs defines the input parameters for the create_committee tool.
+type CreateCommitteeArgs struct {
+	ProjectUID            string   `json:"project_uid" jsonschema:"Project UID the committee belongs to"`
+	Name                  string   `json:"name" jsonschema:"Name of the committee"`
+	Category              string   `json:"category" jsonschema:"Category of the committee"`
+	Description           *string  `json:"description,omitempty" jsonschema:"Description of the committee"`
+	Website               *string  `json:"website,omitempty" jsonschema:"Website URL of the committee"`
+	EnableVoting          bool     `json:"enable_voting,omitempty" jsonschema:"Whether voting is enabled"`
+	SSOGroupEnabled       bool     `json:"sso_group_enabled,omitempty" jsonschema:"Whether SSO group integration is enabled"`
+	RequiresReview        bool     `json:"requires_review,omitempty" jsonschema:"Whether the committee requires review"`
+	Public                bool     `json:"public,omitempty" jsonschema:"Whether the committee is publicly visible"`
+	CalendarPublic        *bool    `json:"calendar_public,omitempty" jsonschema:"Whether the committee calendar is publicly visible"`
+	DisplayName           *string  `json:"display_name,omitempty" jsonschema:"Display name of the committee"`
+	ParentUID             *string  `json:"parent_uid,omitempty" jsonschema:"UID of the parent committee, if any"`
+	BusinessEmailRequired bool     `json:"business_email_required,omitempty" jsonschema:"Whether business email is required for members"`
+	MemberVisibility      string   `json:"member_visibility,omitempty" jsonschema:"Visibility level of member profiles to other members"`
+	ShowMeetingAttendees  bool     `json:"show_meeting_attendees,omitempty" jsonschema:"Whether to show meeting attendees by default"`
+	Writers               []string `json:"writers,omitempty" jsonschema:"Manager user IDs who can edit this committee"`
+	Auditors              []string `json:"auditors,omitempty" jsonschema:"Auditor user IDs who can audit this committee"`
+}
+
+// UpdateCommitteeArgs defines the input parameters for the update_committee tool.
+type UpdateCommitteeArgs struct {
+	UID             string  `json:"uid" jsonschema:"UID of the committee to update"`
+	ProjectUID      string  `json:"project_uid" jsonschema:"Project UID the committee belongs to"`
+	Name            string  `json:"name" jsonschema:"Name of the committee"`
+	Category        string  `json:"category" jsonschema:"Category of the committee"`
+	Description     *string `json:"description,omitempty" jsonschema:"Description of the committee"`
+	Website         *string `json:"website,omitempty" jsonschema:"Website URL of the committee"`
+	EnableVoting    bool    `json:"enable_voting,omitempty" jsonschema:"Whether voting is enabled"`
+	SSOGroupEnabled bool    `json:"sso_group_enabled,omitempty" jsonschema:"Whether SSO group integration is enabled"`
+	RequiresReview  bool    `json:"requires_review,omitempty" jsonschema:"Whether the committee requires review"`
+	Public          bool    `json:"public,omitempty" jsonschema:"Whether the committee is publicly visible"`
+	CalendarPublic  *bool   `json:"calendar_public,omitempty" jsonschema:"Whether the committee calendar is publicly visible"`
+	DisplayName     *string `json:"display_name,omitempty" jsonschema:"Display name of the committee"`
+	ParentUID       *string `json:"parent_uid,omitempty" jsonschema:"UID of the parent committee, if any"`
+}
+
+// UpdateCommitteeSettingsArgs defines the input parameters for the update_committee_settings tool.
+type UpdateCommitteeSettingsArgs struct {
+	UID                   string   `json:"uid" jsonschema:"UID of the committee whose settings to update"`
+	BusinessEmailRequired bool     `json:"business_email_required,omitempty" jsonschema:"Whether business email is required for members"`
+	MemberVisibility      string   `json:"member_visibility,omitempty" jsonschema:"Visibility level of member profiles to other members"`
+	ShowMeetingAttendees  bool     `json:"show_meeting_attendees,omitempty" jsonschema:"Whether to show meeting attendees by default"`
+	Writers               []string `json:"writers,omitempty" jsonschema:"Manager user IDs who can edit this committee"`
+	Auditors              []string `json:"auditors,omitempty" jsonschema:"Auditor user IDs who can audit this committee"`
+}
+
+// DeleteCommitteeArgs defines the input parameters for the delete_committee tool.
+type DeleteCommitteeArgs struct {
+	UID string `json:"uid" jsonschema:"UID of the committee to delete"`
+}
+
+// --- Committee member write args ---
+
+// CommitteeMemberRoleArgs defines role information for a committee member.
+type CommitteeMemberRoleArgs struct {
+	Name      string  `json:"name" jsonschema:"Role name"`
+	StartDate *string `json:"start_date,omitempty" jsonschema:"Role start date in RFC3339 format"`
+	EndDate   *string `json:"end_date,omitempty" jsonschema:"Role end date in RFC3339 format"`
+}
+
+// CommitteeMemberVotingArgs defines voting information for a committee member.
+type CommitteeMemberVotingArgs struct {
+	Status    string  `json:"status" jsonschema:"Voting status"`
+	StartDate *string `json:"start_date,omitempty" jsonschema:"Voting start date in RFC3339 format"`
+	EndDate   *string `json:"end_date,omitempty" jsonschema:"Voting end date in RFC3339 format"`
+}
+
+// CommitteeMemberOrganizationArgs defines organization information for a committee member.
+type CommitteeMemberOrganizationArgs struct {
+	ID      *string `json:"id,omitempty" jsonschema:"Organization ID"`
+	Name    *string `json:"name,omitempty" jsonschema:"Organization name"`
+	Website *string `json:"website,omitempty" jsonschema:"Organization website URL"`
+}
+
+// CreateCommitteeMemberArgs defines the input parameters for the create_committee_member tool.
+type CreateCommitteeMemberArgs struct {
+	CommitteeUID    string                           `json:"committee_uid" jsonschema:"UID of the committee to add the member to"`
+	Email           string                           `json:"email" jsonschema:"Primary email address of the member"`
+	AppointedBy     string                           `json:"appointed_by" jsonschema:"How the member was appointed"`
+	Status          string                           `json:"status" jsonschema:"Member status"`
+	Username        *string                          `json:"username,omitempty" jsonschema:"LF ID username"`
+	FirstName       *string                          `json:"first_name,omitempty" jsonschema:"First name"`
+	LastName        *string                          `json:"last_name,omitempty" jsonschema:"Last name"`
+	JobTitle        *string                          `json:"job_title,omitempty" jsonschema:"Job title at organization"`
+	LinkedinProfile *string                          `json:"linkedin_profile,omitempty" jsonschema:"LinkedIn profile URL"`
+	Role            *CommitteeMemberRoleArgs         `json:"role,omitempty" jsonschema:"Committee role information"`
+	Voting          *CommitteeMemberVotingArgs       `json:"voting,omitempty" jsonschema:"Voting information"`
+	Organization    *CommitteeMemberOrganizationArgs `json:"organization,omitempty" jsonschema:"Organization information"`
+}
+
+// UpdateCommitteeMemberArgs defines the input parameters for the update_committee_member tool.
+type UpdateCommitteeMemberArgs struct {
+	CommitteeUID    string                           `json:"committee_uid" jsonschema:"UID of the committee"`
+	MemberUID       string                           `json:"member_uid" jsonschema:"UID of the member to update"`
+	Email           string                           `json:"email" jsonschema:"Primary email address of the member"`
+	AppointedBy     string                           `json:"appointed_by" jsonschema:"How the member was appointed"`
+	Status          string                           `json:"status" jsonschema:"Member status"`
+	Username        *string                          `json:"username,omitempty" jsonschema:"LF ID username"`
+	FirstName       *string                          `json:"first_name,omitempty" jsonschema:"First name"`
+	LastName        *string                          `json:"last_name,omitempty" jsonschema:"Last name"`
+	JobTitle        *string                          `json:"job_title,omitempty" jsonschema:"Job title at organization"`
+	LinkedinProfile *string                          `json:"linkedin_profile,omitempty" jsonschema:"LinkedIn profile URL"`
+	Role            *CommitteeMemberRoleArgs         `json:"role,omitempty" jsonschema:"Committee role information"`
+	Voting          *CommitteeMemberVotingArgs       `json:"voting,omitempty" jsonschema:"Voting information"`
+	Organization    *CommitteeMemberOrganizationArgs `json:"organization,omitempty" jsonschema:"Organization information"`
+}
+
+// DeleteCommitteeMemberArgs defines the input parameters for the delete_committee_member tool.
+type DeleteCommitteeMemberArgs struct {
+	CommitteeUID string `json:"committee_uid" jsonschema:"UID of the committee"`
+	MemberUID    string `json:"member_uid" jsonschema:"UID of the member to delete"`
+}
+
+// --- Registration functions ---
+
+// RegisterCreateCommittee registers the create_committee tool with the MCP server.
+func RegisterCreateCommittee(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "create_committee",
+		Description: "Create a new committee under a project.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Create Committee",
+			DestructiveHint: boolPtr(false),
+		},
+	}, handleCreateCommittee)
+}
+
+// RegisterUpdateCommittee registers the update_committee tool with the MCP server.
+func RegisterUpdateCommittee(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_committee",
+		Description: "Update a committee's base information (name, category, visibility, etc.).",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Update Committee",
+			DestructiveHint: boolPtr(false),
+		},
+	}, handleUpdateCommittee)
+}
+
+// RegisterUpdateCommitteeSettings registers the update_committee_settings tool with the MCP server.
+func RegisterUpdateCommitteeSettings(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_committee_settings",
+		Description: "Update a committee's settings (member visibility, writers, auditors, etc.).",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Update Committee Settings",
+			DestructiveHint: boolPtr(false),
+		},
+	}, handleUpdateCommitteeSettings)
+}
+
+// RegisterDeleteCommittee registers the delete_committee tool with the MCP server.
+func RegisterDeleteCommittee(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_committee",
+		Description: "Delete a committee by its UID.",
+		Annotations: &mcp.ToolAnnotations{
+			Title: "Delete Committee",
+		},
+	}, handleDeleteCommittee)
+}
+
+// RegisterCreateCommitteeMember registers the create_committee_member tool with the MCP server.
+func RegisterCreateCommitteeMember(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "create_committee_member",
+		Description: "Add a new member to a committee.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Create Committee Member",
+			DestructiveHint: boolPtr(false),
+		},
+	}, handleCreateCommitteeMember)
+}
+
+// RegisterUpdateCommitteeMember registers the update_committee_member tool with the MCP server.
+func RegisterUpdateCommitteeMember(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_committee_member",
+		Description: "Update an existing committee member's information.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Update Committee Member",
+			DestructiveHint: boolPtr(false),
+		},
+	}, handleUpdateCommitteeMember)
+}
+
+// RegisterDeleteCommitteeMember registers the delete_committee_member tool with the MCP server.
+func RegisterDeleteCommitteeMember(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_committee_member",
+		Description: "Remove a member from a committee.",
+		Annotations: &mcp.ToolAnnotations{
+			Title: "Delete Committee Member",
+		},
+	}, handleDeleteCommitteeMember)
+}
+
+// --- Handler helpers ---
+
+// committeeWriteClients creates LFX v2 clients for committee write operations,
+// returning the clients and MCP logger, or an error tool result.
+func committeeWriteClients(ctx context.Context, req *mcp.CallToolRequest) (context.Context, *lfxv2.Clients, *slog.Logger, *mcp.CallToolResult) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if committeeConfig == nil {
+		logger.Error("committee tools not configured")
+		return ctx, nil, logger, &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: committee tools not configured"},
+			},
+			IsError: true,
+		}
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return ctx, nil, logger, &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           committeeConfig.LFXAPIURL,
+		TokenExchangeClient: committeeConfig.TokenExchangeClient,
+		DebugLogger:         committeeConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return ctx, nil, logger, &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}
+	}
+
+	return ctx, clients, logger, nil
+}
+
+// --- Committee handlers ---
+
+// handleCreateCommittee implements the create_committee tool logic.
+func handleCreateCommittee(ctx context.Context, req *mcp.CallToolRequest, args CreateCommitteeArgs) (*mcp.CallToolResult, any, error) {
+	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
+	if errResult != nil {
+		return errResult, nil, nil
+	}
+
+	logger.Info("creating committee", "project_uid", args.ProjectUID, "name", args.Name)
+
+	payload := &committeeservice.CreateCommitteePayload{
+		Version:               strPtr("1"),
+		ProjectUID:            args.ProjectUID,
+		Name:                  args.Name,
+		Category:              args.Category,
+		Description:           args.Description,
+		Website:               args.Website,
+		EnableVoting:          args.EnableVoting,
+		SsoGroupEnabled:       args.SSOGroupEnabled,
+		RequiresReview:        args.RequiresReview,
+		Public:                args.Public,
+		DisplayName:           args.DisplayName,
+		ParentUID:             args.ParentUID,
+		BusinessEmailRequired: args.BusinessEmailRequired,
+		MemberVisibility:      args.MemberVisibility,
+		ShowMeetingAttendees:  args.ShowMeetingAttendees,
+		Writers:               args.Writers,
+		Auditors:              args.Auditors,
+	}
+
+	if args.CalendarPublic != nil {
+		payload.Calendar = &struct{ Public bool }{Public: *args.CalendarPublic}
+	}
+
+	result, err := clients.Committee.CreateCommittee(ctx, payload)
+	if err != nil {
+		logger.Error("CreateCommittee failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to create committee: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("create_committee succeeded", "project_uid", args.ProjectUID, "name", args.Name)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleUpdateCommittee implements the update_committee tool logic.
+func handleUpdateCommittee(ctx context.Context, req *mcp.CallToolRequest, args UpdateCommitteeArgs) (*mcp.CallToolResult, any, error) {
+	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
+	if errResult != nil {
+		return errResult, nil, nil
+	}
+
+	if args.UID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("updating committee", "uid", args.UID)
+
+	payload := &committeeservice.UpdateCommitteeBasePayload{
+		Version:         strPtr("1"),
+		UID:             &args.UID,
+		ProjectUID:      args.ProjectUID,
+		Name:            args.Name,
+		Category:        args.Category,
+		Description:     args.Description,
+		Website:         args.Website,
+		EnableVoting:    args.EnableVoting,
+		SsoGroupEnabled: args.SSOGroupEnabled,
+		RequiresReview:  args.RequiresReview,
+		Public:          args.Public,
+		DisplayName:     args.DisplayName,
+		ParentUID:       args.ParentUID,
+	}
+
+	if args.CalendarPublic != nil {
+		payload.Calendar = &struct{ Public bool }{Public: *args.CalendarPublic}
+	}
+
+	result, err := clients.Committee.UpdateCommitteeBase(ctx, payload)
+	if err != nil {
+		logger.Error("UpdateCommitteeBase failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to update committee: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("update_committee succeeded", "uid", args.UID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleUpdateCommitteeSettings implements the update_committee_settings tool logic.
+func handleUpdateCommitteeSettings(ctx context.Context, req *mcp.CallToolRequest, args UpdateCommitteeSettingsArgs) (*mcp.CallToolResult, any, error) {
+	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
+	if errResult != nil {
+		return errResult, nil, nil
+	}
+
+	if args.UID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("updating committee settings", "uid", args.UID)
+
+	payload := &committeeservice.UpdateCommitteeSettingsPayload{
+		Version:               strPtr("1"),
+		UID:                   &args.UID,
+		BusinessEmailRequired: args.BusinessEmailRequired,
+		MemberVisibility:      args.MemberVisibility,
+		ShowMeetingAttendees:  args.ShowMeetingAttendees,
+		Writers:               args.Writers,
+		Auditors:              args.Auditors,
+	}
+
+	result, err := clients.Committee.UpdateCommitteeSettings(ctx, payload)
+	if err != nil {
+		logger.Error("UpdateCommitteeSettings failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to update committee settings: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("update_committee_settings succeeded", "uid", args.UID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleDeleteCommittee implements the delete_committee tool logic.
+func handleDeleteCommittee(ctx context.Context, req *mcp.CallToolRequest, args DeleteCommitteeArgs) (*mcp.CallToolResult, any, error) {
+	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
+	if errResult != nil {
+		return errResult, nil, nil
+	}
+
+	if args.UID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("deleting committee", "uid", args.UID)
+
+	err := clients.Committee.DeleteCommittee(ctx, &committeeservice.DeleteCommitteePayload{
+		Version: strPtr("1"),
+		UID:     &args.UID,
+	})
+	if err != nil {
+		logger.Error("DeleteCommittee failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to delete committee: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("delete_committee succeeded", "uid", args.UID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("Committee %s deleted successfully.", args.UID)},
+		},
+	}, nil, nil
+}
+
+// --- Committee member handlers ---
+
+// buildMemberRole converts CommitteeMemberRoleArgs to the anonymous struct expected by the API payload.
+func buildMemberRole(r *CommitteeMemberRoleArgs) *struct {
+	Name      string
+	StartDate *string
+	EndDate   *string
+} {
+	if r == nil {
+		return nil
+	}
+	return &struct {
+		Name      string
+		StartDate *string
+		EndDate   *string
+	}{
+		Name:      r.Name,
+		StartDate: r.StartDate,
+		EndDate:   r.EndDate,
+	}
+}
+
+// buildMemberVoting converts CommitteeMemberVotingArgs to the anonymous struct expected by the API payload.
+func buildMemberVoting(v *CommitteeMemberVotingArgs) *struct {
+	Status    string
+	StartDate *string
+	EndDate   *string
+} {
+	if v == nil {
+		return nil
+	}
+	return &struct {
+		Status    string
+		StartDate *string
+		EndDate   *string
+	}{
+		Status:    v.Status,
+		StartDate: v.StartDate,
+		EndDate:   v.EndDate,
+	}
+}
+
+// buildMemberOrganization converts CommitteeMemberOrganizationArgs to the anonymous struct expected by the API payload.
+func buildMemberOrganization(o *CommitteeMemberOrganizationArgs) *struct {
+	ID      *string
+	Name    *string
+	Website *string
+} {
+	if o == nil {
+		return nil
+	}
+	return &struct {
+		ID      *string
+		Name    *string
+		Website *string
+	}{
+		ID:      o.ID,
+		Name:    o.Name,
+		Website: o.Website,
+	}
+}
+
+// handleCreateCommitteeMember implements the create_committee_member tool logic.
+func handleCreateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, args CreateCommitteeMemberArgs) (*mcp.CallToolResult, any, error) {
+	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
+	if errResult != nil {
+		return errResult, nil, nil
+	}
+
+	if args.CommitteeUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: committee_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("creating committee member", "committee_uid", args.CommitteeUID, "email", args.Email)
+
+	payload := &committeeservice.CreateCommitteeMemberPayload{
+		Version:         "1",
+		UID:             args.CommitteeUID,
+		Email:           args.Email,
+		AppointedBy:     args.AppointedBy,
+		Status:          args.Status,
+		Username:        args.Username,
+		FirstName:       args.FirstName,
+		LastName:        args.LastName,
+		JobTitle:        args.JobTitle,
+		LinkedinProfile: args.LinkedinProfile,
+		Role:            buildMemberRole(args.Role),
+		Voting:          buildMemberVoting(args.Voting),
+		Organization:    buildMemberOrganization(args.Organization),
+	}
+
+	result, err := clients.Committee.CreateCommitteeMember(ctx, payload)
+	if err != nil {
+		logger.Error("CreateCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to create committee member: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("create_committee_member succeeded", "committee_uid", args.CommitteeUID, "email", args.Email)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleUpdateCommitteeMember implements the update_committee_member tool logic.
+func handleUpdateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, args UpdateCommitteeMemberArgs) (*mcp.CallToolResult, any, error) {
+	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
+	if errResult != nil {
+		return errResult, nil, nil
+	}
+
+	if args.CommitteeUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: committee_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.MemberUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: member_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("updating committee member", "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
+
+	payload := &committeeservice.UpdateCommitteeMemberPayload{
+		Version:         "1",
+		UID:             args.CommitteeUID,
+		MemberUID:       args.MemberUID,
+		Email:           args.Email,
+		AppointedBy:     args.AppointedBy,
+		Status:          args.Status,
+		Username:        args.Username,
+		FirstName:       args.FirstName,
+		LastName:        args.LastName,
+		JobTitle:        args.JobTitle,
+		LinkedinProfile: args.LinkedinProfile,
+		Role:            buildMemberRole(args.Role),
+		Voting:          buildMemberVoting(args.Voting),
+		Organization:    buildMemberOrganization(args.Organization),
+	}
+
+	result, err := clients.Committee.UpdateCommitteeMember(ctx, payload)
+	if err != nil {
+		logger.Error("UpdateCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to update committee member: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("update_committee_member succeeded", "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleDeleteCommitteeMember implements the delete_committee_member tool logic.
+func handleDeleteCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, args DeleteCommitteeMemberArgs) (*mcp.CallToolResult, any, error) {
+	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
+	if errResult != nil {
+		return errResult, nil, nil
+	}
+
+	if args.CommitteeUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: committee_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.MemberUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: member_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("deleting committee member", "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
+
+	err := clients.Committee.DeleteCommitteeMember(ctx, &committeeservice.DeleteCommitteeMemberPayload{
+		Version:   "1",
+		UID:       args.CommitteeUID,
+		MemberUID: args.MemberUID,
+	})
+	if err != nil {
+		logger.Error("DeleteCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to delete committee member: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("delete_committee_member succeeded", "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("Committee member %s deleted successfully from committee %s.", args.MemberUID, args.CommitteeUID)},
+		},
+	}, nil, nil
+}
+
+// strPtr returns a pointer to the given string value.
+func strPtr(s string) *string {
+	return &s
+}

--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -19,50 +19,50 @@ import (
 
 // CreateCommitteeArgs defines the input parameters for the create_committee tool.
 type CreateCommitteeArgs struct {
-	ProjectUID            string   `json:"project_uid" jsonschema:"Project UID the committee belongs to"`
-	Name                  string   `json:"name" jsonschema:"Name of the committee"`
-	Category              string   `json:"category" jsonschema:"Category of the committee"`
-	Description           *string  `json:"description,omitempty" jsonschema:"Description of the committee"`
-	Website               *string  `json:"website,omitempty" jsonschema:"Website URL of the committee"`
-	EnableVoting          bool     `json:"enable_voting,omitempty" jsonschema:"Whether voting is enabled"`
-	SSOGroupEnabled       bool     `json:"sso_group_enabled,omitempty" jsonschema:"Whether SSO group integration is enabled"`
-	RequiresReview        bool     `json:"requires_review,omitempty" jsonschema:"Whether the committee requires review"`
-	Public                bool     `json:"public,omitempty" jsonschema:"Whether the committee is publicly visible"`
-	CalendarPublic        *bool    `json:"calendar_public,omitempty" jsonschema:"Whether the committee calendar is publicly visible"`
-	DisplayName           *string  `json:"display_name,omitempty" jsonschema:"Display name of the committee"`
-	ParentUID             *string  `json:"parent_uid,omitempty" jsonschema:"UID of the parent committee, if any"`
-	BusinessEmailRequired bool     `json:"business_email_required,omitempty" jsonschema:"Whether business email is required for members"`
-	MemberVisibility      string   `json:"member_visibility,omitempty" jsonschema:"Visibility level of member profiles to other members"`
-	ShowMeetingAttendees  bool     `json:"show_meeting_attendees,omitempty" jsonschema:"Whether to show meeting attendees by default"`
-	Writers               []string `json:"writers,omitempty" jsonschema:"Manager user IDs who can edit this committee"`
-	Auditors              []string `json:"auditors,omitempty" jsonschema:"Auditor user IDs who can audit this committee"`
+	ProjectUID            string  `json:"project_uid" jsonschema:"Project UID the committee belongs to"`
+	Name                  string  `json:"name" jsonschema:"Name of the committee"`
+	Category              string  `json:"category" jsonschema:"Category of the committee"`
+	Description           *string `json:"description,omitempty" jsonschema:"Description of the committee"`
+	Website               *string `json:"website,omitempty" jsonschema:"Website URL of the committee"`
+	EnableVoting          bool    `json:"enable_voting,omitempty" jsonschema:"Whether voting is enabled"`
+	SSOGroupEnabled       bool    `json:"sso_group_enabled,omitempty" jsonschema:"Whether SSO group integration is enabled"`
+	RequiresReview        bool    `json:"requires_review,omitempty" jsonschema:"Whether the committee requires review"`
+	Public                bool    `json:"public,omitempty" jsonschema:"Whether the committee is publicly visible"`
+	CalendarPublic        *bool   `json:"calendar_public,omitempty" jsonschema:"Whether the committee calendar is publicly visible"`
+	DisplayName           *string `json:"display_name,omitempty" jsonschema:"Display name of the committee"`
+	ParentUID             *string `json:"parent_uid,omitempty" jsonschema:"UID of the parent committee, if any"`
+	BusinessEmailRequired bool    `json:"business_email_required,omitempty" jsonschema:"Whether business email is required for members"`
+	MemberVisibility      string  `json:"member_visibility,omitempty" jsonschema:"Visibility level of member profiles to other members"`
+	ShowMeetingAttendees  bool    `json:"show_meeting_attendees,omitempty" jsonschema:"Whether to show meeting attendees by default"`
 }
 
 // UpdateCommitteeArgs defines the input parameters for the update_committee tool.
+// Only fields that are provided (non-nil) will be updated; omitted fields retain
+// their current values (fetch-then-merge semantics).
 type UpdateCommitteeArgs struct {
 	UID             string  `json:"uid" jsonschema:"UID of the committee to update"`
-	ProjectUID      string  `json:"project_uid" jsonschema:"Project UID the committee belongs to"`
-	Name            string  `json:"name" jsonschema:"Name of the committee"`
-	Category        string  `json:"category" jsonschema:"Category of the committee"`
+	ProjectUID      *string `json:"project_uid,omitempty" jsonschema:"Project UID the committee belongs to"`
+	Name            *string `json:"name,omitempty" jsonschema:"Name of the committee"`
+	Category        *string `json:"category,omitempty" jsonschema:"Category of the committee"`
 	Description     *string `json:"description,omitempty" jsonschema:"Description of the committee"`
 	Website         *string `json:"website,omitempty" jsonschema:"Website URL of the committee"`
-	EnableVoting    bool    `json:"enable_voting,omitempty" jsonschema:"Whether voting is enabled"`
-	SSOGroupEnabled bool    `json:"sso_group_enabled,omitempty" jsonschema:"Whether SSO group integration is enabled"`
-	RequiresReview  bool    `json:"requires_review,omitempty" jsonschema:"Whether the committee requires review"`
-	Public          bool    `json:"public,omitempty" jsonschema:"Whether the committee is publicly visible"`
+	EnableVoting    *bool   `json:"enable_voting,omitempty" jsonschema:"Whether voting is enabled"`
+	SSOGroupEnabled *bool   `json:"sso_group_enabled,omitempty" jsonschema:"Whether SSO group integration is enabled"`
+	RequiresReview  *bool   `json:"requires_review,omitempty" jsonschema:"Whether the committee requires review"`
+	Public          *bool   `json:"public,omitempty" jsonschema:"Whether the committee is publicly visible"`
 	CalendarPublic  *bool   `json:"calendar_public,omitempty" jsonschema:"Whether the committee calendar is publicly visible"`
 	DisplayName     *string `json:"display_name,omitempty" jsonschema:"Display name of the committee"`
 	ParentUID       *string `json:"parent_uid,omitempty" jsonschema:"UID of the parent committee, if any"`
 }
 
 // UpdateCommitteeSettingsArgs defines the input parameters for the update_committee_settings tool.
+// Only fields that are provided (non-nil) will be updated; omitted fields retain
+// their current values (fetch-then-merge semantics).
 type UpdateCommitteeSettingsArgs struct {
-	UID                   string   `json:"uid" jsonschema:"UID of the committee whose settings to update"`
-	BusinessEmailRequired bool     `json:"business_email_required,omitempty" jsonschema:"Whether business email is required for members"`
-	MemberVisibility      string   `json:"member_visibility,omitempty" jsonschema:"Visibility level of member profiles to other members"`
-	ShowMeetingAttendees  bool     `json:"show_meeting_attendees,omitempty" jsonschema:"Whether to show meeting attendees by default"`
-	Writers               []string `json:"writers,omitempty" jsonschema:"Manager user IDs who can edit this committee"`
-	Auditors              []string `json:"auditors,omitempty" jsonschema:"Auditor user IDs who can audit this committee"`
+	UID                   string  `json:"uid" jsonschema:"UID of the committee whose settings to update"`
+	BusinessEmailRequired *bool   `json:"business_email_required,omitempty" jsonschema:"Whether business email is required for members"`
+	MemberVisibility      *string `json:"member_visibility,omitempty" jsonschema:"Visibility level of member profiles to other members"`
+	ShowMeetingAttendees  *bool   `json:"show_meeting_attendees,omitempty" jsonschema:"Whether to show meeting attendees by default"`
 }
 
 // DeleteCommitteeArgs defines the input parameters for the delete_committee tool.
@@ -110,12 +110,14 @@ type CreateCommitteeMemberArgs struct {
 }
 
 // UpdateCommitteeMemberArgs defines the input parameters for the update_committee_member tool.
+// Only fields that are provided (non-nil) will be updated; omitted fields retain
+// their current values (fetch-then-merge semantics).
 type UpdateCommitteeMemberArgs struct {
 	CommitteeUID    string                           `json:"committee_uid" jsonschema:"UID of the committee"`
 	MemberUID       string                           `json:"member_uid" jsonschema:"UID of the member to update"`
-	Email           string                           `json:"email" jsonschema:"Primary email address of the member"`
-	AppointedBy     string                           `json:"appointed_by" jsonschema:"How the member was appointed"`
-	Status          string                           `json:"status" jsonschema:"Member status"`
+	Email           *string                          `json:"email,omitempty" jsonschema:"Primary email address of the member"`
+	AppointedBy     *string                          `json:"appointed_by,omitempty" jsonschema:"How the member was appointed"`
+	Status          *string                          `json:"status,omitempty" jsonschema:"Member status"`
 	Username        *string                          `json:"username,omitempty" jsonschema:"LF ID username"`
 	FirstName       *string                          `json:"first_name,omitempty" jsonschema:"First name"`
 	LastName        *string                          `json:"last_name,omitempty" jsonschema:"Last name"`
@@ -150,10 +152,11 @@ func RegisterCreateCommittee(server *mcp.Server) {
 func RegisterUpdateCommittee(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_committee",
-		Description: "Update a committee's base information (name, category, visibility, etc.).",
+		Description: "Update a committee's base information (name, category, visibility, etc.). Only provided fields are changed; omitted fields keep their current values.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Update Committee",
-			DestructiveHint: boolPtr(false),
+			DestructiveHint: boolPtr(true),
+			IdempotentHint:  true,
 		},
 	}, handleUpdateCommittee)
 }
@@ -162,10 +165,11 @@ func RegisterUpdateCommittee(server *mcp.Server) {
 func RegisterUpdateCommitteeSettings(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_committee_settings",
-		Description: "Update a committee's settings (member visibility, writers, auditors, etc.).",
+		Description: "Update a committee's settings (member visibility, email requirements, meeting attendee defaults). Only provided fields are changed; omitted fields keep their current values.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Update Committee Settings",
-			DestructiveHint: boolPtr(false),
+			DestructiveHint: boolPtr(true),
+			IdempotentHint:  true,
 		},
 	}, handleUpdateCommitteeSettings)
 }
@@ -176,7 +180,8 @@ func RegisterDeleteCommittee(server *mcp.Server) {
 		Name:        "delete_committee",
 		Description: "Delete a committee by its UID.",
 		Annotations: &mcp.ToolAnnotations{
-			Title: "Delete Committee",
+			Title:           "Delete Committee",
+			DestructiveHint: boolPtr(true),
 		},
 	}, handleDeleteCommittee)
 }
@@ -197,10 +202,11 @@ func RegisterCreateCommitteeMember(server *mcp.Server) {
 func RegisterUpdateCommitteeMember(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_committee_member",
-		Description: "Update an existing committee member's information.",
+		Description: "Update an existing committee member's information. Only provided fields are changed; omitted fields keep their current values.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Update Committee Member",
-			DestructiveHint: boolPtr(false),
+			DestructiveHint: boolPtr(true),
+			IdempotentHint:  true,
 		},
 	}, handleUpdateCommitteeMember)
 }
@@ -211,7 +217,8 @@ func RegisterDeleteCommitteeMember(server *mcp.Server) {
 		Name:        "delete_committee_member",
 		Description: "Remove a member from a committee.",
 		Annotations: &mcp.ToolAnnotations{
-			Title: "Delete Committee Member",
+			Title:           "Delete Committee Member",
+			DestructiveHint: boolPtr(true),
 		},
 	}, handleDeleteCommitteeMember)
 }
@@ -291,8 +298,6 @@ func handleCreateCommittee(ctx context.Context, req *mcp.CallToolRequest, args C
 		BusinessEmailRequired: args.BusinessEmailRequired,
 		MemberVisibility:      args.MemberVisibility,
 		ShowMeetingAttendees:  args.ShowMeetingAttendees,
-		Writers:               args.Writers,
-		Auditors:              args.Auditors,
 	}
 
 	if args.CalendarPublic != nil {
@@ -331,6 +336,8 @@ func handleCreateCommittee(ctx context.Context, req *mcp.CallToolRequest, args C
 }
 
 // handleUpdateCommittee implements the update_committee tool logic.
+// It fetches the current committee base, merges in the provided fields,
+// and PUTs the result with If-Match for optimistic concurrency.
 func handleUpdateCommittee(ctx context.Context, req *mcp.CallToolRequest, args UpdateCommitteeArgs) (*mcp.CallToolResult, any, error) {
 	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
 	if errResult != nil {
@@ -348,24 +355,77 @@ func handleUpdateCommittee(ctx context.Context, req *mcp.CallToolRequest, args U
 
 	logger.Info("updating committee", "uid", args.UID)
 
-	payload := &committeeservice.UpdateCommitteeBasePayload{
-		Version:         strPtr("1"),
-		UID:             &args.UID,
-		ProjectUID:      args.ProjectUID,
-		Name:            args.Name,
-		Category:        args.Category,
-		Description:     args.Description,
-		Website:         args.Website,
-		EnableVoting:    args.EnableVoting,
-		SsoGroupEnabled: args.SSOGroupEnabled,
-		RequiresReview:  args.RequiresReview,
-		Public:          args.Public,
-		DisplayName:     args.DisplayName,
-		ParentUID:       args.ParentUID,
+	// Fetch current state for merge.
+	current, err := clients.Committee.GetCommitteeBase(ctx, &committeeservice.GetCommitteeBasePayload{
+		UID: &args.UID,
+	})
+	if err != nil {
+		logger.Error("GetCommitteeBase failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee for update: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
 	}
 
+	base := current.CommitteeBase
+
+	// Build payload from current state, overriding with any provided args.
+	payload := &committeeservice.UpdateCommitteeBasePayload{
+		Version:         strPtr("1"),
+		IfMatch:         current.Etag,
+		UID:             &args.UID,
+		ProjectUID:      derefStr(base.ProjectUID),
+		Name:            derefStr(base.Name),
+		Category:        derefStr(base.Category),
+		Description:     base.Description,
+		Website:         base.Website,
+		EnableVoting:    base.EnableVoting,
+		SsoGroupEnabled: base.SsoGroupEnabled,
+		RequiresReview:  base.RequiresReview,
+		Public:          base.Public,
+		Calendar:        base.Calendar,
+		DisplayName:     base.DisplayName,
+		ParentUID:       base.ParentUID,
+	}
+
+	// Override with provided args.
+	if args.ProjectUID != nil {
+		payload.ProjectUID = *args.ProjectUID
+	}
+	if args.Name != nil {
+		payload.Name = *args.Name
+	}
+	if args.Category != nil {
+		payload.Category = *args.Category
+	}
+	if args.Description != nil {
+		payload.Description = args.Description
+	}
+	if args.Website != nil {
+		payload.Website = args.Website
+	}
+	if args.EnableVoting != nil {
+		payload.EnableVoting = *args.EnableVoting
+	}
+	if args.SSOGroupEnabled != nil {
+		payload.SsoGroupEnabled = *args.SSOGroupEnabled
+	}
+	if args.RequiresReview != nil {
+		payload.RequiresReview = *args.RequiresReview
+	}
+	if args.Public != nil {
+		payload.Public = *args.Public
+	}
 	if args.CalendarPublic != nil {
 		payload.Calendar = &struct{ Public bool }{Public: *args.CalendarPublic}
+	}
+	if args.DisplayName != nil {
+		payload.DisplayName = args.DisplayName
+	}
+	if args.ParentUID != nil {
+		payload.ParentUID = args.ParentUID
 	}
 
 	result, err := clients.Committee.UpdateCommitteeBase(ctx, payload)
@@ -400,6 +460,8 @@ func handleUpdateCommittee(ctx context.Context, req *mcp.CallToolRequest, args U
 }
 
 // handleUpdateCommitteeSettings implements the update_committee_settings tool logic.
+// It fetches the current committee settings, merges in the provided fields,
+// and PUTs the result with If-Match for optimistic concurrency.
 func handleUpdateCommitteeSettings(ctx context.Context, req *mcp.CallToolRequest, args UpdateCommitteeSettingsArgs) (*mcp.CallToolResult, any, error) {
 	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
 	if errResult != nil {
@@ -417,14 +479,41 @@ func handleUpdateCommitteeSettings(ctx context.Context, req *mcp.CallToolRequest
 
 	logger.Info("updating committee settings", "uid", args.UID)
 
+	// Fetch current state for merge.
+	current, err := clients.Committee.GetCommitteeSettings(ctx, &committeeservice.GetCommitteeSettingsPayload{
+		UID: &args.UID,
+	})
+	if err != nil {
+		logger.Error("GetCommitteeSettings failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee settings for update: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	settings := current.CommitteeSettings
+
+	// Build payload from current state, overriding with any provided args.
 	payload := &committeeservice.UpdateCommitteeSettingsPayload{
 		Version:               strPtr("1"),
+		IfMatch:               current.Etag,
 		UID:                   &args.UID,
-		BusinessEmailRequired: args.BusinessEmailRequired,
-		MemberVisibility:      args.MemberVisibility,
-		ShowMeetingAttendees:  args.ShowMeetingAttendees,
-		Writers:               args.Writers,
-		Auditors:              args.Auditors,
+		BusinessEmailRequired: settings.BusinessEmailRequired,
+		MemberVisibility:      settings.MemberVisibility,
+		ShowMeetingAttendees:  settings.ShowMeetingAttendees,
+	}
+
+	// Override with provided args.
+	if args.BusinessEmailRequired != nil {
+		payload.BusinessEmailRequired = *args.BusinessEmailRequired
+	}
+	if args.MemberVisibility != nil {
+		payload.MemberVisibility = *args.MemberVisibility
+	}
+	if args.ShowMeetingAttendees != nil {
+		payload.ShowMeetingAttendees = *args.ShowMeetingAttendees
 	}
 
 	result, err := clients.Committee.UpdateCommitteeSettings(ctx, payload)
@@ -476,8 +565,23 @@ func handleDeleteCommittee(ctx context.Context, req *mcp.CallToolRequest, args D
 
 	logger.Info("deleting committee", "uid", args.UID)
 
-	err := clients.Committee.DeleteCommittee(ctx, &committeeservice.DeleteCommitteePayload{
+	// Fetch current state to obtain the ETag required by the API.
+	current, err := clients.Committee.GetCommitteeBase(ctx, &committeeservice.GetCommitteeBasePayload{
+		UID: &args.UID,
+	})
+	if err != nil {
+		logger.Error("GetCommitteeBase failed", "error", err, "uid", args.UID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee for delete: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	err = clients.Committee.DeleteCommittee(ctx, &committeeservice.DeleteCommitteePayload{
 		Version: strPtr("1"),
+		IfMatch: current.Etag,
 		UID:     &args.UID,
 	})
 	if err != nil {
@@ -627,6 +731,8 @@ func handleCreateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 // handleUpdateCommitteeMember implements the update_committee_member tool logic.
+// It fetches the current member data, merges in the provided fields,
+// and PUTs the result with If-Match for optimistic concurrency.
 func handleUpdateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, args UpdateCommitteeMemberArgs) (*mcp.CallToolResult, any, error) {
 	ctx, clients, logger, errResult := committeeWriteClients(ctx, req)
 	if errResult != nil {
@@ -653,21 +759,76 @@ func handleUpdateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 
 	logger.Info("updating committee member", "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
 
+	// Fetch current state for merge.
+	current, err := clients.Committee.GetCommitteeMember(ctx, &committeeservice.GetCommitteeMemberPayload{
+		Version:   "1",
+		UID:       args.CommitteeUID,
+		MemberUID: args.MemberUID,
+	})
+	if err != nil {
+		logger.Error("GetCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee member for update: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	member := current.Member
+
+	// Build payload from current state, overriding with any provided args.
 	payload := &committeeservice.UpdateCommitteeMemberPayload{
 		Version:         "1",
+		IfMatch:         current.Etag,
 		UID:             args.CommitteeUID,
 		MemberUID:       args.MemberUID,
-		Email:           args.Email,
-		AppointedBy:     args.AppointedBy,
-		Status:          args.Status,
-		Username:        args.Username,
-		FirstName:       args.FirstName,
-		LastName:        args.LastName,
-		JobTitle:        args.JobTitle,
-		LinkedinProfile: args.LinkedinProfile,
-		Role:            buildMemberRole(args.Role),
-		Voting:          buildMemberVoting(args.Voting),
-		Organization:    buildMemberOrganization(args.Organization),
+		Email:           derefStr(member.Email),
+		AppointedBy:     member.AppointedBy,
+		Status:          member.Status,
+		Username:        member.Username,
+		FirstName:       member.FirstName,
+		LastName:        member.LastName,
+		JobTitle:        member.JobTitle,
+		LinkedinProfile: member.LinkedinProfile,
+		Role:            member.Role,
+		Voting:          member.Voting,
+		Organization:    member.Organization,
+	}
+
+	// Override with provided args.
+	if args.Email != nil {
+		payload.Email = *args.Email
+	}
+	if args.AppointedBy != nil {
+		payload.AppointedBy = *args.AppointedBy
+	}
+	if args.Status != nil {
+		payload.Status = *args.Status
+	}
+	if args.Username != nil {
+		payload.Username = args.Username
+	}
+	if args.FirstName != nil {
+		payload.FirstName = args.FirstName
+	}
+	if args.LastName != nil {
+		payload.LastName = args.LastName
+	}
+	if args.JobTitle != nil {
+		payload.JobTitle = args.JobTitle
+	}
+	if args.LinkedinProfile != nil {
+		payload.LinkedinProfile = args.LinkedinProfile
+	}
+	if args.Role != nil {
+		payload.Role = buildMemberRole(args.Role)
+	}
+	if args.Voting != nil {
+		payload.Voting = buildMemberVoting(args.Voting)
+	}
+	if args.Organization != nil {
+		payload.Organization = buildMemberOrganization(args.Organization)
 	}
 
 	result, err := clients.Committee.UpdateCommitteeMember(ctx, payload)
@@ -728,8 +889,25 @@ func handleDeleteCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 
 	logger.Info("deleting committee member", "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
 
-	err := clients.Committee.DeleteCommitteeMember(ctx, &committeeservice.DeleteCommitteeMemberPayload{
+	// Fetch current state to obtain the ETag required by the API.
+	current, err := clients.Committee.GetCommitteeMember(ctx, &committeeservice.GetCommitteeMemberPayload{
 		Version:   "1",
+		UID:       args.CommitteeUID,
+		MemberUID: args.MemberUID,
+	})
+	if err != nil {
+		logger.Error("GetCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee member for delete: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	err = clients.Committee.DeleteCommitteeMember(ctx, &committeeservice.DeleteCommitteeMemberPayload{
+		Version:   "1",
+		IfMatch:   current.Etag,
 		UID:       args.CommitteeUID,
 		MemberUID: args.MemberUID,
 	})
@@ -752,3 +930,10 @@ func handleDeleteCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 	}, nil, nil
 }
 
+// derefStr safely dereferences a *string, returning "" if nil.
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -9,3 +9,9 @@ package tools
 func boolPtr(b bool) *bool {
 	return &b
 }
+
+// strPtr returns a pointer to the given string value. Used for optional
+// payload fields that distinguish between "unset" and "zero value".
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Summary
- Add 7 new MCP tools for committee write operations: `create_committee`, `update_committee`, `update_committee_settings`, `delete_committee`, `create_committee_member`, `update_committee_member`, `delete_committee_member`
- New tools follow the same patterns as existing read-only committee tools, reusing `committeeConfig` and the shared client setup
- Update README with new tools in the Committees section

## Details
- New file `internal/tools/committee_write.go` with all 7 tools
- `committeeWriteClients()` helper extracted to reduce boilerplate across handlers
- `CalendarPublic` flattened from nested `Calendar.Public` for simpler schema
- `Role`, `Voting`, `Organization` kept as nested structs for committee member tools
- Create/update tools annotated with `DestructiveHint: false`; delete tools default to `true`
- All 7 tools added to `defaultTools` and registered in `newServer()`

## Test plan
- [x] `make build` — compiles cleanly
- [x] `make fmt && make vet` — no issues
- [x] `./scripts/test_server.sh` — existing integration tests pass
- [x] `tools/list` via stdio confirms all 7 new tools with correct schemas and annotations
- [ ] End-to-end API calls against dev environment with valid auth token