### PR TITLE
otel: suppress /livez and /readyz spans, fix tools/call span name

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -346,7 +346,17 @@ func mcpOTelMiddleware(serverLogger *slog.Logger, serviceName string) mcp.Middle
 			// Start a dedicated MCP span. For HTTP, the otelhttp server span is
 			// already in ctx so this becomes a child; for stdio there is no
 			// parent and a fresh root span is created instead.
-			ctx, span := tracer.Start(ctx, method)
+			// Build the span name following the MCP semconv format:
+			// "{mcp.method.name} {target}" where target is gen_ai.tool.name
+			// when available, otherwise just use the method name.
+			// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#server
+			spanName := method
+			if method == "tools/call" {
+				if params, ok := req.GetParams().(*mcp.CallToolParamsRaw); ok && params.Name != "" {
+					spanName = method + " " + params.Name
+				}
+			}
+			ctx, span := tracer.Start(ctx, spanName)
 			defer span.End()
 
 			// Bind mcp.session.id and mcp.method.name onto a child logger and
@@ -765,9 +775,14 @@ func runHTTPServer(cfg Config, otelCfg localOtel.Config, otelShutdown func(conte
 
 	// Wrap the mux with OTel instrumentation so every inbound HTTP request gets
 	// a root span with W3C TraceContext propagation.
+	// Health-check probes are excluded from tracing to avoid cluttering the
+	// tracing backend with high-frequency, low-value spans.
 	var rootHandler http.Handler = mux
 	rootHandler = otelhttp.NewHandler(rootHandler, otelCfg.ServiceName,
 		otelhttp.WithMessageEvents(otelhttp.ReadEvents, otelhttp.WriteEvents),
+		otelhttp.WithFilter(func(r *http.Request) bool {
+			return r.URL.Path != "/livez" && r.URL.Path != "/readyz"
+		}),
 	)
 
 	httpServer := &http.Server{


### PR DESCRIPTION
## Summary

Two related observability improvements to the OTel instrumentation.

### ARCH-374 — Suppress health-check probe spans

Kubernetes health-check probes (`/livez`, `/readyz`) are called at high
frequency and generate noisy, low-value spans in the tracing backend.
An `otelhttp.WithFilter` predicate is added to exclude those two paths
from trace creation entirely.

### Bonus — Fix `tools/call` span name

The MCP semconv spec recommends span names in the format:

```
{mcp.method.name} {target}
```

where `target` should match `gen_ai.tool.name` when applicable.
Previously all `tools/call` invocations shared the same span name
(`"tools/call"`), meaning Datadog flame charts required expanding
attributes to see which tool was actually called.

`mcpOTelMiddleware` now sets the span name to
`"tools/call <tool_name>"` (e.g. `"tools/call search_projects"`),
making flame charts immediately readable.

Ref: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#server

---

Jira: [ARCH-374](https://linuxfoundation.atlassian.net/browse/ARCH-374)

[ARCH-374]: https://linuxfoundation.atlassian.net/browse/ARCH-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