### PR TITLE
Enforce read:all / manage:all scopes on MCP tool calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Client (Claude, etc.) → JSON-RPC 2.0 → stdio transport → MCP Server → To
 ### Key Design Principles
 
 1. **Simplicity**: Minimal abstraction layers using the official MCP Go SDK
-2. **Extensibility**: Easy to add new tools through the `mcp.AddTool` pattern
+2. **Extensibility**: Easy to add new tools through the `AddToolWithScopes` pattern
 3. **Type Safety**: Strong typing with automatic schema generation
 4. **Testability**: Simple stdio testing via JSON-RPC messages
 5. **Observability**: Structured JSON logging with optional debug mode
@@ -211,19 +211,32 @@ mcpLogger.Error("tool operation failed", "error", err)
 
 ## Adding New Tools
 
-The MCP Go SDK provides a simple pattern for adding tools. Tools are implemented in the `internal/tools` package and registered with the server.
+The MCP Go SDK provides a simple pattern for adding tools. Tools are implemented in the `internal/tools` package and registered with the server. Every tool **must** be registered via `AddToolWithScopes` (defined in `internal/tools/scopes.go`) so that scope enforcement is applied automatically in HTTP mode. In stdio mode (no auth), the scope check is skipped.
+
+### Scope Enforcement
+
+Two scope constants are defined in `internal/tools/scopes.go`:
+
+| Constant | Value | Used for |
+|----------|-------|----------|
+| `ScopeRead` | `read:all` | Tools with `ReadOnlyHint: true` |
+| `ScopeManage` | `manage:all` | Tools where `ReadOnlyHint` is `false` (the default) |
+
+Use the helper functions `ReadScopes()` and `WriteScopes()` when registering tools.
+
+When a caller's JWT token lacks the required scope, the tool returns a structured `IsError` result (not a JSON-RPC error), keeping the failure inside the MCP tool-call protocol.
 
 ### Tool Implementation Steps
 
 1. **Create a new file** in `internal/tools/` (e.g., `my_tool.go`)
 2. **Define the input struct** with JSON schema tags
 3. **Implement the handler function** with tool logic
-4. **Create a registration function** to register with the server
+4. **Create a registration function** using `AddToolWithScopes` with the correct scope
 5. **Call the registration function** in `main.go`
 
 ### Example Tool Implementation
 
-**File: `internal/tools/my_tool.go`**
+**File: `internal/tools/my_tool.go`** (read-only tool)
 
 ```go
 // Copyright The Linux Foundation and contributors.
@@ -246,14 +259,14 @@ type MyToolArgs struct {
 
 // RegisterMyTool registers the my_tool tool with the MCP server.
 func RegisterMyTool(server *mcp.Server) {
-    mcp.AddTool(server, &mcp.Tool{
+    AddToolWithScopes(server, &mcp.Tool{
         Name:        "my_tool",
         Description: "Brief description of what the tool does",
         Annotations: &mcp.ToolAnnotations{
             Title:        "My Tool",
             ReadOnlyHint: true,
         },
-    }, handleMyTool)
+    }, ReadScopes(), handleMyTool)
 }
 
 // handleMyTool implements the my_tool tool logic.
@@ -265,6 +278,21 @@ func handleMyTool(ctx context.Context, req *mcp.CallToolRequest, args MyToolArgs
             &mcp.TextContent{Text: result},
         },
     }, nil, nil
+}
+```
+
+For a **write tool** (where `ReadOnlyHint` is `false` / unset), use `WriteScopes()` instead:
+
+```go
+func RegisterMyWriteTool(server *mcp.Server) {
+    AddToolWithScopes(server, &mcp.Tool{
+        Name:        "create_thing",
+        Description: "Create a new thing",
+        Annotations: &mcp.ToolAnnotations{
+            Title:           "Create Thing",
+            DestructiveHint: boolPtr(false),
+        },
+    }, WriteScopes(), handleCreateThing)
 }
 ```
 
