### PR TITLE
Return 401 for invalid tokens instead of 500

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -487,10 +487,13 @@ func runHTTPServer(cfg Config) {
 		verifyToken := func(ctx context.Context, tokenString string, _ *http.Request) (*auth.TokenInfo, error) {
 			token, err := jwtVerifier.VerifyToken(ctx, tokenString)
 			if err != nil {
-				logger.Debug("token verification failed", errKey, err)
 				if errors.Is(err, lfxauth.ErrTokenInvalid) {
+					// Expected invalid/expired token: log at debug and wrap as auth.ErrInvalidToken.
+					logger.Debug("token verification failed", errKey, err)
 					return nil, fmt.Errorf("%w: %w", auth.ErrInvalidToken, err)
 				}
+				// Infrastructure or unexpected verification failure: log at error level.
+				logger.Error("token verification failed", errKey, err)
 				return nil, err
 			}
 

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -486,7 +487,10 @@ func runHTTPServer(cfg Config) {
 		verifyToken := func(ctx context.Context, tokenString string, _ *http.Request) (*auth.TokenInfo, error) {
 			token, err := jwtVerifier.VerifyToken(ctx, tokenString)
 			if err != nil {
-				logger.Error("token verification failed", errKey, err)
+				logger.Debug("token verification failed", errKey, err)
+				if errors.Is(err, lfxauth.ErrTokenInvalid) {
+					return nil, fmt.Errorf("%w: %w", auth.ErrInvalidToken, err)
+				}
 				return nil, err
 			}
 

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -487,13 +487,14 @@ func runHTTPServer(cfg Config) {
 		verifyToken := func(ctx context.Context, tokenString string, _ *http.Request) (*auth.TokenInfo, error) {
 			token, err := jwtVerifier.VerifyToken(ctx, tokenString)
 			if err != nil {
-				if errors.Is(err, lfxauth.ErrTokenInvalid) {
-					// Expected invalid/expired token: log at debug and wrap as auth.ErrInvalidToken.
+				if errors.Is(err, auth.ErrInvalidToken) {
+					// Expected invalid/expired token: log at debug and return as-is
+					// (jwt_verifier already wraps with auth.ErrInvalidToken).
 					logger.Debug("token verification failed", errKey, err)
-					return nil, fmt.Errorf("%w: %w", auth.ErrInvalidToken, err)
+				} else {
+					// Infrastructure or unexpected verification failure: log at error level.
+					logger.Error("token verification failed", errKey, err)
 				}
-				// Infrastructure or unexpected verification failure: log at error level.
-				logger.Error("token verification failed", errKey, err)
 				return nil, err
 			}
 

--- a/internal/auth/jwt_verifier.go
+++ b/internal/auth/jwt_verifier.go
@@ -6,6 +6,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,6 +15,11 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 )
+
+// ErrTokenInvalid is returned when a token fails validation (bad format, unknown
+// issuer, expired, bad signature, etc.). Callers can distinguish this from
+// infrastructure errors (e.g. JWKS fetch failures) using errors.Is.
+var ErrTokenInvalid = errors.New("token invalid")
 
 // JWTVerifierConfig holds configuration for JWT verification.
 type JWTVerifierConfig struct {
@@ -84,12 +90,12 @@ func (v *JWTVerifier) VerifyToken(ctx context.Context, tokenString string) (jwt.
 	// Parse token to get the issuer for JWKS lookup.
 	unverifiedToken, err := jwt.ParseString(tokenString, jwt.WithVerify(false), jwt.WithValidate(false))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse token: %w", err)
+		return nil, fmt.Errorf("%w: failed to parse token: %w", ErrTokenInvalid, err)
 	}
 
 	issuer := unverifiedToken.Issuer()
 	if issuer == "" {
-		return nil, fmt.Errorf("token missing issuer claim")
+		return nil, fmt.Errorf("%w: token missing issuer claim", ErrTokenInvalid)
 	}
 
 	// Normalize issuer (remove trailing slash).
@@ -106,12 +112,14 @@ func (v *JWTVerifier) VerifyToken(ctx context.Context, tokenString string) (jwt.
 	}
 
 	if jwksURL == "" {
-		return nil, fmt.Errorf("token issuer %s not in configured auth servers", issuer)
+		return nil, fmt.Errorf("%w: token issuer %s not in configured auth servers", ErrTokenInvalid, issuer)
 	}
 
 	// Fetch JWKS from cache.
 	keySet, err := v.jwksCache.Get(ctx, jwksURL)
 	if err != nil {
+		// Infrastructure error — do not wrap as ErrTokenInvalid; the token itself
+		// may be valid and the caller should not retry with a new token.
 		return nil, fmt.Errorf("failed to fetch JWKS from %s: %w", jwksURL, err)
 	}
 
@@ -123,7 +131,7 @@ func (v *JWTVerifier) VerifyToken(ctx context.Context, tokenString string) (jwt.
 		jwt.WithAudience(v.config.Audience),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("token verification failed: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrTokenInvalid, err)
 	}
 
 	return token, nil

--- a/internal/auth/jwt_verifier.go
+++ b/internal/auth/jwt_verifier.go
@@ -6,20 +6,16 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 )
-
-// ErrTokenInvalid is returned when a token fails validation (bad format, unknown
-// issuer, expired, bad signature, etc.). Callers can distinguish this from
-// infrastructure errors (e.g. JWKS fetch failures) using errors.Is.
-var ErrTokenInvalid = errors.New("token invalid")
 
 // JWTVerifierConfig holds configuration for JWT verification.
 type JWTVerifierConfig struct {
@@ -90,12 +86,12 @@ func (v *JWTVerifier) VerifyToken(ctx context.Context, tokenString string) (jwt.
 	// Parse token to get the issuer for JWKS lookup.
 	unverifiedToken, err := jwt.ParseString(tokenString, jwt.WithVerify(false), jwt.WithValidate(false))
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to parse token: %w", ErrTokenInvalid, err)
+		return nil, fmt.Errorf("%w: failed to parse token: %w", sdkauth.ErrInvalidToken, err)
 	}
 
 	issuer := unverifiedToken.Issuer()
 	if issuer == "" {
-		return nil, fmt.Errorf("%w: token missing issuer claim", ErrTokenInvalid)
+		return nil, fmt.Errorf("%w: token missing issuer claim", sdkauth.ErrInvalidToken)
 	}
 
 	// Normalize issuer (remove trailing slash).
@@ -112,7 +108,7 @@ func (v *JWTVerifier) VerifyToken(ctx context.Context, tokenString string) (jwt.
 	}
 
 	if jwksURL == "" {
-		return nil, fmt.Errorf("%w: token issuer %s not in configured auth servers", ErrTokenInvalid, issuer)
+		return nil, fmt.Errorf("%w: token issuer %s not in configured auth servers", sdkauth.ErrInvalidToken, issuer)
 	}
 
 	// Fetch JWKS from cache.
@@ -131,7 +127,7 @@ func (v *JWTVerifier) VerifyToken(ctx context.Context, tokenString string) (jwt.
 		jwt.WithAudience(v.config.Audience),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrTokenInvalid, err)
+		return nil, fmt.Errorf("%w: %w", sdkauth.ErrInvalidToken, err)
 	}
 
 	return token, nil


### PR DESCRIPTION
Add ErrTokenInvalid sentinel to the JWT verifier and wrap all token-level errors (bad format, unknown issuer, expired, bad signature) with it. Map these to auth.ErrInvalidToken in the HTTP verifier so the SDK returns 401. JWKS fetch failures remain 500 since they are infrastructure errors and the client should not retry with a new token.

Token verification failures are logged at debug level as they represent normal client behaviour (expired tokens, etc.) rather than server errors.