### PR TITLE
feat(search_projects): add parent_uid filter to return child projects

### DIFF
--- a/internal/tools/project.go
+++ b/internal/tools/project.go
@@ -36,7 +36,7 @@ func SetProjectConfig(cfg *ProjectConfig) {
 func RegisterSearchProjects(server *mcp.Server) {
 	AddToolWithScopes(server, &mcp.Tool{
 		Name:        "search_projects",
-		Description: "Search for LFX projects by name using the LFX query service",
+		Description: "Search for LFX projects by name or by parent project UID using the LFX query service",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Projects",
 			ReadOnlyHint: true,
@@ -58,7 +58,8 @@ func RegisterGetProject(server *mcp.Server) {
 
 // SearchProjectsArgs defines the input parameters for the search_projects tool.
 type SearchProjectsArgs struct {
-	Name      string `json:"name" jsonschema:"Name or partial name of the project to search for"`
+	Name      string `json:"name,omitempty" jsonschema:"Name or partial name of the project to search for"`
+	ParentUID string `json:"parent_uid,omitempty" jsonschema:"Optional UID of a foundation or umbrella project to filter child projects by"`
 	PageSize  int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
@@ -113,11 +114,17 @@ func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args Se
 		payload.Name = &args.Name
 	}
 
+	if args.ParentUID != "" {
+		// The query service requires parent refs in the form "<type>:<id>".
+		parentRef := "project:" + args.ParentUID
+		payload.Parent = &parentRef
+	}
+
 	if args.PageToken != "" {
 		payload.PageToken = &args.PageToken
 	}
 
-	logger.InfoContext(ctx, "searching projects", "name", args.Name, "page_size", pageSize)
+	logger.InfoContext(ctx, "searching projects", "name", args.Name, "parent_uid", args.ParentUID, "page_size", pageSize)
 
 	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds an optional `parent_uid` parameter to the `search_projects` tool so callers can retrieve child projects scoped to a specific parent foundation or umbrella project UID.

## Changes

- `SearchProjectsArgs` gains a new optional `parent_uid` field with a descriptive `jsonschema` tag.
- When `parent_uid` is provided, the query payload `Parent` field is set to `"project:<parent_uid>"` — mirroring the existing pattern used by `search_committees` and `search_committee_members`.
- The `name` field is now `omitempty` so callers can filter by parent alone without supplying a name.
- The tool description is updated to mention the parent filter.
- The info log line includes `parent_uid` alongside `name` and `page_size`.

## Jira

[ARCH-364](https://linuxfoundation.atlassian.net/browse/ARCH-364)

[ARCH-364]: https://linuxfoundation.atlassian.net/browse/ARCH-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