@@ -533,7 +561,7 @@ func(ctx context.Context, req *mcp.CallToolRequest, args MyToolArgs) (*mcp.CallT
 
 1. **Add Tools**: Create new tools in `internal/tools/` following the established pattern
 2. **Tool Organization**: One tool per file (e.g., `hello_world.go`, `my_tool.go`)
-3. **Registration Pattern**: Each tool should have a `Register<ToolName>(server)` function
+3. **Registration Pattern**: Each tool should have a `Register<ToolName>(server)` function that calls `AddToolWithScopes` with `ReadScopes()` or `WriteScopes()` — never call `mcp.AddTool` directly
 4. **Schema Tags**: Always include descriptive `jsonschema` tags
 5. **Testing**: Test new tools with the test script (`./scripts/test_server.sh`)
 6. **Documentation**: Update README.md for user-facing changes

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -530,10 +530,18 @@ func runHTTPServer(cfg Config) {
 			resourceURL = fmt.Sprintf("http://%s:%d/mcp", cfg.HTTP.Host, cfg.HTTP.Port)
 		}
 
+		// Use defaults when no scopes are configured, then validate to ensure
+		// the enforced scopes are always present and warn about unknown ones.
+		scopesSupported := cfg.MCPAPI.Scopes
+		if len(scopesSupported) == 0 {
+			scopesSupported = tools.DefaultScopes()
+		}
+		scopesSupported = tools.ValidateScopes(scopesSupported, logger.Warn)
+
 		metadata := &oauthex.ProtectedResourceMetadata{
 			Resource:             resourceURL,
 			AuthorizationServers: authServers,
-			ScopesSupported:      cfg.MCPAPI.Scopes,
+			ScopesSupported:      scopesSupported,
 		}
 
 		mux.Handle("/.well-known/oauth-protected-resource", auth.ProtectedResourceMetadataHandler(metadata))

--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -38,50 +38,50 @@ func SetCommitteeConfig(cfg *CommitteeConfig) {
 
 // RegisterSearchCommittees registers the search_committees tool with the MCP server.
 func RegisterSearchCommittees(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_committees",
 		Description: "Search for LFX committees by name using the LFX query service. Optionally filter by project UID.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Committees",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchCommittees)
+	}, ReadScopes(), handleSearchCommittees)
 }
 
 // RegisterGetCommittee registers the get_committee tool with the MCP server.
 func RegisterGetCommittee(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_committee",
 		Description: "Get an LFX committee's base info and settings by its UID. Privileged committee settings may be omitted if the caller lacks sufficient permissions.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Committee",
 			ReadOnlyHint: true,
 		},
-	}, handleGetCommittee)
+	}, ReadScopes(), handleGetCommittee)
 }
 
 // RegisterGetCommitteeMember registers the get_committee_member tool with the MCP server.
 func RegisterGetCommitteeMember(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_committee_member",
 		Description: "Get a specific committee member by committee UID and member UID.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Committee Member",
 			ReadOnlyHint: true,
 		},
-	}, handleGetCommitteeMember)
+	}, ReadScopes(), handleGetCommitteeMember)
 }
 
 // RegisterSearchCommitteeMembers registers the search_committee_members tool with the MCP server.
 func RegisterSearchCommitteeMembers(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_committee_members",
 		Description: "Search for LFX committee members. Optionally filter by committee UID, project UID (v2), and/or name. At least one filter is recommended but not required.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Committee Members",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchCommitteeMembers)
+	}, ReadScopes(), handleSearchCommitteeMembers)
 }
 
 // SearchCommitteesArgs defines the input parameters for the search_committees tool.

