### PR TITLE
Fix mailing list resource type constants

### DIFF
--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -17,10 +17,10 @@ import (
 )
 
 // mailingListResourceType is the resource type filter for mailing list queries.
-const mailingListResourceType = "grpsio_mailing_list"
+const mailingListResourceType = "groupsio_mailing_list"
 
 // mailingListMemberResourceType is the resource type filter for mailing list member queries.
-const mailingListMemberResourceType = "grpsio_mailing_list_member"
+const mailingListMemberResourceType = "groupsio_member"
 
 // MailingListConfig holds configuration shared by mailing list tools.
 type MailingListConfig struct {


### PR DESCRIPTION
## Summary
- Fix typo in mailing list resource type: `grpsio_mailing_list` → `groupsio_mailing_list`
- Correct mailing list member resource type: `grpsio_mailing_list_member` → `groupsio_member`

## Test plan
- [ ] Verify mailing list search tools return results with corrected resource types
- [ ] Verify mailing list member search tools return results with corrected resource type

Signed-off-by: Nirav Patel <npatel@linuxfoundation.org>