### PR TITLE
docs: split README into end-user and developer docs; add client setup instructions

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,224 @@
+# LFX MCP Server — Developer Guide
+
+This guide covers building, running, testing, and extending the LFX MCP Server. For end-user integration instructions, see [README.md](README.md).
+
+## Prerequisites
+
+- Go 1.26.0 or later
+
+## Build
+
+```bash
+make build
+# Or directly:
+go build -ldflags="-s -w" -o bin/lfx-mcp-server ./cmd/lfx-mcp-server
+```
+
+## Running Locally
+
+> **Note:** The stdio transport only exposes the `hello_world` tool. All LFX data tools require OAuth authentication, which is only supported via the HTTP transport. There is currently no personal access token (PAT) capability in LFX, so running the full server locally for end-to-end use is not practical without a complete OAuth setup.
+
+**Stdio transport:**
+
+```bash
+./bin/lfx-mcp-server
+# With debug logging:
+./bin/lfx-mcp-server -debug
+```
+
+**HTTP transport:**
+
+```bash
+./bin/lfx-mcp-server -mode=http
+# With debug logging:
+./bin/lfx-mcp-server -mode=http -debug
+```
+
+The HTTP server listens at `http://localhost:8080/mcp` by default.
+
+## Configuration
+
+Environment variables use the `LFXMCP_` prefix and **override** their corresponding flags.
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `-mode` | `LFXMCP_MODE` | `stdio` | Transport mode: `stdio` or `http` |
+| `-http.host` | `LFXMCP_HTTP_HOST` | `127.0.0.1` | HTTP server bind address |
+| `-http.port` | `LFXMCP_HTTP_PORT` | `8080` | HTTP server port |
+| `-http.public_url` | `LFXMCP_HTTP_PUBLIC_URL` | — | Public URL for HTTP transport (reverse proxies) |
+| `-debug` | `LFXMCP_DEBUG` | `false` | Enable debug logging with source locations |
+| `-debug_traffic` | `LFXMCP_DEBUG_TRAFFIC` | `false` | Log outbound LFX API request/response bodies |
+| `-tools` | `LFXMCP_TOOLS` | — | Comma-separated list of tools to enable |
+| `-mcp_api.auth_servers` | `LFXMCP_MCP_API_AUTH_SERVERS` | — | OAuth authorization server URLs (comma-separated) |
+| `-mcp_api.public_url` | `LFXMCP_MCP_API_PUBLIC_URL` | — | Public URL for MCP API (OAuth PRM) |
+| `-mcp_api.scopes` | `LFXMCP_MCP_API_SCOPES` | — | OAuth scopes (comma-separated) |
+| `-client_id` | `LFXMCP_CLIENT_ID` | — | OAuth client ID for token exchange |
+| `-client_secret` | `LFXMCP_CLIENT_SECRET` | — | OAuth client secret |
+| `-client_assertion_signing_key` | `LFXMCP_CLIENT_ASSERTION_SIGNING_KEY` | — | PEM-encoded RSA private key for client assertion (RFC 7523) |
+| `-token_endpoint` | `LFXMCP_TOKEN_ENDPOINT` | — | OAuth2 token endpoint URL (RFC 8693) |
+| `-lfx_api_url` | `LFXMCP_LFX_API_URL` | — | LFX API base URL (token exchange audience) |
+
+## Code Quality
+
+```bash
+make fmt     # Format code.
+make vet     # Run go vet.
+make lint    # Run golangci-lint (install if needed).
+make check   # Run fmt, vet, and lint together.
+```
+
+## Testing
+
+### Automated tests
+
+```bash
+make test           # Run all Go tests.
+make test-coverage  # Run tests with coverage report.
+```
+
+### Integration test script
+
+```bash
+./scripts/test_server.sh          # Run integration tests.
+./scripts/test_server.sh --debug  # With debug logging.
+```
+
+### Manual stdio testing
+
+Send raw JSON-RPC messages to the server:
+
+```bash
+# List available tools.
+(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}';
+ echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}';
+ sleep 0.5) | ./bin/lfx-mcp-server stdio
+
+# Call the hello_world tool.
+(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}';
+ echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"LFX User"}}}';
+ sleep 0.5) | ./bin/lfx-mcp-server stdio
+```
+
+### Manual HTTP testing
+
+```bash
+# Start the server.
+./bin/lfx-mcp-server -mode=http &
+
+# List tools.
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Responses are returned as Server-Sent Events (SSE) with `event: message` and `data:` fields.
+
+## Logging
+
+The server uses structured JSON logging via Go's `slog` package. Logs go to stderr in stdio mode, or stdout in HTTP mode.
+
+Enable debug logging via flag or environment variable:
+
+```bash
+./bin/lfx-mcp-server -debug
+# Or:
+LFXMCP_DEBUG=true ./bin/lfx-mcp-server
+```
+
+To log full request/response bodies for outbound LFX API calls:
+
+```bash
+./bin/lfx-mcp-server -debug_traffic
+```
+
+## Project Structure
+
+```text
+lfx-mcp/
+├── cmd/
+│   └── lfx-mcp-server/     # Main application entry point
+├── internal/
+│   └── tools/              # MCP tool implementations
+├── bin/                    # Built binaries (created by make build)
+├── charts/                 # Helm chart for Kubernetes deployment
+├── go.mod                  # Go module definition
+├── Makefile                # Build automation
+├── README.md               # End-user documentation
+├── DEVELOPER.md            # This file
+└── AGENTS.md               # AI agent / architecture guide
+```
+
+## Adding New Tools
+
+Tools live in `internal/tools/`, one file per tool. Each file defines an args struct, a handler function, and a `Register<ToolName>` function.
+
+1. **Create** `internal/tools/my_tool.go`:
+
+```go
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+// Package tools contains MCP tool implementations.
+package tools
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// MyToolArgs defines the input parameters for the my_tool tool.
+type MyToolArgs struct {
+    Param1 string `json:"param1" jsonschema:"Description of parameter 1"`
+    Param2 int    `json:"param2,omitempty" jsonschema:"Optional parameter 2"`
+}
+
+// RegisterMyTool registers the my_tool tool with the MCP server.
+func RegisterMyTool(server *mcp.Server) {
+    mcp.AddTool(server, &mcp.Tool{
+        Name:        "my_tool",
+        Description: "Brief description of what the tool does.",
+        Annotations: &mcp.ToolAnnotations{
+            Title:        "My Tool",
+            ReadOnlyHint: true,
+        },
+    }, handleMyTool)
+}
+
+// handleMyTool implements the my_tool tool logic.
+func handleMyTool(ctx context.Context, req *mcp.CallToolRequest, args MyToolArgs) (*mcp.CallToolResult, any, error) {
+    result := fmt.Sprintf("Processed: %s with value %d", args.Param1, args.Param2)
+
+    return &mcp.CallToolResult{
+        Content: []mcp.Content{
+            &mcp.TextContent{Text: result},
+        },
+    }, nil, nil
+}
+```
+
+2. **Register** the tool in `cmd/lfx-mcp-server/main.go`:
+
+```go
+tools.RegisterMyTool(server)
+```
+
+For more detail on tool annotations, JSON schema tags, content types, and the MCP Go SDK patterns used throughout this codebase, see [AGENTS.md](AGENTS.md).
+
+## Build System
+
+| Target | Description |
+|--------|-------------|
+| `all` | Clean, check, and build (default) |
+| `build` | Compile the binary |
+| `clean` | Remove build artifacts |
+| `fmt` | Format Go code |
+| `vet` | Run go vet |
+| `lint` | Run golangci-lint |
+| `check` | Run fmt, vet, and lint |
+| `run` | Build and run in stdio mode |
+| `test` | Run Go tests |
+| `test-coverage` | Run tests with coverage |
+| `deps` | Download and tidy dependencies |
+| `install-tools` | Install development tools |

--- a/README.md
+++ b/README.md
@@ -10,31 +10,84 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that c
 - **Query members** — Search memberships by tier, status, organization, and more; get key contacts
 - **Track meetings** — Find upcoming meetings, registrants, past participants, transcripts, and AI-generated summaries
 
-## Quick Start
+## Connecting to the LFX MCP Server
 
-### Prerequisites
+The LFX MCP Server is available as a hosted, production service at:
 
-- Go 1.26.0+
-
-### Build & Run
-
-```bash
-git clone https://github.com/linuxfoundation/lfx-mcp.git
-cd lfx-mcp
-make build
+```
+https://mcp.lfx.dev/mcp
 ```
 