--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -135,19 +135,19 @@ type DeleteCommitteeMemberArgs struct {
 
 // RegisterCreateCommittee registers the create_committee tool with the MCP server.
 func RegisterCreateCommittee(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "create_committee",
 		Description: "Create a new committee under a project.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Create Committee",
 			DestructiveHint: boolPtr(false),
 		},
-	}, handleCreateCommittee)
+	}, WriteScopes(), handleCreateCommittee)
 }
 
 // RegisterUpdateCommittee registers the update_committee tool with the MCP server.
 func RegisterUpdateCommittee(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "update_committee",
 		Description: "Update a committee's base information (name, category, visibility, etc.). Only provided fields are changed; omitted fields keep their current values.",
 		Annotations: &mcp.ToolAnnotations{
@@ -155,12 +155,12 @@ func RegisterUpdateCommittee(server *mcp.Server) {
 			DestructiveHint: boolPtr(true),
 			IdempotentHint:  true,
 		},
-	}, handleUpdateCommittee)
+	}, WriteScopes(), handleUpdateCommittee)
 }
 
 // RegisterUpdateCommitteeSettings registers the update_committee_settings tool with the MCP server.
 func RegisterUpdateCommitteeSettings(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "update_committee_settings",
 		Description: "Update a committee's settings (member visibility, email requirements, meeting attendee defaults). Only provided fields are changed; omitted fields keep their current values.",
 		Annotations: &mcp.ToolAnnotations{
@@ -168,36 +168,36 @@ func RegisterUpdateCommitteeSettings(server *mcp.Server) {
 			DestructiveHint: boolPtr(true),
 			IdempotentHint:  true,
 		},
-	}, handleUpdateCommitteeSettings)
+	}, WriteScopes(), handleUpdateCommitteeSettings)
 }
 
 // RegisterDeleteCommittee registers the delete_committee tool with the MCP server.
 func RegisterDeleteCommittee(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "delete_committee",
 		Description: "Delete a committee by its UID.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Delete Committee",
 			DestructiveHint: boolPtr(true),
 		},
-	}, handleDeleteCommittee)
+	}, WriteScopes(), handleDeleteCommittee)
 }
 
 // RegisterCreateCommitteeMember registers the create_committee_member tool with the MCP server.
 func RegisterCreateCommitteeMember(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "create_committee_member",
 		Description: "Add a new member to a committee.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Create Committee Member",
 			DestructiveHint: boolPtr(false),
 		},
-	}, handleCreateCommitteeMember)
+	}, WriteScopes(), handleCreateCommitteeMember)
 }
 
 // RegisterUpdateCommitteeMember registers the update_committee_member tool with the MCP server.
 func RegisterUpdateCommitteeMember(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "update_committee_member",
 		Description: "Update an existing committee member's information. Only provided fields are changed; omitted fields keep their current values.",
 		Annotations: &mcp.ToolAnnotations{
@@ -205,19 +205,19 @@ func RegisterUpdateCommitteeMember(server *mcp.Server) {
 			DestructiveHint: boolPtr(true),
 			IdempotentHint:  true,
 		},
-	}, handleUpdateCommitteeMember)
+	}, WriteScopes(), handleUpdateCommitteeMember)
 }
 
 // RegisterDeleteCommitteeMember registers the delete_committee_member tool with the MCP server.
 func RegisterDeleteCommitteeMember(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "delete_committee_member",
 		Description: "Remove a member from a committee.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Delete Committee Member",
 			DestructiveHint: boolPtr(true),
 		},
-	}, handleDeleteCommitteeMember)
+	}, WriteScopes(), handleDeleteCommitteeMember)
 }
 
 // --- Handler helpers ---

--- a/internal/tools/hello_world.go
+++ b/internal/tools/hello_world.go
@@ -20,7 +20,7 @@ type HelloWorldArgs struct {
 
 // RegisterHelloWorld registers the hello_world tool with the MCP server.
 func RegisterHelloWorld(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "hello_world",
 		Description: "A simple hello world tool that greets the user with an optional custom message",
 		Annotations: &mcp.ToolAnnotations{
@@ -28,7 +28,7 @@ func RegisterHelloWorld(server *mcp.Server) {
 			ReadOnlyHint:  true,
 			OpenWorldHint: boolPtr(false),
 		},
-	}, handleHelloWorld)
+	}, ReadScopes(), handleHelloWorld)
 }
 
 // handleHelloWorld implements the hello_world tool logic.

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -71,62 +71,62 @@ type SearchMailingListsArgs struct {
 
 // RegisterGetMailingListService registers the get_mailing_list_service tool with the MCP server.
 func RegisterGetMailingListService(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_mailing_list_service",
 		Description: "Get a mailing list service's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Mailing List Service",
 			ReadOnlyHint: true,
 		},
-	}, handleGetMailingListService)
+	}, ReadScopes(), handleGetMailingListService)
 }
 
 // RegisterGetMailingList registers the get_mailing_list tool with the MCP server.
 func RegisterGetMailingList(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_mailing_list",
 		Description: "Get a mailing list's base info and settings by its UID. Privileged settings may be omitted if the caller lacks sufficient permissions.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Mailing List",
 			ReadOnlyHint: true,
 		},
