### PR TITLE
fix(lfxv2): use client_credentials grant for M2M token callers

### DIFF
--- a/internal/lfxv2/client.go
+++ b/internal/lfxv2/client.go
@@ -414,15 +414,30 @@ func (a *authInterceptor) RoundTrip(req *http.Request) (*http.Response, error) {
 	return a.base.RoundTrip(reqClone)
 }
 
-// getOrExchangeToken gets a cached LFX token or performs token exchange.
+// m2mCacheKey is the cache key used for all M2M token requests. Since M2M callers
+// all receive the same LFX token (minted via client_credentials), a single entry
+// covers them all rather than one entry per unique M2M subject token.
+const m2mCacheKey = "__m2m__"
+
+// getOrExchangeToken gets a cached LFX token or obtains a new one.
+// For user tokens, it performs RFC 8693 token exchange.
+// For M2M tokens (Auth0 @clients subject), it uses the client_credentials grant
+// because Auth0 cannot exchange M2M tokens via token exchange (no user to propagate).
 func (c *Clients) getOrExchangeToken(ctx context.Context, mcpToken string) (string, error) {
 	if c.tokenExchangeClient == nil {
 		return "", fmt.Errorf("token exchange client not configured")
 	}
 
+	// M2M tokens all share a single cached LFX token obtained via client_credentials.
+	useClientCredentials := isM2MToken(mcpToken)
+	cacheKey := mcpToken
+	if useClientCredentials {
+		cacheKey = m2mCacheKey
+	}
+
 	// Check cache first (read lock).
 	c.mu.RLock()
-	cached, exists := c.tokenCache[mcpToken]
+	cached, exists := c.tokenCache[cacheKey]
 	c.mu.RUnlock()
 
 	// Return cached token if valid.
@@ -430,25 +445,31 @@ func (c *Clients) getOrExchangeToken(ctx context.Context, mcpToken string) (stri
 		return cached.accessToken, nil
 	}
 
-	// Need to exchange token (write lock).
+	// Need to fetch token (write lock).
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	// Double-check cache in case another goroutine just updated it.
-	cached, exists = c.tokenCache[mcpToken]
+	cached, exists = c.tokenCache[cacheKey]
 	if exists && time.Now().Before(cached.expiry) {
 		return cached.accessToken, nil
 	}
 
-	// Perform token exchange.
-	resp, err := c.tokenExchangeClient.ExchangeToken(ctx, mcpToken)
+	// Obtain LFX token via the appropriate grant type.
+	var resp *TokenExchangeResponse
+	var err error
+	if useClientCredentials {
+		resp, err = c.tokenExchangeClient.ClientCredentials(ctx)
+	} else {
+		resp, err = c.tokenExchangeClient.ExchangeToken(ctx, mcpToken)
+	}
 	if err != nil {
 		return "", err
 	}
 
-	// Cache the exchanged token with 5-minute buffer.
+	// Cache the token with a 5-minute buffer before expiry.
 	expiryBuffer := 5 * time.Minute
-	c.tokenCache[mcpToken] = &cachedToken{
+	c.tokenCache[cacheKey] = &cachedToken{
 		accessToken: resp.AccessToken,
 		expiry:      time.Now().Add(time.Duration(resp.ExpiresIn)*time.Second - expiryBuffer),
 	}

--- a/internal/lfxv2/token_exchange.go
+++ b/internal/lfxv2/token_exchange.go
@@ -149,44 +149,49 @@ func (c *TokenExchangeClient) generateClientAssertion() (string, error) {
 	return string(signed), nil
 }
 
-// ExchangeToken exchanges a subject token for a new access token per RFC 8693.
-func (c *TokenExchangeClient) ExchangeToken(ctx context.Context, subjectToken string) (*TokenExchangeResponse, error) {
-	// Build token exchange request per RFC 8693 Section 2.1.
-	data := url.Values{}
-	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
-	data.Set("client_id", c.config.ClientID)
-	data.Set("subject_token", subjectToken)
-	data.Set("subject_token_type", c.config.SubjectTokenType)
-	data.Set("audience", c.config.Audience)
+// isM2MToken reports whether token is a machine-to-machine (client credentials)
+// JWT, identified by Auth0's convention of a subject claim ending in "@clients".
+func isM2MToken(token string) bool {
+	parsed, err := jwt.ParseInsecure([]byte(token))
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(parsed.Subject(), "@clients")
+}
 
-	// Use client assertion if signing key is provided, otherwise use client secret.
+// addClientAuth adds client authentication fields (secret or JWT assertion) to data.
+func (c *TokenExchangeClient) addClientAuth(data url.Values) error {
 	if c.config.ClientAssertionSigningKey != "" {
 		assertion, err := c.generateClientAssertion()
 		if err != nil {
-			return nil, fmt.Errorf("failed to generate client assertion: %w", err)
+			return fmt.Errorf("failed to generate client assertion: %w", err)
 		}
 		data.Set("client_assertion", assertion)
 		data.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
 	} else {
 		data.Set("client_secret", c.config.ClientSecret)
 	}
+	return nil
+}
 
+// postTokenRequest sends a token request and returns the parsed response.
+func (c *TokenExchangeClient) postTokenRequest(ctx context.Context, data url.Values) (*TokenExchangeResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.config.TokenEndpoint, strings.NewReader(data.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create token exchange request: %w", err)
+		return nil, fmt.Errorf("failed to create token request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to exchange token: %w", err)
+		return nil, fmt.Errorf("failed to execute token request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read token exchange response: %w", err)
+		return nil, fmt.Errorf("failed to read token response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -195,8 +200,41 @@ func (c *TokenExchangeClient) ExchangeToken(ctx context.Context, subjectToken st
 
 	var tokenResp TokenExchangeResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return nil, fmt.Errorf("failed to parse token exchange response: %w", err)
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
 	}
 
 	return &tokenResp, nil
+}
+
+// ExchangeToken exchanges a subject token for a new access token per RFC 8693.
+func (c *TokenExchangeClient) ExchangeToken(ctx context.Context, subjectToken string) (*TokenExchangeResponse, error) {
+	data := url.Values{}
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	data.Set("client_id", c.config.ClientID)
+	data.Set("subject_token", subjectToken)
+	data.Set("subject_token_type", c.config.SubjectTokenType)
+	data.Set("audience", c.config.Audience)
+
+	if err := c.addClientAuth(data); err != nil {
+		return nil, err
+	}
+
+	return c.postTokenRequest(ctx, data)
+}
+
+// ClientCredentials obtains an LFX API token using the client_credentials grant.
+// This is used when the caller presents an M2M token, which Auth0 cannot exchange
+// via RFC 8693 token exchange (it requires a user subject). Instead, the MCP server
+// mints a fresh LFX token using its own client identity.
+func (c *TokenExchangeClient) ClientCredentials(ctx context.Context) (*TokenExchangeResponse, error) {
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", c.config.ClientID)
+	data.Set("audience", c.config.Audience)
+
+	if err := c.addClientAuth(data); err != nil {
+		return nil, err
+	}
+
+	return c.postTokenRequest(ctx, data)
 }


### PR DESCRIPTION
Auth0's token exchange (RFC 8693) requires a user subject to propagate identity. When an M2M token is presented (Auth0 sub ends in @clients), the exchange fails with "User not found" because there is no user to look up. Since the M2M token only has audience for the MCP API — not the LFX v2 API — it also can't be passed through directly.

Detect M2M tokens by inspecting the sub claim and fall back to a client_credentials grant so the MCP server mints its own LFX token. All M2M callers share a single cache entry since they all receive the same LFX token regardless of which M2M subject token they presented.