### PR TITLE
Log token verification errors to aid debugging

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -486,6 +486,7 @@ func runHTTPServer(cfg Config) {
 		verifyToken := func(ctx context.Context, tokenString string, _ *http.Request) (*auth.TokenInfo, error) {
 			token, err := jwtVerifier.VerifyToken(ctx, tokenString)
 			if err != nil {
+				logger.Error("token verification failed", errKey, err)
 				return nil, err
 			}
 


### PR DESCRIPTION
Token verification failures were silently returning HTTP 500 with no server-side log, making it impossible to diagnose the root cause from pod logs alone.