### PR TITLE
member: update lfx-v2-member-service to v0.4.1; rename search to search_name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,11 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/linuxfoundation/lfx-v2-committee-service v0.2.23
 	github.com/linuxfoundation/lfx-v2-mailing-list-service v0.3.0
-	github.com/linuxfoundation/lfx-v2-member-service v0.4.0
+	github.com/linuxfoundation/lfx-v2-member-service v0.4.1
 	github.com/linuxfoundation/lfx-v2-project-service v0.5.7
 	github.com/linuxfoundation/lfx-v2-query-service v0.4.12
 	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/remychantenay/slog-otel v1.3.5
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0
 	go.opentelemetry.io/contrib/propagators/jaeger v1.42.0
@@ -54,7 +55,6 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/linuxfoundation/lfx-v2-committee-service v0.2.23 h1:UA0DF/dsUQVgFNZdR
 github.com/linuxfoundation/lfx-v2-committee-service v0.2.23/go.mod h1:Ew8lSv3US9q4d9nO+QFa7YaEb18D+LYyKwjAW+h9CQc=
 github.com/linuxfoundation/lfx-v2-mailing-list-service v0.3.0 h1:CS6zl1ZqL7GTaj3VxOwTSonK9thJQS1ea0XTru1XEBI=
 github.com/linuxfoundation/lfx-v2-mailing-list-service v0.3.0/go.mod h1:2vY8kKHA8EJi/MPTAN3fQPqX+s2Il/VSgVs4w4HmpEI=
-github.com/linuxfoundation/lfx-v2-member-service v0.4.0 h1:Hpku1pi6wXkpiNrJHDLVUySDQ9jYLnm6RqWlxPQ1qyA=
-github.com/linuxfoundation/lfx-v2-member-service v0.4.0/go.mod h1:qMzCkX1KayvzmxZQhVL2+dX1jXHqU3CcRGZ/t41vbgs=
+github.com/linuxfoundation/lfx-v2-member-service v0.4.1 h1:5ygVasdjTd77WzqLu4cPsgSfu0LdivnA3Q4szliqD64=
+github.com/linuxfoundation/lfx-v2-member-service v0.4.1/go.mod h1:qMzCkX1KayvzmxZQhVL2+dX1jXHqU3CcRGZ/t41vbgs=
 github.com/linuxfoundation/lfx-v2-project-service v0.5.7 h1:qycjiPSogIIHhRXDFSa0Zxu5ZLb/4jt9I8/JJmAJ0M4=
 github.com/linuxfoundation/lfx-v2-project-service v0.5.7/go.mod h1:JCQZhtqf6lqxG0LA55qbQrTFwV3oSdAoLKn/1BvcMe4=
 github.com/linuxfoundation/lfx-v2-query-service v0.4.12 h1:2sp/7zyhzsq8slNTWefixzjAI88yBYGYPuOjcnGke7I=

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -32,7 +32,7 @@ func SetMemberConfig(cfg *MemberConfig) {
 // SearchMembersArgs defines the input parameters for the search_members tool.
 type SearchMembersArgs struct {
 	ProjectUID string `json:"project_uid" jsonschema:"Project UUID (required)"`
-	Search     string `json:"search,omitempty" jsonschema:"Free-text search across company name, project name, and tier"`
+	SearchName string `json:"search_name,omitempty" jsonschema:"Search memberships by member company name (case-insensitive substring match)."`
 	TierUID    string `json:"tier_uid,omitempty" jsonschema:"Filter by membership tier UID (UUID from list_project_tiers)"`
 	Sort       string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
 	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
@@ -326,11 +326,11 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		payload.Filter = &filterStr
 	}
 
-	if args.Search != "" {
-		payload.Search = &args.Search
+	if args.SearchName != "" {
+		payload.SearchName = &args.SearchName
 	}
 
-	logger.InfoContext(ctx, "searching members", "project_uid", args.ProjectUID, "filter_count", len(filters), "page_size", pageSize, "page_token", args.PageToken, "search", args.Search)
+	logger.InfoContext(ctx, "searching members", "project_uid", args.ProjectUID, "filter_count", len(filters), "page_size", pageSize, "page_token", args.PageToken, "search_name", args.SearchName)
 
 	result, err := clients.Member.ListProjectMemberships(ctx, payload)
 	if err != nil {

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -193,7 +193,7 @@ func toKeyContactView(c *memberservice.ProjectKeyContactResponse) keyContactView
 func RegisterSearchMembers(server *mcp.Server) {
 	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_members",
-		Description: "List and search memberships for a project. Use this tool when users ask about members, memberships, or member organizations for a specific project. Requires project_uid. Supports free-text search, tier_uid filter, and sort order (newest, name, last_modified). Uses cursor-based pagination via page_token.",
+		Description: "List and search memberships for a project. Use this tool when users ask about members, memberships, or member organizations for a specific project. Requires project_uid. Supports search_name for case-insensitive company name substring search, tier_uid filter, and sort order (newest, name, last_modified). Uses cursor-based pagination via page_token.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Members",
 			ReadOnlyHint: true,


### PR DESCRIPTION
## Summary

Picks up the API contract change from [lfx-v2-member-service#21](https://github.com/linuxfoundation/lfx-v2-member-service/pull/21) (ARCH-371).

The `list-project-memberships` query parameter was renamed from `search` to `search_name` and narrowed to a company-name-only SOQL `LIKE` pushdown. This updates the Go client dependency and renames the corresponding field in `SearchMembersArgs` / `handleSearchMembers`.

## Changes

- Bump `github.com/linuxfoundation/lfx-v2-member-service` `v0.4.0` → `v0.4.1`
- `SearchMembersArgs.Search` → `SearchName`, JSON tag `search` → `search_name`, description updated
- `payload.Search` → `payload.SearchName` in `handleSearchMembers`
- Log key updated from `search` to `search_name`

Jira: [ARCH-371](https://linuxfoundation.atlassian.net/browse/ARCH-371)

[ARCH-371]: https://linuxfoundation.atlassian.net/browse/ARCH-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