-**Stdio transport** (default — used by Claude Desktop, Claude Code, etc.):
+This endpoint uses the [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport with OAuth 2.0 authentication. You will be prompted to log in with your Linux Foundation account the first time you connect.
 
-```bash
-./bin/lfx-mcp-server
+> **Note:** Running the LFX MCP Server locally (e.g. in stdio mode) is not a supported end-user configuration. The full tool set requires OAuth authentication flows that are only available through the hosted service.
+
+### Claude
+
+Claude supports remote MCP servers directly. Add the LFX MCP Server in **Settings → Integrations → Add Integration**:
+
+- **URL:** `https://mcp.lfx.dev/mcp`
+- **Client ID:** `Ef9tuU5wcJJIXmNGvZyGUkZFfD8CZWar`
+
+### Cursor
+
+Cursor supports remote MCP servers with static OAuth. Add the following to your `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "lfx": {
+      "url": "https://mcp.lfx.dev/mcp",
+      "auth": {
+        "CLIENT_ID": "HwGWwUy4uvqVQYDsuXb9IVamzcUhdZj5"
+      }
+    }
+  }
+}
 ```
 
-**HTTP transport** (streamable HTTP with SSE):
+### stdio-only clients (via mcp-remote)
+
+If your MCP client only supports stdio-based servers, you can use [mcp-remote](https://github.com/geelen/mcp-remote) as a local proxy. It handles the OAuth flow in your browser and bridges stdio to the remote HTTP server.
+
+The port `3334` is required so that the OAuth callback URL matches the registered client. Please refer to your client's documentation for the exact configuration syntax. For example, in **Zed** (`~/.config/zed/settings.json`):
+
+```json
+{
+  "context_servers": {
+    "lfx": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.lfx.dev/mcp",
+        "3334",
+        "--static-oauth-client-info",
+        "{\"client_id\":\"TODO: fill in after auth0-terraform deployment\"}"
+      ]
+    }
+  }
+}
+```
+
+A browser window will open for authentication on first use. To clear cached credentials (e.g. to re-authenticate):
 
 ```bash
-./bin/lfx-mcp-server -mode=http
+rm -rf ~/.mcp-auth
 ```
+
+### MCP Inspector (developer testing)
+
+[MCP Inspector](https://github.com/modelcontextprotocol/inspector) is a browser-based tool for exploring and testing MCP servers. To connect it to the LFX MCP Server:
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Then in the Inspector UI:
+
+- **Transport:** Streamable HTTP
+- **URL:** `https://mcp.lfx.dev/mcp`
+- **Client ID:** `TODO: fill in after auth0-terraform deployment`
 
 ## Available Tools
 
@@ -98,43 +151,6 @@ make build
 |------|-------------|
 | `hello_world` | Simple greeting tool for testing MCP connectivity |
 | `user_info` | Get the authenticated user's OpenID Connect profile |
-
-## Configuration
-
-<details>
-<summary>All flags and environment variables</summary>
-
-Environment variables use the `LFXMCP_` prefix and **override** their corresponding flags.
-
-| Flag | Env Var | Default | Description |
-|------|---------|---------|-------------|
-| `-mode` | `LFXMCP_MODE` | `stdio` | Transport mode: `stdio` or `http` |
-| `-http.host` | `LFXMCP_HTTP_HOST` | `127.0.0.1` | HTTP server bind address |
-| `-http.port` | `LFXMCP_HTTP_PORT` | `8080` | HTTP server port |
-| `-http.public_url` | `LFXMCP_HTTP_PUBLIC_URL` | — | Public URL for HTTP transport (reverse proxies) |
-| `-debug` | `LFXMCP_DEBUG` | `false` | Enable debug logging with source locations |
-| `-debug_traffic` | `LFXMCP_DEBUG_TRAFFIC` | `false` | Log outbound LFX API request/response bodies |
-| `-tools` | `LFXMCP_TOOLS` | — | Comma-separated list of tools to enable |
-| `-mcp_api.auth_servers` | `LFXMCP_MCP_API_AUTH_SERVERS` | — | OAuth authorization server URLs (comma-separated) |
-| `-mcp_api.public_url` | `LFXMCP_MCP_API_PUBLIC_URL` | — | Public URL for MCP API (OAuth PRM) |
-| `-mcp_api.scopes` | `LFXMCP_MCP_API_SCOPES` | — | OAuth scopes (comma-separated) |
-| `-client_id` | `LFXMCP_CLIENT_ID` | — | OAuth client ID for token exchange |
-| `-client_secret` | `LFXMCP_CLIENT_SECRET` | — | OAuth client secret |
-| `-client_assertion_signing_key` | `LFXMCP_CLIENT_ASSERTION_SIGNING_KEY` | — | PEM-encoded RSA private key for client assertion |
-| `-token_endpoint` | `LFXMCP_TOKEN_ENDPOINT` | — | OAuth2 token endpoint URL (RFC 8693) |
-| `-lfx_api_url` | `LFXMCP_LFX_API_URL` | — | LFX API base URL (token exchange audience) |
-
-</details>
-
-## Development
-
-See [AGENTS.md](AGENTS.md) for architecture details, adding tools, testing patterns, and coding guidelines.
-
-```bash
-make build    # Compile the binary
-make check    # Format, vet, and lint
-make test     # Run tests
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,18 @@ This endpoint uses the [Streamable HTTP](https://modelcontextprotocol.io/specifi
 
 > **Note:** Running the LFX MCP Server locally (e.g. in stdio mode) is not a supported end-user configuration. The full tool set requires OAuth authentication flows that are only available through the hosted service.
 
+**Linux Foundation SSO does not support Dynamic Client Registration (DCR) or Client ID Metadata Documents (CIMD) at this time.** Please file an issue to request additional client support.
+
 ### Claude
 
-Claude supports remote MCP servers directly. Add the LFX MCP Server in **Settings → Integrations → Add Integration**:
+Add the LFX MCP Server in **Settings → Integrations → Add Integration**:
 
 - **URL:** `https://mcp.lfx.dev/mcp`
 - **Client ID:** `Ef9tuU5wcJJIXmNGvZyGUkZFfD8CZWar`
 
 ### Cursor
 
-Cursor supports remote MCP servers with static OAuth. Add the following to your `~/.cursor/mcp.json`:
+Add the following to your `~/.cursor/mcp.json`:
 
 ```json
 {
@@ -46,9 +48,9 @@ Cursor supports remote MCP servers with static OAuth. Add the following to your 
 }
 ```
 
-### stdio-only clients (via mcp-remote)
+### Additional clients (via mcp-remote)
 
-If your MCP client only supports stdio-based servers, you can use [mcp-remote](https://github.com/geelen/mcp-remote) as a local proxy. It handles the OAuth flow in your browser and bridges stdio to the remote HTTP server.
+If your MCP client does not support OAuth 2.0 with Streamable HTTP, you can use [mcp-remote](https://github.com/geelen/mcp-remote) as a local proxy. It handles the OAuth flow in your browser and serves a `stdio` transport to your MCP client.
 
 The port `3334` is required so that the OAuth callback URL matches the registered client. Please refer to your client's documentation for the exact configuration syntax. For example, in **Zed** (`~/.config/zed/settings.json`):
 
@@ -62,7 +64,7 @@ The port `3334` is required so that the OAuth callback URL matches the registere
         "https://mcp.lfx.dev/mcp",
         "3334",
         "--static-oauth-client-info",
-        "{\"client_id\":\"TODO: fill in after auth0-terraform deployment\"}"
+        "{\"client_id\":\"tjrXD5ZJORf6rpngMSRqqPmf3W1bnHEV\"}"
       ]
     }
   }
@@ -87,7 +89,9 @@ Then in the Inspector UI:
 
 - **Transport:** Streamable HTTP
 - **URL:** `https://mcp.lfx.dev/mcp`
-- **Client ID:** `TODO: fill in after auth0-terraform deployment`
+- **Authentication → OAuth 2.0 Flow → Client ID:** `4ibLLbnz9kwMEcE3RUCUH51F0RS3Hx3O`
+
+Before hitting **Connect**, follow the **Open Auth Settings** button, then select **Quick OAuth Flow**.
 
 ## Available Tools
 


### PR DESCRIPTION
## Summary

Restructures documentation to separate end-user and developer content, and adds integration instructions for all supported MCP clients.

### Changes

**`README.md`** — rewritten to be end-user focused:
- Production endpoint `https://mcp.lfx.dev/mcp` prominently at the top
- Setup instructions for Claude and Cursor with their OAuth client IDs
- Setup instructions for stdio-only clients via `mcp-remote` (Zed shown as example), using port 3334 with `--static-oauth-client-info`
- MCP Inspector instructions for developer testing
- Note that running locally (stdio mode) is not a supported end-user configuration
- Full tools reference table retained

**`DEVELOPER.md`** — new file with all developer content moved from README:
- Prerequisites and build instructions
- Running locally (stdio and HTTP modes) with caveat about OAuth limitations
- Full configuration flag/env var reference table
- Code quality, testing (automated, integration script, manual stdio/HTTP)
- Logging and debug traffic flags
- Project structure
- Adding new tools guide (with example code)
- Build system target reference

### Notes

- The mcp-remote and MCP Inspector client IDs in README are marked TBD — they will be filled in once the companion auth0-terraform PR is merged and deployed.

Closes ARCH-354 (partial — auth0-terraform PR also required)
Epic: ARCH-319