-	}, handleGetMailingList)
+	}, ReadScopes(), handleGetMailingList)
 }
 
 // RegisterGetMailingListMember registers the get_mailing_list_member tool with the MCP server.
 func RegisterGetMailingListMember(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_mailing_list_member",
 		Description: "Get a specific mailing list member by mailing list UID and member UID.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Mailing List Member",
 			ReadOnlyHint: true,
 		},
-	}, handleGetMailingListMember)
+	}, ReadScopes(), handleGetMailingListMember)
 }
 
 // RegisterSearchMailingListMembers registers the search_mailing_list_members tool with the MCP server.
 func RegisterSearchMailingListMembers(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_mailing_list_members",
 		Description: "Search for LFX mailing list members. Optionally filter by mailing list UID, project UID (v2), and/or name. At least one filter is recommended but not required.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Mailing List Members",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchMailingListMembers)
+	}, ReadScopes(), handleSearchMailingListMembers)
 }
 
 // RegisterSearchMailingLists registers the search_mailing_lists tool with the MCP server.
 func RegisterSearchMailingLists(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_mailing_lists",
 		Description: "Search for LFX mailing lists by name using the LFX query service. Optionally filter by project UID.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Mailing Lists",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchMailingLists)
+	}, ReadScopes(), handleSearchMailingLists)
 }
 
 // handleGetMailingListService implements the get_mailing_list_service tool logic.

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -46,122 +46,122 @@ func SetMeetingConfig(cfg *MeetingConfig) {
 
 // RegisterSearchMeetings registers the search_meetings tool with the MCP server.
 func RegisterSearchMeetings(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_meetings",
 		Description: "Search for LFX meetings using the query service. Supports filtering by project, committee, date range, and other fields.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Meetings",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchMeetings)
+	}, ReadScopes(), handleSearchMeetings)
 }
 
 // RegisterGetMeeting registers the get_meeting tool with the MCP server.
 func RegisterGetMeeting(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_meeting",
 		Description: "Get an LFX meeting by its UID using the query service.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Meeting",
 			ReadOnlyHint: true,
 		},
-	}, handleGetMeeting)
+	}, ReadScopes(), handleGetMeeting)
 }
 
 // RegisterSearchMeetingRegistrants registers the search_meeting_registrants tool with the MCP server.
 func RegisterSearchMeetingRegistrants(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_meeting_registrants",
 		Description: "Search for LFX meeting registrants using the query service. Supports filtering by meeting, committee, project, date range, and other fields.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Meeting Registrants",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchMeetingRegistrants)
+	}, ReadScopes(), handleSearchMeetingRegistrants)
 }
 
 // RegisterGetMeetingRegistrant registers the get_meeting_registrant tool with the MCP server.
 func RegisterGetMeetingRegistrant(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_meeting_registrant",
 		Description: "Get an LFX meeting registrant by its UID using the query service.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Meeting Registrant",
 			ReadOnlyHint: true,
 		},
-	}, handleGetMeetingRegistrant)
+	}, ReadScopes(), handleGetMeetingRegistrant)
 }
 
 // RegisterSearchPastMeetingParticipants registers the search_past_meeting_participants tool with the MCP server.
 func RegisterSearchPastMeetingParticipants(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_past_meeting_participants",
 		Description: "Search for LFX past meeting participants using the query service. Supports filtering by meeting, committee, project, and other fields.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meeting Participants",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchPastMeetingParticipants)
