### PR TITLE
feat: add temporary static API key authentication

### DIFF
--- a/charts/lfx-mcp/templates/deployment.yaml
+++ b/charts/lfx-mcp/templates/deployment.yaml
@@ -72,6 +72,20 @@ spec:
                   name: {{ .Values.secrets.name }}
                   key: {{ .Values.secrets.keys.clientAssertionSigningKey }}
                   optional: true
+            {{- /*
+              TEMPORARY: Expose each API key credential as an individual env var
+              LFXMCP_API_CREDENTIALS_<KEY>=<secret> sourced from the Secret referenced by
+              apiCredentials.secretName. Remove this block when static API key support is retired.
+            */}}
+            {{- if and .Values.apiCredentials .Values.apiCredentials.secretName .Values.apiCredentials.keys }}
+            {{- range $consumerKey, $secretKey := .Values.apiCredentials.keys }}
+            - name: {{ printf "LFXMCP_API_CREDENTIALS_%s" ($consumerKey | upper) }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.apiCredentials.secretName }}
+                  key: {{ $secretKey }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: web
               containerPort: {{ .Values.service.port }}

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -80,3 +80,34 @@ secrets:
     # assertions (used when authenticating with a JWT client assertion instead of a
     # client secret).
     clientAssertionSigningKey: client_assertion_signing_key
+# apiCredentials is a TEMPORARY stop-gap for MCP clients that cannot complete a full
+# OAuth2 authorization code flow. Remove this stanza once all clients support proper
+# OAuth2.
+#
+# NOTE: app.mcpApiAuthServers must also be set for API-key authentication to take
+# effect. apiCredentials is a fallback within the OAuth2 bearer-token middleware —
+# it is not an independent auth mechanism.
+#
+# When set, the Deployment will expose each consumer-key→secret pair as an individual
+# env var (LFXMCP_API_CREDENTIALS_<KEY>=<secret>) sourced from the referenced Secret.
+# Clients authenticate by passing the shared secret as "Authorization: Bearer <secret>".
+# Authenticated requests are granted the same scopes as an OAuth2 M2M
+# client_credentials token (read:all, manage:all).
+#
+# This stanza has NO default values and is entirely opt-in. Example:
+#
+#   apiCredentials:
+#     secretName: lfx-mcp-api-keys
+#     keys:
+#       my-client: my_client_api_key
+#
+# The Secret referenced by secretName must already exist before the chart is deployed.
+# Its data keys must match the values listed under apiCredentials.keys.
+#
+# apiCredentials:
+#   # secretName is the name of the pre-existing Kubernetes Secret holding the API key pairs.
+#   secretName: ""
+#   # keys maps API consumer identifiers (used as TokenInfo.UserID) to key names in the
+#   # Secret whose values are the corresponding shared-secret passwords.
+#   keys: {}
+#   #   my-client: my_client_api_key

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -44,6 +44,9 @@ type Config struct {
 	Tools                     []string     `koanf:"tools"`
 	Debug                     bool         `koanf:"debug"`
 	DebugTraffic              bool         `koanf:"debug_traffic"`
+	// APICredentials is a consumer-key→shared-secret map for static API-key auth.
+	// TEMPORARY: stop-gap for MCP clients that cannot complete OAuth2.
+	APICredentials map[string]string `koanf:"api_credentials"`
 }
 
 // HTTPConfig holds HTTP transport configuration.
@@ -165,6 +168,16 @@ func main() {
 			// Handle comma-separated lists.
 			if (key == "tools" || key == "mcp_api.auth_servers" || key == "mcp_api.scopes") && v != "" {
 				return key, strings.Split(v, ",")
+			}
+			// TEMPORARY: map LFXMCP_API_CREDENTIALS_<KEY>=<secret> env vars into the
+			// api_credentials koanf map. Each env var contributes one entry.
+			// Remove this block when static API key support is retired.
+			const apiCredPrefix = "api_credentials_"
+			if strings.HasPrefix(key, apiCredPrefix) {
+				credKey := strings.TrimPrefix(key, apiCredPrefix)
+				if credKey != "" {
+					return "api_credentials." + credKey, v
+				}
 			}
 			return key, v
 		},
@@ -495,7 +508,14 @@ func runHTTPServer(cfg Config) {
 	// accessible via kubectl port-forward but blocked from ingress traffic.
 	mux.Handle("/debug/vars", localhostOnly(expvar.Handler()))
 
-	// Apply OAuth bearer token middleware if auth servers are configured.
+	// TEMPORARY: build API-key verifier when credentials are configured.
+	// Returns nil when no credentials are set, so the check is zero-cost in the common path.
+	apiKeyVerifier := lfxauth.NewAPIKeyVerifier(cfg.APICredentials)
+	if apiKeyVerifier != nil {
+		logger.Info("static API-key authentication enabled (TEMPORARY)")
+	}
+
+	// Apply auth middleware to the /mcp handler.
 	var mcpHandler http.Handler = handler
 	if len(cfg.MCPAPI.AuthServers) > 0 {
 		// Use the public URL base for the resource metadata URL so that MCP clients
@@ -526,8 +546,22 @@ func runHTTPServer(cfg Config) {
 			os.Exit(1)
 		}
 
-		// Token verifier that performs full JWT signature verification.
+		// Token verifier that:
+		//  1. TEMPORARY: tries static API-key auth first when configured.
+		//  2. Falls back to full JWT signature verification.
 		verifyToken := func(ctx context.Context, tokenString string, _ *http.Request) (*auth.TokenInfo, error) {
+			// TEMPORARY: check whether the bearer value is a static API key.
+			if apiKeyVerifier != nil {
+				if info, handled, err := apiKeyVerifier.VerifyAPIKey(ctx, tokenString); handled {
+					if err != nil {
+						logger.Debug("api key verification failed", errKey, err)
+						return nil, err
+					}
+					return info, nil
+				}
+			}
+
+			// Standard JWT verification path.
 			token, err := jwtVerifier.VerifyToken(ctx, tokenString)
 			if err != nil {
 				if errors.Is(err, auth.ErrInvalidToken) {

--- a/internal/auth/apikey_verifier.go
+++ b/internal/auth/apikey_verifier.go
@@ -1,0 +1,115 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+// Package auth provides JWT verification with JWKS caching for the LFX MCP server.
+package auth
+
+// APIKeyVerifier validates static API-key credentials passed as Authorization: Bearer
+// tokens, and synthesises auth.TokenInfo equivalent to an OAuth2 M2M
+// client_credentials token.
+//
+// TEMPORARY: This is an intentional stop-gap for MCP clients that cannot complete a
+// full OAuth2 authorization code flow. It MUST be removed once all clients support
+// proper OAuth2.
+//
+// Authenticated requests carry Extra["api_key_auth"]=true in their TokenInfo. The
+// lfxv2 token-exchange layer checks this marker to select the client_credentials
+// grant instead of attempting to parse and exchange the bearer token as a JWT.
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+)
+
+// M2MScopes are the scopes granted to every API-key-authenticated request.
+// They mirror what an OAuth2 M2M client_credentials token carries.
+var M2MScopes = []string{"read:all", "manage:all"}
+
+// APIKeyVerifier validates Authorization: Bearer header values against a static map
+// of consumer-key → shared-secret pairs.
+//
+// TEMPORARY — see package-level comment.
+type APIKeyVerifier struct {
+	// credentials maps API consumer key identifiers to their shared-secret values.
+	credentials map[string]string
+}
+
+// NewAPIKeyVerifier creates a new verifier from the supplied key→secret map.
+// Returns nil when credentials is empty so callers can skip wiring it up entirely.
+//
+// TEMPORARY — see package-level comment.
+func NewAPIKeyVerifier(credentials map[string]string) *APIKeyVerifier {
+	if len(credentials) == 0 {
+		return nil
+	}
+	return &APIKeyVerifier{credentials: credentials}
+}
+
+// VerifyAPIKey checks whether the Authorization: Bearer value in the request matches
+// a known static secret.
+//
+// Return semantics:
+//   - (TokenInfo, true, nil)        — secret present and valid; caller should proceed.
+//   - (nil, true, ErrInvalidToken)  — bearer value present but not a known secret;
+//     caller must not fall through to JWT verification.
+//   - (nil, false, nil)             — no Authorization header present; caller should
+//     try the next verifier.
+//
+// The verifier is called from within the existing verifyToken closure, which already
+// receives the raw bearer value from RequireBearerToken. Callers should invoke this
+// before attempting JWT parsing.
+//
+// TEMPORARY — see package-level comment.
+func (v *APIKeyVerifier) VerifyAPIKey(_ context.Context, bearerValue string) (*sdkauth.TokenInfo, bool, error) {
+	if bearerValue == "" {
+		return nil, false, nil
+	}
+
+	// Reject anything that looks like a JWT so that real tokens always reach the
+	// JWT verifier rather than getting a spurious "invalid key" error.
+	if looksLikeJWT(bearerValue) {
+		return nil, false, nil
+	}
+
+	// Validate against known credentials.
+	for consumerKey, knownSecret := range v.credentials {
+		if knownSecret == bearerValue {
+			return buildTokenInfo(consumerKey), true, nil
+		}
+	}
+
+	// Bearer value was present and not a JWT, but didn't match any known secret.
+	return nil, true, sdkauth.ErrInvalidToken
+}
+
+// APIKeyAuthExtraKey is the key used in TokenInfo.Extra to signal that the request
+// was authenticated via a static API key rather than a bearer JWT. The lfxv2
+// token-exchange layer checks this marker to select the client_credentials grant.
+const APIKeyAuthExtraKey = "api_key_auth"
+
+// buildTokenInfo constructs a TokenInfo for a successfully authenticated API-key request.
+// Extra[APIKeyAuthExtraKey]=true signals to the lfxv2 token-exchange layer that it
+// should use the client_credentials grant rather than attempting to exchange the
+// bearer value as a JWT.
+//
+// TEMPORARY — see package-level comment.
+func buildTokenInfo(consumerKey string) *sdkauth.TokenInfo {
+	return &sdkauth.TokenInfo{
+		UserID:     consumerKey,
+		Scopes:     M2MScopes,
+		Expiration: time.Now().Add(time.Hour), // arbitrary; re-evaluated each request
+		Extra: map[string]any{
+			// Signals to lfxv2.getOrExchangeToken to use the client_credentials grant.
+			APIKeyAuthExtraKey: true,
+		},
+	}
+}
+
+// looksLikeJWT returns true when s has the structural signature of a compact-
+// serialised JWT: exactly two '.' separators (header.payload.signature).
+func looksLikeJWT(s string) bool {
+	return strings.Count(s, ".") == 2
+}

--- a/internal/lfxv2/client.go
+++ b/internal/lfxv2/client.go
@@ -86,12 +86,30 @@ func mcpTokenFromContext(ctx context.Context) string {
 	return ""
 }
 
+// apiKeyMCPToken is the sentinel value stored in the MCP token context when a
+// request was authenticated via a static API key. getOrExchangeToken recognises
+// this value and uses the client_credentials grant directly, bypassing the
+// RFC 8693 token-exchange path (which requires a real bearer token).
+//
+// TEMPORARY — remove when static API key support is retired.
+const apiKeyMCPToken = "__api_key__"
+
 // ExtractMCPToken extracts the raw MCP token from auth.TokenInfo.Extra.
 // This token can be passed to WithMCPToken for use in LFX API calls.
 // Returns an error if the token cannot be extracted.
+//
+// For requests authenticated via a static API key (Extra["api_key_auth"]==true),
+// the apiKeyMCPToken sentinel is returned so that the token-exchange layer uses
+// the client_credentials grant rather than attempting to exchange a bearer token.
 func ExtractMCPToken(tokenInfo *auth.TokenInfo) (string, error) {
 	if tokenInfo == nil || tokenInfo.Extra == nil {
 		return "", fmt.Errorf("tokenInfo or Extra map is nil")
+	}
+
+	// TEMPORARY: static API-key requests carry no bearer token; signal the
+	// token-exchange layer to use client_credentials instead.
+	if isAPIKey, _ := tokenInfo.Extra["api_key_auth"].(bool); isAPIKey {
+		return apiKeyMCPToken, nil
 	}
 
 	rawToken, ok := tokenInfo.Extra["raw_token"].(string)
@@ -434,13 +452,15 @@ const m2mCacheKey = "__m2m__"
 // For user tokens, it performs RFC 8693 token exchange.
 // For M2M tokens (Auth0 @clients subject), it uses the client_credentials grant
 // because Auth0 cannot exchange M2M tokens via token exchange (no user to propagate).
+// For static API-key requests (apiKeyMCPToken sentinel), it also uses the
+// client_credentials grant since there is no bearer token to exchange.
 func (c *Clients) getOrExchangeToken(ctx context.Context, mcpToken string) (string, error) {
 	if c.tokenExchangeClient == nil {
 		return "", fmt.Errorf("token exchange client not configured")
 	}
 
-	// M2M tokens all share a single cached LFX token obtained via client_credentials.
-	useClientCredentials := isM2MToken(mcpToken)
+	// API-key and M2M requests both use client_credentials; they share a cache entry.
+	useClientCredentials := mcpToken == apiKeyMCPToken || isM2MToken(mcpToken)
 	cacheKey := mcpToken
 	if useClientCredentials {
 		cacheKey = m2mCacheKey

--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -114,7 +114,7 @@ type SearchCommitteeMembersArgs struct {
 
 // handleSearchCommittees implements the search_committees tool logic.
 func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args SearchCommitteesArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if committeeConfig == nil {
 		logger.Error("committee tools not configured")
@@ -233,7 +233,7 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 // handleGetCommittee implements the get_committee tool logic, fetching both base
 // info and settings for the given committee UID.
 func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetCommitteeArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if committeeConfig == nil {
 		logger.Error("committee tools not configured")
@@ -342,7 +342,7 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 
 // handleGetCommitteeMember implements the get_committee_member tool logic.
 func handleGetCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, args GetCommitteeMemberArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if committeeConfig == nil {
 		logger.Error("committee tools not configured")
@@ -439,7 +439,7 @@ func handleGetCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, arg
 
 // handleSearchCommitteeMembers implements the search_committee_members tool logic.
 func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchCommitteeMembersArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if committeeConfig == nil {
 		logger.Error("committee tools not configured")

--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -225,7 +225,7 @@ func RegisterDeleteCommitteeMember(server *mcp.Server) {
 // committeeWriteClients creates LFX v2 clients for committee write operations,
 // returning the clients and MCP logger, or an error tool result.
 func committeeWriteClients(ctx context.Context, req *mcp.CallToolRequest) (context.Context, *lfxv2.Clients, *slog.Logger, *mcp.CallToolResult) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if committeeConfig == nil {
 		logger.Error("committee tools not configured")

--- a/internal/tools/hello_world.go
+++ b/internal/tools/hello_world.go
@@ -7,7 +7,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -34,7 +33,7 @@ func RegisterHelloWorld(server *mcp.Server) {
 // handleHelloWorld implements the hello_world tool logic.
 func handleHelloWorld(_ context.Context, req *mcp.CallToolRequest, args HelloWorldArgs) (*mcp.CallToolResult, any, error) {
 	// Create MCP logger that sends logs to the client.
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	// Extract name parameter with default.
 	name := "World"

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -4,6 +4,61 @@
 // Package tools provides MCP tool implementations for the LFX MCP server.
 package tools
 
+import (
+	"context"
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newToolLogger returns a logger that writes to both the MCP client session
+// (so the AI sees log output) and the server's default system logger (so
+// operators see it in server stdout/stderr).
+//
+// Use this for all tool log calls that matter to operators — errors, warnings,
+// and key informational events. For messages that are only useful to the MCP
+// client (e.g. "N results were filtered by permissions"), call
+// newToolLogger(req) directly instead.
+func newToolLogger(req *mcp.CallToolRequest) *slog.Logger {
+	mcpHandler := mcp.NewLoggingHandler(req.Session, nil)
+	sysHandler := slog.Default().Handler()
+	return slog.New(&teeHandler{mcp: mcpHandler, sys: sysHandler})
+}
+
+// teeHandler is an slog.Handler that forwards every record to two handlers.
+type teeHandler struct {
+	mcp slog.Handler
+	sys slog.Handler
+}
+
+func (t *teeHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return t.mcp.Enabled(ctx, level) || t.sys.Enabled(ctx, level)
+}
+
+func (t *teeHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Best-effort: forward to both, return the first non-nil error.
+	var firstErr error
+	if t.sys.Enabled(ctx, r.Level) {
+		if err := t.sys.Handle(ctx, r); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if t.mcp.Enabled(ctx, r.Level) {
+		if err := t.mcp.Handle(ctx, r); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (t *teeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &teeHandler{mcp: t.mcp.WithAttrs(attrs), sys: t.sys.WithAttrs(attrs)}
+}
+
+func (t *teeHandler) WithGroup(name string) slog.Handler {
+	return &teeHandler{mcp: t.mcp.WithGroup(name), sys: t.sys.WithGroup(name)}
+}
+
 // boolPtr returns a pointer to the given bool value. Used for optional
 // annotation fields that distinguish between "unset" and "false".
 func boolPtr(b bool) *bool {

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -131,7 +131,7 @@ func RegisterSearchMailingLists(server *mcp.Server) {
 
 // handleGetMailingListService implements the get_mailing_list_service tool logic.
 func handleGetMailingListService(ctx context.Context, req *mcp.CallToolRequest, args GetMailingListServiceArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if mailingListConfig == nil {
 		logger.Error("mailing list tools not configured")
@@ -237,7 +237,7 @@ func handleGetMailingListService(ctx context.Context, req *mcp.CallToolRequest, 
 
 // handleGetMailingList implements the get_mailing_list tool logic.
 func handleGetMailingList(ctx context.Context, req *mcp.CallToolRequest, args GetMailingListArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if mailingListConfig == nil {
 		logger.Error("mailing list tools not configured")
@@ -344,7 +344,7 @@ func handleGetMailingList(ctx context.Context, req *mcp.CallToolRequest, args Ge
 
 // handleGetMailingListMember implements the get_mailing_list_member tool logic.
 func handleGetMailingListMember(ctx context.Context, req *mcp.CallToolRequest, args GetMailingListMemberArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if mailingListConfig == nil {
 		logger.Error("mailing list tools not configured")
@@ -441,7 +441,7 @@ func handleGetMailingListMember(ctx context.Context, req *mcp.CallToolRequest, a
 
 // handleSearchMailingLists implements the search_mailing_lists tool logic.
 func handleSearchMailingLists(ctx context.Context, req *mcp.CallToolRequest, args SearchMailingListsArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if mailingListConfig == nil {
 		logger.Error("mailing list tools not configured")
@@ -556,7 +556,7 @@ func handleSearchMailingLists(ctx context.Context, req *mcp.CallToolRequest, arg
 
 // handleSearchMailingListMembers implements the search_mailing_list_members tool logic.
 func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchMailingListMembersArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if mailingListConfig == nil {
 		logger.Error("mailing list tools not configured")

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -253,7 +253,7 @@ type GetPastMeetingSummaryArgs struct {
 
 // handleSearchMeetings implements the search_meetings tool logic.
 func handleSearchMeetings(ctx context.Context, req *mcp.CallToolRequest, args SearchMeetingsArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if meetingConfig == nil {
 		logger.Error("meeting tools not configured")
@@ -399,7 +399,7 @@ func handleSearchMeetings(ctx context.Context, req *mcp.CallToolRequest, args Se
 
 // handleGetMeeting implements the get_meeting tool logic.
 func handleGetMeeting(ctx context.Context, req *mcp.CallToolRequest, args GetMeetingArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if meetingConfig == nil {
 		logger.Error("meeting tools not configured")
@@ -501,7 +501,7 @@ func handleGetMeeting(ctx context.Context, req *mcp.CallToolRequest, args GetMee
 
 // handleSearchMeetingRegistrants implements the search_meeting_registrants tool logic.
 func handleSearchMeetingRegistrants(ctx context.Context, req *mcp.CallToolRequest, args SearchMeetingRegistrantsArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if meetingConfig == nil {
 		logger.Error("meeting tools not configured")
@@ -634,7 +634,7 @@ func handleSearchMeetingRegistrants(ctx context.Context, req *mcp.CallToolReques
 
 // handleGetMeetingRegistrant implements the get_meeting_registrant tool logic.
 func handleGetMeetingRegistrant(ctx context.Context, req *mcp.CallToolRequest, args GetMeetingRegistrantArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if meetingConfig == nil {
 		logger.Error("meeting tools not configured")
@@ -766,7 +766,7 @@ func handleGetPastMeetingSummary(ctx context.Context, req *mcp.CallToolRequest, 
 
 // handleSearchPastMeetingResource is a shared implementation for searching past meeting resource types.
 func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest, resourceType, resourceLabel, meetingID, committeeUID, projectUID, name string, filters []string, sort string, pageSize int, pageToken string) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if meetingConfig == nil {
 		logger.Error("meeting tools not configured")
@@ -896,7 +896,7 @@ func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolReque
 
 // handleGetPastMeetingResource is a shared implementation for getting a past meeting resource by UID.
 func handleGetPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest, resourceType, resourceLabel, uid string) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if meetingConfig == nil {
 		logger.Error("meeting tools not configured")

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -144,7 +144,7 @@ func RegisterGetMembershipKeyContact(server *mcp.Server) {
 
 // handleSearchMembers implements the search_members tool logic.
 func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchMembersArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")
@@ -260,7 +260,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 
 // handleGetMemberMembership implements the get_member_membership tool logic.
 func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, args GetMemberMembershipArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")
@@ -358,7 +358,7 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 
 // handleListProjectTiers implements the list_project_tiers tool logic.
 func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args ListProjectTiersArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")
@@ -446,7 +446,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 
 // handleGetProjectTier implements the get_project_tier tool logic.
 func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args GetProjectTierArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")
@@ -544,7 +544,7 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 
 // handleGetMembershipKeyContacts implements the get_membership_key_contacts tool logic.
 func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactsArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")
@@ -642,7 +642,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 
 // handleGetMembershipKeyContact implements the get_membership_key_contact tool logic.
 func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")

--- a/internal/tools/member_write.go
+++ b/internal/tools/member_write.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	"github.com/linuxfoundation/lfx-mcp/internal/lfxv2"
 	memberservice "github.com/linuxfoundation/lfx-v2-member-service/gen/membership_service"
@@ -101,7 +100,7 @@ func RegisterDeleteMembershipKeyContact(server *mcp.Server) {
 // --- Handlers ---
 
 func handleCreateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest, args CreateMembershipKeyContactArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")
@@ -209,7 +208,7 @@ func handleCreateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func handleUpdateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest, args UpdateMembershipKeyContactArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")
@@ -298,7 +297,7 @@ func handleUpdateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func handleDeleteMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest, args DeleteMembershipKeyContactArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if memberConfig == nil {
 		logger.Error("member tools not configured")

--- a/internal/tools/project.go
+++ b/internal/tools/project.go
@@ -71,7 +71,7 @@ type GetProjectArgs struct {
 
 // handleSearchProjects implements the search_projects tool logic.
 func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args SearchProjectsArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if projectConfig == nil {
 		logger.Error("project tools not configured")
@@ -178,7 +178,7 @@ func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args Se
 // handleGetProject implements the get_project tool logic, fetching both base
 // info and settings for the given project UID.
 func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetProjectArgs) (*mcp.CallToolResult, any, error) {
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if projectConfig == nil {
 		logger.Error("project tools not configured")
@@ -242,15 +242,15 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 		}, nil, nil
 	}
 
-	// Settings may be unavailable due to insufficient permissions; treat that
-	// as a partial result rather than a hard failure so callers still get the
-	// base data they are authorised to see.
+	// Settings may be unavailable (e.g. insufficient permissions, or a response
+	// decode failure); treat that as a partial result rather than a hard failure
+	// so callers still get the base data they are authorised to see.
 	var projectSettings *projectservice.ProjectSettings
 	settingsResult, err := clients.Project.GetOneProjectSettings(ctx, &projectservice.GetOneProjectSettingsPayload{
 		UID: &args.UID,
 	})
 	if err != nil {
-		logger.Warn("getting privileged project settings failed, returning base only", "error", lfxv2.ErrorMessage(err), "uid", args.UID)
+		logger.Error("getting project settings failed, returning base only", "error", lfxv2.ErrorMessage(err), "uid", args.UID)
 	} else {
 		projectSettings = settingsResult.ProjectSettings
 	}

--- a/internal/tools/user_info.go
+++ b/internal/tools/user_info.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -48,7 +47,7 @@ func RegisterUserInfo(server *mcp.Server) {
 // handleUserInfo implements the user_info tool logic.
 func handleUserInfo(ctx context.Context, req *mcp.CallToolRequest, _ UserInfoArgs) (*mcp.CallToolResult, any, error) {
 	// Create MCP logger that sends logs to the client.
-	logger := slog.New(mcp.NewLoggingHandler(req.Session, nil))
+	logger := newToolLogger(req)
 
 	if userInfoConfig == nil {
 		logger.Error("user_info tool not configured")


### PR DESCRIPTION
## Overview

Adds a stop-gap `Authorization: Bearer <secret>` authentication path for MCP clients that cannot complete a full OAuth2 authorization code flow. Once all clients support proper OAuth2 this entire feature should be removed.

## How it works

The static credential is passed as a standard `Authorization: Bearer <secret>` value, flowing naturally through the existing `RequireBearerToken` middleware into the `verifyToken` closure. The `APIKeyVerifier` is called first, before JWT verification. It rejects anything that looks like a JWT (two `.` separators) so real tokens always reach the JWT path unaffected. On a match, it returns `TokenInfo` with `read:all`/`manage:all` scopes — equivalent to an OAuth2 M2M `client_credentials` token.

The `lfxv2` token-exchange layer detects API-key-authenticated requests via `Extra["api_key_auth"]=true` in the `TokenInfo` and routes them through the existing `client_credentials` grant (sharing the M2M cache entry), bypassing the RFC 8693 exchange path which requires a real bearer JWT.

Requires `app.mcpApiAuthServers` to also be configured — there is no standalone API-key-only mode.

## Changes

- **`internal/auth/apikey_verifier.go`** — new `APIKeyVerifier` that validates the `Authorization: Bearer` value against a configured `consumer-key → secret` map
- **`internal/lfxv2/client.go`** — `ExtractMCPToken` detects `api_key_auth` and returns an `apiKeyMCPToken` sentinel; `getOrExchangeToken` recognises the sentinel and uses `client_credentials`, sharing the M2M cache entry
- **`cmd/lfx-mcp-server/main.go`** — new `APICredentials map[string]string` config field populated via `LFXMCP_API_CREDENTIALS_<KEY>=<secret>` env vars
- **`charts/lfx-mcp/values.yaml`** — opt-in `apiCredentials` stanza with no default values, referencing a pre-existing Kubernetes Secret
- **`charts/lfx-mcp/templates/deployment.yaml`** — emits one `LFXMCP_API_CREDENTIALS_*` env var per entry in `apiCredentials.keys`

## Acceptance criteria

- [x] Helm chart supports an optional Kubernetes Secret for API credentials with no defaults
- [x] API credentials flow through koanf configuration
- [x] `Authorization: Bearer <secret>` requests with a valid secret are authenticated and granted M2M scopes
- [x] Authenticated API-key requests obtain an LFX v2 token via `client_credentials`
- [x] Requests with an unrecognised non-JWT bearer value receive a `401` response
- [x] Real JWT bearer tokens are unaffected — they bypass the API key check and reach the JWT verifier normally
- [x] Manually verified end-to-end with `get_project` against a local server instance