### PR TITLE
feat(ARCH-363): add list_project_tiers, get_project_tier, get_membership_key_contact tools

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -90,9 +90,12 @@ var defaultTools = []string{
 	"get_mailing_list_member",
 	"search_mailing_lists",
 	"search_mailing_list_members",
+	"list_project_tiers",
+	"get_project_tier",
 	"search_members",
 	"get_member_membership",
 	"get_membership_key_contacts",
+	"get_membership_key_contact",
 	"create_membership_key_contact",
 	"update_membership_key_contact",
 	"delete_membership_key_contact",
@@ -389,6 +392,12 @@ func newServer(cfg Config) *mcp.Server {
 	if enabledTools["search_mailing_list_members"] {
 		tools.RegisterSearchMailingListMembers(server)
 	}
+	if enabledTools["list_project_tiers"] {
+		tools.RegisterListProjectTiers(server)
+	}
+	if enabledTools["get_project_tier"] {
+		tools.RegisterGetProjectTier(server)
+	}
 	if enabledTools["search_members"] {
 		tools.RegisterSearchMembers(server)
 	}
@@ -397,6 +406,9 @@ func newServer(cfg Config) *mcp.Server {
 	}
 	if enabledTools["get_membership_key_contacts"] {
 		tools.RegisterGetMembershipKeyContacts(server)
+	}
+	if enabledTools["get_membership_key_contact"] {
+		tools.RegisterGetMembershipKeyContact(server)
 	}
 	if enabledTools["create_membership_key_contact"] {
 		tools.RegisterCreateMembershipKeyContact(server)

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ go 1.26.0
 require (
 	github.com/knadh/koanf/providers/basicflag v1.1.0
 	github.com/knadh/koanf/providers/env/v2 v2.0.0
-	github.com/knadh/koanf/v2 v2.3.3
+	github.com/knadh/koanf/v2 v2.3.4
 	github.com/lestrrat-go/jwx/v2 v2.1.6
-	github.com/linuxfoundation/lfx-v2-committee-service v0.2.20
-	github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10
-	github.com/linuxfoundation/lfx-v2-member-service v0.3.0
+	github.com/linuxfoundation/lfx-v2-committee-service v0.2.22
+	github.com/linuxfoundation/lfx-v2-mailing-list-service v0.3.0
+	github.com/linuxfoundation/lfx-v2-member-service v0.3.1
 	github.com/linuxfoundation/lfx-v2-project-service v0.5.7
 	github.com/linuxfoundation/lfx-v2-query-service v0.4.12
 	github.com/modelcontextprotocol/go-sdk v1.4.1
@@ -22,7 +22,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
 	github.com/go-chi/chi/v5 v5.2.5 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
+github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -27,6 +29,8 @@ github.com/knadh/koanf/providers/env/v2 v2.0.0 h1:Ad5H3eun722u+FvchiIcEIJZsZ2M6o
 github.com/knadh/koanf/providers/env/v2 v2.0.0/go.mod h1:1g01PE+Ve1gBfWNNw2wmULRP0tc8RJrjn5p2N/jNCIc=
 github.com/knadh/koanf/v2 v2.3.3 h1:jLJC8XCRfLC7n4F+ZKKdBsbq1bfXTpuFhf4L7t94D94=
 github.com/knadh/koanf/v2 v2.3.3/go.mod h1:gRb40VRAbd4iJMYYD5IxZ6hfuopFcXBpc9bbQpZwo28=
+github.com/knadh/koanf/v2 v2.3.4 h1:fnynNSDlujWE+v83hAp8wKr/cdoxHLO0629SN+U8Urc=
+github.com/knadh/koanf/v2 v2.3.4/go.mod h1:gRb40VRAbd4iJMYYD5IxZ6hfuopFcXBpc9bbQpZwo28=
 github.com/lestrrat-go/blackmagic v1.0.4 h1:IwQibdnf8l2KoO+qC3uT4OaTWsW7tuRQXy9TRN9QanA=
 github.com/lestrrat-go/blackmagic v1.0.4/go.mod h1:6AWFyKNNj0zEXQYfTMPfZrAXUWUfTIZ5ECEUEJaijtw=
 github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZrIE=
@@ -41,10 +45,16 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/linuxfoundation/lfx-v2-committee-service v0.2.20 h1:lyqDzceQba+KjrvXFHJJSFiycNUBzbHSnya3fQJezlM=
 github.com/linuxfoundation/lfx-v2-committee-service v0.2.20/go.mod h1:zhJDE23mzaiUv1ZACoelN8w9JoUb/Kt9TPuHxU89T9Q=
+github.com/linuxfoundation/lfx-v2-committee-service v0.2.22 h1:/zrQGAT4zrRd02BRkpJUWp4Rrx5+ihIptWMiVA1AQ4Y=
+github.com/linuxfoundation/lfx-v2-committee-service v0.2.22/go.mod h1:8Jry9qGxz9bMDKrukMK60w4CkElPJC61wm0omZU63Sk=
 github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10 h1:OG+usJ9DZDMT5d9YZ+H53v0+BBTKsq7cqRAakLxlGvs=
 github.com/linuxfoundation/lfx-v2-mailing-list-service v0.1.10/go.mod h1:d78d8z0Ll17hsRzKK3QtNj1ssMIDkJ5kgm5pV8KmB3Q=
+github.com/linuxfoundation/lfx-v2-mailing-list-service v0.3.0 h1:CS6zl1ZqL7GTaj3VxOwTSonK9thJQS1ea0XTru1XEBI=
+github.com/linuxfoundation/lfx-v2-mailing-list-service v0.3.0/go.mod h1:2vY8kKHA8EJi/MPTAN3fQPqX+s2Il/VSgVs4w4HmpEI=
 github.com/linuxfoundation/lfx-v2-member-service v0.3.0 h1:mGcd3x461hkwGwxLNnRopu55hV11TuDfzuw1IzD/UT8=
 github.com/linuxfoundation/lfx-v2-member-service v0.3.0/go.mod h1:qMzCkX1KayvzmxZQhVL2+dX1jXHqU3CcRGZ/t41vbgs=
+github.com/linuxfoundation/lfx-v2-member-service v0.3.1 h1:JEwK9S3io/uT2hCgplil0iQYfXRmW/YcozNOylqEJNE=
+github.com/linuxfoundation/lfx-v2-member-service v0.3.1/go.mod h1:qMzCkX1KayvzmxZQhVL2+dX1jXHqU3CcRGZ/t41vbgs=
 github.com/linuxfoundation/lfx-v2-project-service v0.5.7 h1:qycjiPSogIIHhRXDFSa0Zxu5ZLb/4jt9I8/JJmAJ0M4=
 github.com/linuxfoundation/lfx-v2-project-service v0.5.7/go.mod h1:JCQZhtqf6lqxG0LA55qbQrTFwV3oSdAoLKn/1BvcMe4=
 github.com/linuxfoundation/lfx-v2-query-service v0.4.12 h1:2sp/7zyhzsq8slNTWefixzjAI88yBYGYPuOjcnGke7I=

--- a/internal/lfxv2/client.go
+++ b/internal/lfxv2/client.go
@@ -198,6 +198,17 @@ func NewClients(_ context.Context, cfg ClientConfig) (*Clients, error) {
 		committeeHTTPClient.GetCommitteeMember(),
 		committeeHTTPClient.UpdateCommitteeMember(),
 		committeeHTTPClient.DeleteCommitteeMember(),
+		committeeHTTPClient.GetInvite(),
+		committeeHTTPClient.CreateInvite(),
+		committeeHTTPClient.RevokeInvite(),
+		committeeHTTPClient.AcceptInvite(),
+		committeeHTTPClient.DeclineInvite(),
+		committeeHTTPClient.GetApplication(),
+		committeeHTTPClient.SubmitApplication(),
+		committeeHTTPClient.ApproveApplication(),
+		committeeHTTPClient.RejectApplication(),
+		committeeHTTPClient.JoinCommittee(),
+		committeeHTTPClient.LeaveCommittee(),
 	)
 
 	// Initialize mailing list service client.

--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -76,7 +76,7 @@ func RegisterGetCommitteeMember(server *mcp.Server) {
 func RegisterSearchCommitteeMembers(server *mcp.Server) {
 	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_committee_members",
-		Description: "Search for LFX committee members. Optionally filter by committee UID, project UID (v2), and/or name. At least one filter is recommended but not required.",
+		Description: "Search for LFX committee members. Optionally filter by committee UID, project UID, and/or name. At least one filter is recommended but not required.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Committee Members",
 			ReadOnlyHint: true,
@@ -87,26 +87,26 @@ func RegisterSearchCommitteeMembers(server *mcp.Server) {
 // SearchCommitteesArgs defines the input parameters for the search_committees tool.
 type SearchCommitteesArgs struct {
 	Name       string `json:"name,omitempty" jsonschema:"Name or partial name of the committee to search for"`
-	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional v2 project UID to filter committees by project (e.g. a27394a3-7a6c-4d0f-9e0f-692d8753924f)"`
+	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional project UID to filter committees by project"`
 	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // GetCommitteeArgs defines the input parameters for the get_committee tool.
 type GetCommitteeArgs struct {
-	UID string `json:"uid" jsonschema:"The v2 UID of the committee to retrieve"`
+	UID string `json:"uid" jsonschema:"The UID of the committee to retrieve"`
 }
 
 // GetCommitteeMemberArgs defines the input parameters for the get_committee_member tool.
 type GetCommitteeMemberArgs struct {
-	CommitteeUID string `json:"committee_uid" jsonschema:"The v2 UID of the committee"`
-	MemberUID    string `json:"member_uid" jsonschema:"The v2 UID of the committee member"`
+	CommitteeUID string `json:"committee_uid" jsonschema:"The UID of the committee"`
+	MemberUID    string `json:"member_uid" jsonschema:"The UID of the committee member"`
 }
 
 // SearchCommitteeMembersArgs defines the input parameters for the search_committee_members tool.
 type SearchCommitteeMembersArgs struct {
-	CommitteeUID string `json:"committee_uid,omitempty" jsonschema:"Optional v2 UID of the committee to filter members by"`
-	ProjectUID   string `json:"project_uid,omitempty" jsonschema:"Optional v2 project UID to filter committee members by project (e.g. a27394a3-7a6c-4d0f-9e0f-692d8753924f)"`
+	CommitteeUID string `json:"committee_uid,omitempty" jsonschema:"Optional UID of the committee to filter members by"`
+	ProjectUID   string `json:"project_uid,omitempty" jsonschema:"Optional project UID to filter committee members by project"`
 	Name         string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
 	PageSize     int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -38,24 +38,24 @@ func SetMailingListConfig(cfg *MailingListConfig) {
 
 // GetMailingListServiceArgs defines the input parameters for the get_mailing_list_service tool.
 type GetMailingListServiceArgs struct {
-	UID string `json:"uid" jsonschema:"The v2 UID of the mailing list service to retrieve"`
+	UID string `json:"uid" jsonschema:"The UID of the mailing list service to retrieve"`
 }
 
 // GetMailingListArgs defines the input parameters for the get_mailing_list tool.
 type GetMailingListArgs struct {
-	UID string `json:"uid" jsonschema:"The v2 UID of the mailing list to retrieve"`
+	UID string `json:"uid" jsonschema:"The UID of the mailing list to retrieve"`
 }
 
 // GetMailingListMemberArgs defines the input parameters for the get_mailing_list_member tool.
 type GetMailingListMemberArgs struct {
-	MailingListUID string `json:"mailing_list_uid" jsonschema:"The v2 UID of the mailing list"`
-	MemberUID      string `json:"member_uid" jsonschema:"The v2 UID of the mailing list member"`
+	MailingListUID string `json:"mailing_list_uid" jsonschema:"The UID of the mailing list"`
+	MemberUID      string `json:"member_uid" jsonschema:"The UID of the mailing list member"`
 }
 
 // SearchMailingListMembersArgs defines the input parameters for the search_mailing_list_members tool.
 type SearchMailingListMembersArgs struct {
-	MailingListUID string `json:"mailing_list_uid,omitempty" jsonschema:"Optional v2 UID of the mailing list to filter members by"`
-	ProjectUID     string `json:"project_uid,omitempty" jsonschema:"Optional v2 project UID to filter mailing list members by project"`
+	MailingListUID string `json:"mailing_list_uid,omitempty" jsonschema:"Optional UID of the mailing list to filter members by"`
+	ProjectUID     string `json:"project_uid,omitempty" jsonschema:"Optional project UID to filter mailing list members by project"`
 	Name           string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
 	PageSize       int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10)"`
 	PageToken      string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -64,7 +64,7 @@ type SearchMailingListMembersArgs struct {
 // SearchMailingListsArgs defines the input parameters for the search_mailing_lists tool.
 type SearchMailingListsArgs struct {
 	Name       string `json:"name,omitempty" jsonschema:"Name or partial name of the mailing list to search for"`
-	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional v2 project UID to filter mailing lists by project (e.g. a27394a3-7a6c-4d0f-9e0f-692d8753924f)"`
+	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional project UID to filter mailing lists by project"`
 	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10)"`
 	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
@@ -109,7 +109,7 @@ func RegisterGetMailingListMember(server *mcp.Server) {
 func RegisterSearchMailingListMembers(server *mcp.Server) {
 	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_mailing_list_members",
-		Description: "Search for LFX mailing list members. Optionally filter by mailing list UID, project UID (v2), and/or name. At least one filter is recommended but not required.",
+		Description: "Search for LFX mailing list members. Optionally filter by mailing list UID, project UID, and/or name. At least one filter is recommended but not required.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Mailing List Members",
 			ReadOnlyHint: true,

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -32,24 +32,42 @@ func SetMemberConfig(cfg *MemberConfig) {
 
 // SearchMembersArgs defines the input parameters for the search_members tool.
 type SearchMembersArgs struct {
-	ProjectUID string `json:"project_uid" jsonschema:"V2 project UUID (required)"`
+	ProjectUID string `json:"project_uid" jsonschema:"Project UUID (required)"`
 	Search     string `json:"search,omitempty" jsonschema:"Free-text search across company name, project name, and tier"`
 	TierUID    string `json:"tier_uid,omitempty" jsonschema:"Filter by membership tier UID (UUID from list_project_tiers)"`
 	Sort       string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
-	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (1-1000, default 25)"`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque cursor from a previous response to fetch the next page"`
 }
 
 // GetMemberMembershipArgs defines the input parameters for the get_member_membership tool.
 type GetMemberMembershipArgs struct {
-	ProjectUID string `json:"project_uid" jsonschema:"V2 project UUID"`
+	ProjectUID string `json:"project_uid" jsonschema:"Project UUID"`
 	ID         string `json:"id" jsonschema:"The membership UID"`
 }
 
 // GetMembershipKeyContactsArgs defines the input parameters for the get_membership_key_contacts tool.
 type GetMembershipKeyContactsArgs struct {
-	ProjectUID string `json:"project_uid" jsonschema:"V2 project UUID"`
+	ProjectUID string `json:"project_uid" jsonschema:"Project UUID"`
 	ID         string `json:"id" jsonschema:"The membership UID"`
+}
+
+// ListProjectTiersArgs defines the input parameters for the list_project_tiers tool.
+type ListProjectTiersArgs struct {
+	ProjectUID string `json:"project_uid" jsonschema:"Project UUID (required)"`
+}
+
+// GetProjectTierArgs defines the input parameters for the get_project_tier tool.
+type GetProjectTierArgs struct {
+	ProjectUID string `json:"project_uid" jsonschema:"Project UUID (required)"`
+	TierID     string `json:"tier_id" jsonschema:"Membership tier UID"`
+}
+
+// GetMembershipKeyContactArgs defines the input parameters for the get_membership_key_contact tool.
+type GetMembershipKeyContactArgs struct {
+	ProjectUID string `json:"project_uid" jsonschema:"Project UUID"`
+	ID         string `json:"id" jsonschema:"The membership UID"`
+	Cid        string `json:"cid" jsonschema:"Key contact UID"`
 }
 
 // RegisterSearchMembers registers the search_members tool with the MCP server.
@@ -76,6 +94,30 @@ func RegisterGetMemberMembership(server *mcp.Server) {
 	}, ReadScopes(), handleGetMemberMembership)
 }
 
+// RegisterListProjectTiers registers the list_project_tiers tool with the MCP server.
+func RegisterListProjectTiers(server *mcp.Server) {
+	AddToolWithScopes(server, &mcp.Tool{
+		Name:        "list_project_tiers",
+		Description: "List all membership tiers (e.g. Gold, Silver, Bronze) defined for a project. Use this to discover available tier UIDs before filtering search_members by tier_uid.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "List Project Tiers",
+			ReadOnlyHint: true,
+		},
+	}, ReadScopes(), handleListProjectTiers)
+}
+
+// RegisterGetProjectTier registers the get_project_tier tool with the MCP server.
+func RegisterGetProjectTier(server *mcp.Server) {
+	AddToolWithScopes(server, &mcp.Tool{
+		Name:        "get_project_tier",
+		Description: "Get a single membership tier by project UID and tier UID.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Project Tier",
+			ReadOnlyHint: true,
+		},
+	}, ReadScopes(), handleGetProjectTier)
+}
+
 // RegisterGetMembershipKeyContacts registers the get_membership_key_contacts tool with the MCP server.
 func RegisterGetMembershipKeyContacts(server *mcp.Server) {
 	AddToolWithScopes(server, &mcp.Tool{
@@ -86,6 +128,18 @@ func RegisterGetMembershipKeyContacts(server *mcp.Server) {
 			ReadOnlyHint: true,
 		},
 	}, ReadScopes(), handleGetMembershipKeyContacts)
+}
+
+// RegisterGetMembershipKeyContact registers the get_membership_key_contact tool with the MCP server.
+func RegisterGetMembershipKeyContact(server *mcp.Server) {
+	AddToolWithScopes(server, &mcp.Tool{
+		Name:        "get_membership_key_contact",
+		Description: "Get a single key contact for a membership by project UID, membership UID, and key contact UID.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Membership Key Contact",
+			ReadOnlyHint: true,
+		},
+	}, ReadScopes(), handleGetMembershipKeyContact)
 }
 
 // handleSearchMembers implements the search_members tool logic.
@@ -141,7 +195,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 
 	pageSize := args.PageSize
 	if pageSize <= 0 {
-		pageSize = 25
+		pageSize = 10
 	}
 
 	// Build filter string from non-empty filter args.
@@ -302,6 +356,192 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 	}, nil, nil
 }
 
+// handleListProjectTiers implements the list_project_tiers tool logic.
+func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args ListProjectTiersArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if memberConfig == nil {
+		logger.Error("member tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: member tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.ProjectUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: project_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           memberConfig.LFXAPIURL,
+		TokenExchangeClient: memberConfig.TokenExchangeClient,
+		DebugLogger:         memberConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("listing project tiers", "project_uid", args.ProjectUID)
+
+	version := "1"
+	result, err := clients.Member.ListProjectTiers(ctx, &memberservice.ListProjectTiersPayload{
+		Version:    &version,
+		ProjectUID: &args.ProjectUID,
+	})
+	if err != nil {
+		logger.Error("ListProjectTiers failed", "error", err, "project_uid", args.ProjectUID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to list project tiers: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result.Tiers, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal tiers result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("list_project_tiers succeeded", "project_uid", args.ProjectUID, "count", len(result.Tiers))
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleGetProjectTier implements the get_project_tier tool logic.
+func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args GetProjectTierArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if memberConfig == nil {
+		logger.Error("member tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: member tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.ProjectUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: project_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.TierID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: tier_id is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           memberConfig.LFXAPIURL,
+		TokenExchangeClient: memberConfig.TokenExchangeClient,
+		DebugLogger:         memberConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("fetching project tier", "project_uid", args.ProjectUID, "tier_id", args.TierID)
+
+	version := "1"
+	result, err := clients.Member.GetProjectTier(ctx, &memberservice.GetProjectTierPayload{
+		Version:    &version,
+		ProjectUID: &args.ProjectUID,
+		TierID:     &args.TierID,
+	})
+	if err != nil {
+		logger.Error("GetProjectTier failed", "error", err, "project_uid", args.ProjectUID, "tier_id", args.TierID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get project tier: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result.Tier, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal tier result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("get_project_tier succeeded", "project_uid", args.ProjectUID, "tier_id", args.TierID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
 // handleGetMembershipKeyContacts implements the get_membership_key_contacts tool logic.
 func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactsArgs) (*mcp.CallToolResult, any, error) {
 	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
@@ -392,6 +632,114 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 	}
 
 	logger.Info("get_membership_key_contacts succeeded", "project_uid", args.ProjectUID, "id", args.ID)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(prettyJSON)},
+		},
+	}, nil, nil
+}
+
+// handleGetMembershipKeyContact implements the get_membership_key_contact tool logic.
+func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactArgs) (*mcp.CallToolResult, any, error) {
+	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+
+	if memberConfig == nil {
+		logger.Error("member tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: member tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.ProjectUID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: project_uid is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.ID == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: id (membership UID) is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if args.Cid == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: cid (key contact UID) is required"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.Error("failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = lfxv2.WithMCPToken(ctx, mcpToken)
+
+	clients, err := lfxv2.NewClients(ctx, lfxv2.ClientConfig{
+		APIDomain:           memberConfig.LFXAPIURL,
+		TokenExchangeClient: memberConfig.TokenExchangeClient,
+		DebugLogger:         memberConfig.DebugLogger,
+	})
+	if err != nil {
+		logger.Error("failed to create LFX v2 clients", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to connect to LFX API: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("fetching membership key contact", "project_uid", args.ProjectUID, "id", args.ID, "cid", args.Cid)
+
+	version := "1"
+	result, err := clients.Member.GetMembershipKeyContact(ctx, &memberservice.GetMembershipKeyContactPayload{
+		Version:    &version,
+		ProjectUID: &args.ProjectUID,
+		ID:         &args.ID,
+		Cid:        &args.Cid,
+	})
+	if err != nil {
+		logger.Error("GetMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "id", args.ID, "cid", args.Cid)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get membership key contact: %s", lfxv2.ErrorMessage(err))},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(result.Contact, "", "  ")
+	if err != nil {
+		logger.Error("failed to marshal key contact result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.Info("get_membership_key_contact succeeded", "project_uid", args.ProjectUID, "id", args.ID, "cid", args.Cid)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/internal/tools/member_write.go
+++ b/internal/tools/member_write.go
@@ -20,7 +20,7 @@ import (
 // CreateMembershipKeyContactArgs defines the input parameters for the
 // create_membership_key_contact tool.
 type CreateMembershipKeyContactArgs struct {
-	ProjectUID     string  `json:"project_uid" jsonschema:"V2 project UUID"`
+	ProjectUID     string  `json:"project_uid" jsonschema:"Project UUID"`
 	ID             string  `json:"id" jsonschema:"Membership UID"`
 	Email          string  `json:"email" jsonschema:"Contact email address; used to resolve or create the Salesforce Contact record"`
 	FirstName      string  `json:"first_name" jsonschema:"Contact first name; used when creating a new Contact on miss"`
@@ -36,7 +36,7 @@ type CreateMembershipKeyContactArgs struct {
 // update_membership_key_contact tool. Only provided (non-nil) fields are
 // updated; omitted fields retain their current values.
 type UpdateMembershipKeyContactArgs struct {
-	ProjectUID     string  `json:"project_uid" jsonschema:"V2 project UUID"`
+	ProjectUID     string  `json:"project_uid" jsonschema:"Project UUID"`
 	ID             string  `json:"id" jsonschema:"Membership UID"`
 	Cid            string  `json:"cid" jsonschema:"Key contact UID"`
 	Role           *string `json:"role,omitempty" jsonschema:"Contact role designation, e.g. 'Voting Representative'"`
@@ -48,7 +48,7 @@ type UpdateMembershipKeyContactArgs struct {
 // DeleteMembershipKeyContactArgs defines the input parameters for the
 // delete_membership_key_contact tool.
 type DeleteMembershipKeyContactArgs struct {
-	ProjectUID string `json:"project_uid" jsonschema:"V2 project UUID"`
+	ProjectUID string `json:"project_uid" jsonschema:"Project UUID"`
 	ID         string `json:"id" jsonschema:"Membership UID"`
 	Cid        string `json:"cid" jsonschema:"Key contact UID to remove"`
 }

--- a/internal/tools/project.go
+++ b/internal/tools/project.go
@@ -66,7 +66,7 @@ type SearchProjectsArgs struct {
 
 // GetProjectArgs defines the input parameters for the get_project tool.
 type GetProjectArgs struct {
-	UID string `json:"uid" jsonschema:"The v2 UID of the project to retrieve"`
+	UID string `json:"uid" jsonschema:"The UID of the project to retrieve"`
 }
 
 // handleSearchProjects implements the search_projects tool logic.


### PR DESCRIPTION
## ARCH-363: Add missing tier tools, get_membership_key_contact, and fix member tool inconsistencies

### New Tools

- **`list_project_tiers`** – Lists all membership tiers (e.g. Gold, Silver, Bronze) defined for a project. Useful for discovering tier UIDs before filtering `search_members` by `tier_uid`.
- **`get_project_tier`** – Retrieves a single membership tier by project UID and tier UID.
- **`get_membership_key_contact`** – Retrieves a single key contact for a membership by project UID, membership UID, and key contact UID.

### Consistency Fixes

- Standardized `search_members` default page size to 10 (max 100), matching other paginated tools (was 25/1000).
- Removed all user-facing references to "V2" from jsonschema descriptions and tool descriptions across committee, mailing list, and member tools.

### Dependency Updates

- `lfx-v2-member-service` → v0.3.1
- `lfx-v2-mailing-list-service` → v0.3.0
- `lfx-v2-committee-service` → v0.2.22 (adds 11 new endpoints: invites, applications, join/leave — wired into client initializer)
- `koanf/v2` → v2.3.4
- `goccy/go-json` → v0.10.6