+	}, ReadScopes(), handleSearchPastMeetingParticipants)
 }
 
 // RegisterGetPastMeetingParticipant registers the get_past_meeting_participant tool with the MCP server.
 func RegisterGetPastMeetingParticipant(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_past_meeting_participant",
 		Description: "Get an LFX past meeting participant by its UID using the query service.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Past Meeting Participant",
 			ReadOnlyHint: true,
 		},
-	}, handleGetPastMeetingParticipant)
+	}, ReadScopes(), handleGetPastMeetingParticipant)
 }
 
 // RegisterSearchPastMeetingTranscripts registers the search_past_meeting_transcripts tool with the MCP server.
 func RegisterSearchPastMeetingTranscripts(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_past_meeting_transcripts",
 		Description: "Search for LFX past meeting transcripts using the query service. Supports filtering by meeting, committee, project, and other fields.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meeting Transcripts",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchPastMeetingTranscripts)
+	}, ReadScopes(), handleSearchPastMeetingTranscripts)
 }
 
 // RegisterGetPastMeetingTranscript registers the get_past_meeting_transcript tool with the MCP server.
 func RegisterGetPastMeetingTranscript(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_past_meeting_transcript",
 		Description: "Get an LFX past meeting transcript by its UID using the query service.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Past Meeting Transcript",
 			ReadOnlyHint: true,
 		},
-	}, handleGetPastMeetingTranscript)
+	}, ReadScopes(), handleGetPastMeetingTranscript)
 }
 
 // RegisterSearchPastMeetingSummaries registers the search_past_meeting_summaries tool with the MCP server.
 func RegisterSearchPastMeetingSummaries(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_past_meeting_summaries",
 		Description: "Search for LFX past meeting summaries using the query service. Supports filtering by meeting, committee, project, and other fields.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meeting Summaries",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchPastMeetingSummaries)
+	}, ReadScopes(), handleSearchPastMeetingSummaries)
 }
 
 // RegisterGetPastMeetingSummary registers the get_past_meeting_summary tool with the MCP server.
 func RegisterGetPastMeetingSummary(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_past_meeting_summary",
 		Description: "Get an LFX past meeting summary by its UID using the query service.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Past Meeting Summary",
 			ReadOnlyHint: true,
 		},
-	}, handleGetPastMeetingSummary)
+	}, ReadScopes(), handleGetPastMeetingSummary)
 }
 
 // SearchMeetingsArgs defines the input parameters for the search_meetings tool.

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -60,38 +60,38 @@ type GetMembershipKeyContactsArgs struct {
 
 // RegisterSearchMembers registers the search_members tool with the MCP server.
 func RegisterSearchMembers(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_members",
 		Description: "Search and filter members (memberships). Use this tool when users ask about members, memberships, or member organizations. Supports free-text search and filtering by status, membership_type, account_id, project_id, product_id, year, tier (e.g. gold, platinum, silver), contact_id, and auto_renew. Uses offset-based pagination.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Members",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchMembers)
+	}, ReadScopes(), handleSearchMembers)
 }
 
 // RegisterGetMemberMembership registers the get_member_membership tool with the MCP server.
 func RegisterGetMemberMembership(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_member_membership",
 		Description: "Get a single member's membership by member ID and membership ID. Use this when users ask for details about a specific member or membership.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Member Membership",
 			ReadOnlyHint: true,
 		},
-	}, handleGetMemberMembership)
+	}, ReadScopes(), handleGetMemberMembership)
 }
 
 // RegisterGetMembershipKeyContacts registers the get_membership_key_contacts tool with the MCP server.
 func RegisterGetMembershipKeyContacts(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_membership_key_contacts",
 		Description: "Get key contacts for a member's membership by member ID and membership ID. Returns the people associated with a member such as primary contacts and board members.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Membership Key Contacts",
 			ReadOnlyHint: true,
 		},
-	}, handleGetMembershipKeyContacts)
+	}, ReadScopes(), handleGetMembershipKeyContacts)
 }
 
 // handleSearchMembers implements the search_members tool logic.

