### PR TITLE
Remove unsafe foreign-key fields from committee member tools

### DIFF
--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -820,7 +820,24 @@ func handleUpdateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 		payload.Voting = buildMemberVoting(args.Voting)
 	}
 	if args.Organization != nil {
-		payload.Organization = buildMemberOrganization(args.Organization)
+		// Merge into existing organization to preserve the ID (which is not
+		// exposed as an input field).  Start from the current state so that
+		// only the caller-provided Name/Website are overridden.
+		org := payload.Organization // from current member state
+		if org == nil {
+			org = &struct {
+				ID      *string
+				Name    *string
+				Website *string
+			}{}
+		}
+		if args.Organization.Name != nil {
+			org.Name = args.Organization.Name
+		}
+		if args.Organization.Website != nil {
+			org.Website = args.Organization.Website
+		}
+		payload.Organization = org
 	}
 
 	result, err := clients.Committee.UpdateCommitteeMember(ctx, payload)

--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -88,7 +88,6 @@ type CommitteeMemberVotingArgs struct {
 
 // CommitteeMemberOrganizationArgs defines organization information for a committee member.
 type CommitteeMemberOrganizationArgs struct {
-	ID      *string `json:"id,omitempty" jsonschema:"Organization ID"`
 	Name    *string `json:"name,omitempty" jsonschema:"Organization name"`
 	Website *string `json:"website,omitempty" jsonschema:"Organization website URL"`
 }
@@ -99,7 +98,6 @@ type CreateCommitteeMemberArgs struct {
 	Email           string                           `json:"email" jsonschema:"Primary email address of the member"`
 	AppointedBy     string                           `json:"appointed_by" jsonschema:"How the member was appointed"`
 	Status          string                           `json:"status" jsonschema:"Member status"`
-	Username        *string                          `json:"username,omitempty" jsonschema:"LF ID username"`
 	FirstName       *string                          `json:"first_name,omitempty" jsonschema:"First name"`
 	LastName        *string                          `json:"last_name,omitempty" jsonschema:"Last name"`
 	JobTitle        *string                          `json:"job_title,omitempty" jsonschema:"Job title at organization"`
@@ -118,7 +116,6 @@ type UpdateCommitteeMemberArgs struct {
 	Email           *string                          `json:"email,omitempty" jsonschema:"Primary email address of the member"`
 	AppointedBy     *string                          `json:"appointed_by,omitempty" jsonschema:"How the member was appointed"`
 	Status          *string                          `json:"status,omitempty" jsonschema:"Member status"`
-	Username        *string                          `json:"username,omitempty" jsonschema:"LF ID username"`
 	FirstName       *string                          `json:"first_name,omitempty" jsonschema:"First name"`
 	LastName        *string                          `json:"last_name,omitempty" jsonschema:"Last name"`
 	JobTitle        *string                          `json:"job_title,omitempty" jsonschema:"Job title at organization"`
@@ -659,7 +656,6 @@ func buildMemberOrganization(o *CommitteeMemberOrganizationArgs) *struct {
 		Name    *string
 		Website *string
 	}{
-		ID:      o.ID,
 		Name:    o.Name,
 		Website: o.Website,
 	}
@@ -689,7 +685,6 @@ func handleCreateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 		Email:           args.Email,
 		AppointedBy:     args.AppointedBy,
 		Status:          args.Status,
-		Username:        args.Username,
 		FirstName:       args.FirstName,
 		LastName:        args.LastName,
 		JobTitle:        args.JobTitle,
@@ -805,9 +800,6 @@ func handleUpdateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 	}
 	if args.Status != nil {
 		payload.Status = *args.Status
-	}
-	if args.Username != nil {
-		payload.Username = args.Username
 	}
 	if args.FirstName != nil {
 		payload.FirstName = args.FirstName


### PR DESCRIPTION
## Summary
- Remove `Organization.ID` from `CommitteeMemberOrganizationArgs` — a v1 org-service ID that MCP users can't reasonably look up or provide correctly
- Remove `Username` from `CreateCommitteeMemberArgs` — currently broken in v2 (uses `auth0|` sub format with legacy hashes)
- Remove `Username` from `UpdateCommitteeMemberArgs` — same issue; existing value is still preserved on updates via fetch-then-merge

These fields expose unvalidated foreign keys without UI guardrails, which could corrupt data when written via MCP (same rationale as the earlier removal of `writers`/`auditors`).

## Test plan
- [x] `make fmt && make vet && make build` passes
- [ ] Verify via `tools/list` that the 3 fields no longer appear in the JSON schemas for `create_committee_member`, `update_committee_member`, and the `organization` sub-object