--- a/internal/tools/project.go
+++ b/internal/tools/project.go
@@ -35,26 +35,26 @@ func SetProjectConfig(cfg *ProjectConfig) {
 
 // RegisterSearchProjects registers the search_projects tool with the MCP server.
 func RegisterSearchProjects(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_projects",
 		Description: "Search for LFX projects by name using the LFX query service",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Projects",
 			ReadOnlyHint: true,
 		},
-	}, handleSearchProjects)
+	}, ReadScopes(), handleSearchProjects)
 }
 
 // RegisterGetProject registers the get_project tool with the MCP server.
 func RegisterGetProject(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "get_project",
 		Description: "Get an LFX project's base info and settings by its UID. Privileged project settings may be omitted if the caller lacks sufficient permissions.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Project",
 			ReadOnlyHint: true,
 		},
-	}, handleGetProject)
+	}, ReadScopes(), handleGetProject)
 }
 
 // SearchProjectsArgs defines the input parameters for the search_projects tool.

--- a/internal/tools/scopes.go
+++ b/internal/tools/scopes.go
@@ -1,0 +1,121 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+// Package tools provides MCP tool implementations for the LFX MCP server.
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Scope constants used to gate tool access based on the caller's JWT scopes.
+// These MUST match the scopes defined on the Auth0 resource server for the
+// LFX MCP API (see auth0-terraform resource_servers.tf, lfx_mcp_api).
+const (
+	// ScopeRead is required for tools that only read data (ReadOnlyHint == true).
+	ScopeRead = "read:all"
+
+	// ScopeManage is required for tools that mutate data (ReadOnlyHint defaults to false).
+	ScopeManage = "manage:all"
+)
+
+// DefaultScopes returns the set of scopes the server advertises via the OAuth
+// Protected Resource Metadata endpoint. This is the enforced set plus the
+// standard OIDC scopes that clients typically need for the authorization flow.
+func DefaultScopes() []string {
+	return []string{"openid", "profile", "email", ScopeRead, ScopeManage}
+}
+
+// ValidateScopes checks a configured scope list for unrecognised entries and
+// returns it unchanged. It logs a warning for any scope that is neither an
+// enforced scope nor a standard OIDC scope — those will be advertised via the
+// PRM but are not enforced by the server. Omitting an enforced scope from the
+// configured list is intentional and allowed; enforcement at dispatch time is
+// independent of what is advertised.
+func ValidateScopes(configured []string, warn func(msg string, args ...any)) []string {
+	known := map[string]struct{}{
+		"openid":    {},
+		"profile":   {},
+		"email":     {},
+		ScopeRead:   {},
+		ScopeManage: {},
+	}
+
+	for _, s := range configured {
+		if _, ok := known[s]; !ok {
+			warn("unrecognised scope in configuration — it will be advertised but is not enforced by the server", "scope", s)
+		}
+	}
+
+	return configured
+}
+
+// AddToolWithScopes registers a tool on the server and wraps its handler so
+// that the caller's JWT scopes are checked before the handler is invoked.
+//
+// requiredScopes lists the scopes the caller must possess (any one is
+// sufficient). If the caller's token is missing all of the required scopes the
+// tool returns a structured IsError result rather than a JSON-RPC error, which
+// keeps the failure inside the MCP tool-call protocol.
+//
+// When no TokenInfo is present (e.g. stdio transport with no auth) the scope
+// check is skipped so that local development is not blocked.
+func AddToolWithScopes[In, Out any](
+	server *mcp.Server,
+	tool *mcp.Tool,
+	requiredScopes []string,
+	handler mcp.ToolHandlerFor[In, Out],
+) {
+	wrapped := func(ctx context.Context, req *mcp.CallToolRequest, args In) (*mcp.CallToolResult, Out, error) {
+		// Skip enforcement when there is no auth context (e.g. stdio mode).
+		if req.Extra != nil && req.Extra.TokenInfo != nil {
+			if !hasAnyScope(req.Extra.TokenInfo.Scopes, requiredScopes) {
+				var zero Out
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{
+						&mcp.TextContent{
+							Text: fmt.Sprintf(
+								"Error: insufficient scope — this tool requires one of [%s]",
+								strings.Join(requiredScopes, ", "),
+							),
+						},
+					},
+					IsError: true,
+				}, zero, nil
+			}
+		}
+		return handler(ctx, req, args)
+	}
+
+	mcp.AddTool(server, tool, wrapped)
+}
+
+// hasAnyScope returns true if the token's scopes contain at least one of the
+// required scopes.
+func hasAnyScope(tokenScopes, required []string) bool {
+	set := make(map[string]struct{}, len(tokenScopes))
+	for _, s := range tokenScopes {
+		set[s] = struct{}{}
+	}
+	for _, r := range required {
+		if _, ok := set[r]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ReadScopes returns the scope list for read-only tools.
+func ReadScopes() []string {
+	return []string{ScopeRead}
+}
+
+// WriteScopes returns the scope list for write tools. A token carrying the
+// manage scope is sufficient; the read scope is not required.
+func WriteScopes() []string {
+	return []string{ScopeManage}
+}

--- a/internal/tools/user_info.go
+++ b/internal/tools/user_info.go
@@ -35,14 +35,14 @@ func SetUserInfoConfig(cfg *UserInfoConfig) {
 
 // RegisterUserInfo registers the user_info tool with the MCP server.
 func RegisterUserInfo(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
+	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "user_info",
 		Description: "Get the authenticated user's OpenID Connect profile by proxying to the /userinfo endpoint",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "User Info",
 			ReadOnlyHint: true,
 		},
-	}, handleUserInfo)
+	}, ReadScopes(), handleUserInfo)
 }
 
 // handleUserInfo implements the user_info tool logic.


### PR DESCRIPTION
## Summary

Adds scope-based access control so that tool calls are gated on the caller's JWT scopes. All tool registrations now go through `AddToolWithScopes` (in `internal/tools/scopes.go`) rather than calling `mcp.AddTool` directly.

Jira: [ARCH-356](https://linuxfoundation.atlassian.net/browse/ARCH-356)

## Changes

- **`internal/tools/scopes.go`** (new) — defines `ScopeRead` (`read:all`) and `ScopeManage` (`manage:all`), matching the Auth0 resource server scopes in `auth0-terraform`. Provides `AddToolWithScopes`, `ReadScopes()`, `WriteScopes()`, `DefaultScopes()`, and `ValidateScopes()`.
- **All `Register*` functions** — switched from `mcp.AddTool` to `AddToolWithScopes` with `ReadScopes()` for read-only tools and `WriteScopes()` for write tools.
- **`cmd/lfx-mcp-server/main.go`** — PRM `scopes_supported` defaults to the full known scope set (`openid profile email read:all manage:all`) when `LFXMCP_MCP_API_SCOPES` is not configured. `ValidateScopes` warns at startup about any unrecognised scope values.
- **`AGENTS.md`** — documents `AddToolWithScopes`, the scope constants, and the rule that `mcp.AddTool` must never be called directly.

## Behaviour

| Scenario | Result |
|---|---|
| Token has `read:all`, calls a read tool | ✅ Allowed |
| Token has `read:all`, calls a write tool | ❌ `IsError` result with "insufficient scope" message |
| Token has `manage:all`, calls any tool | ✅ Allowed |
| stdio mode (no TokenInfo) | ✅ Scope check skipped — local dev unaffected |

## Notes

- `tools/list` still returns all registered tools regardless of scopes — filtering that is tracked separately in [ARCH-357](https://linuxfoundation.atlassian.net/browse/ARCH-357).
- Operators may advertise a subset of scopes via `LFXMCP_MCP_API_SCOPES`; enforcement at dispatch time is independent of what the PRM advertises.


[ARCH-356]: https://linuxfoundation.atlassian.net/browse/ARCH-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARCH-357]: https://linuxfoundation.atlassian.net/browse/ARCH-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