### PR TITLE
feat(ARCH-375): friendly access-denied message for HTTP 403 errors

### DIFF
--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -173,7 +173,7 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search committees: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search committees", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -264,7 +264,7 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 		logger.ErrorContext(ctx, "GetCommitteeBase failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get committee: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get committee", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -376,7 +376,7 @@ func handleGetCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, arg
 		logger.ErrorContext(ctx, "GetCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get committee member: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get committee member", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -470,7 +470,7 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search committee members: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search committee members", err)},
 			},
 			IsError: true,
 		}, nil, nil

--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -291,7 +291,7 @@ func handleCreateCommittee(ctx context.Context, req *mcp.CallToolRequest, args C
 		logger.ErrorContext(ctx, "CreateCommittee failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to create committee: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to create committee", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -345,7 +345,7 @@ func handleUpdateCommittee(ctx context.Context, req *mcp.CallToolRequest, args U
 		logger.ErrorContext(ctx, "GetCommitteeBase failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee for update: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to fetch committee for update", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -415,7 +415,7 @@ func handleUpdateCommittee(ctx context.Context, req *mcp.CallToolRequest, args U
 		logger.ErrorContext(ctx, "UpdateCommitteeBase failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to update committee: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to update committee", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -469,7 +469,7 @@ func handleUpdateCommitteeSettings(ctx context.Context, req *mcp.CallToolRequest
 		logger.ErrorContext(ctx, "GetCommitteeSettings failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee settings for update: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to fetch committee settings for update", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -503,7 +503,7 @@ func handleUpdateCommitteeSettings(ctx context.Context, req *mcp.CallToolRequest
 		logger.ErrorContext(ctx, "UpdateCommitteeSettings failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to update committee settings: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to update committee settings", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -555,7 +555,7 @@ func handleDeleteCommittee(ctx context.Context, req *mcp.CallToolRequest, args D
 		logger.ErrorContext(ctx, "GetCommitteeBase failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee for delete: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to fetch committee for delete", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -570,7 +570,7 @@ func handleDeleteCommittee(ctx context.Context, req *mcp.CallToolRequest, args D
 		logger.ErrorContext(ctx, "DeleteCommittee failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to delete committee: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to delete committee", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -684,7 +684,7 @@ func handleCreateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 		logger.ErrorContext(ctx, "CreateCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to create committee member: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to create committee member", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -749,7 +749,7 @@ func handleUpdateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 		logger.ErrorContext(ctx, "GetCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee member for update: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to fetch committee member for update", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -830,7 +830,7 @@ func handleUpdateCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 		logger.ErrorContext(ctx, "UpdateCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to update committee member: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to update committee member", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -893,7 +893,7 @@ func handleDeleteCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 		logger.ErrorContext(ctx, "GetCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to fetch committee member for delete: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to fetch committee member for delete", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -909,7 +909,7 @@ func handleDeleteCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, 
 		logger.ErrorContext(ctx, "DeleteCommitteeMember failed", "error", err, "committee_uid", args.CommitteeUID, "member_uid", args.MemberUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to delete committee member: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to delete committee member", err)},
 			},
 			IsError: true,
 		}, nil, nil

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -7,6 +7,7 @@ package tools
 import (
 	"context"
 	"log/slog"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -87,4 +88,23 @@ func boolPtr(b bool) *bool {
 // payload fields that distinguish between "unset" and "zero value".
 func strPtr(s string) *string {
 	return &s
+}
+
+// accessDeniedMessage is the user-facing message returned when a downstream
+// API call is rejected with HTTP 403.
+const accessDeniedMessage = "you do not have enough access to complete this operation. Request support @ https://support.lfx.dev"
+
+// friendlyAPIError formats an API error for display in a tool result.
+// If the error contains "response code 403" it returns a user-friendly
+// access-denied message instead of the raw internal error string.
+// The op argument is a short description of the operation (e.g.
+// "failed to get project") and is used only for non-403 errors.
+func friendlyAPIError(op string, err error) string {
+	if len(op) > 0 {
+		op = strings.ToUpper(op[:1]) + op[1:]
+	}
+	if strings.Contains(err.Error(), "response code 403") {
+		return op + ": " + accessDeniedMessage
+	}
+	return op + ": " + err.Error()
 }

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -98,7 +98,7 @@ const accessDeniedMessage = "you do not have enough access to complete this oper
 // If the error contains "response code 403" it returns a user-friendly
 // access-denied message instead of the raw internal error string.
 // The op argument is a short description of the operation (e.g.
-// "failed to get project") and is used only for non-403 errors.
+// "failed to get project") and is prefixed to both 403 and non-403 error messages.
 func friendlyAPIError(op string, err error) string {
 	if len(op) > 0 {
 		op = strings.ToUpper(op[:1]) + op[1:]

--- a/internal/tools/helpers_test.go
+++ b/internal/tools/helpers_test.go
@@ -1,0 +1,64 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+package tools
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFriendlyAPIError_403(t *testing.T) {
+	err := errors.New("[project-service get-one-project-base]: invalid response code 403")
+	got := friendlyAPIError("failed to get project", err)
+	want := "Failed to get project: " + accessDeniedMessage
+	if got != want {
+		t.Errorf("expected %q, got: %q", want, got)
+	}
+}
+
+func TestFriendlyAPIError_403_embedded(t *testing.T) {
+	// 403 buried deeper in a wrapped error string.
+	err := errors.New("outer: inner: invalid response code 403: forbidden")
+	got := friendlyAPIError("failed to do thing", err)
+	want := "Failed to do thing: " + accessDeniedMessage
+	if got != want {
+		t.Errorf("expected %q, got: %q", want, got)
+	}
+}
+
+func TestFriendlyAPIError_passthrough(t *testing.T) {
+	err := errors.New("invalid response code 500: internal server error")
+	got := friendlyAPIError("failed to get project", err)
+	want := "Failed to get project: invalid response code 500: internal server error"
+	if got != want {
+		t.Errorf("expected %q, got: %q", want, got)
+	}
+}
+
+func TestFriendlyAPIError_404_passthrough(t *testing.T) {
+	err := errors.New("invalid response code 404: not found")
+	got := friendlyAPIError("failed to get member", err)
+	want := "Failed to get member: invalid response code 404: not found"
+	if got != want {
+		t.Errorf("expected %q, got: %q", want, got)
+	}
+}
+
+func TestFriendlyAPIError_noPrefix(t *testing.T) {
+	// Non-403 errors must NOT start with "Error: ".
+	err := errors.New("connection refused")
+	got := friendlyAPIError("failed to search projects", err)
+	if len(got) >= 7 && got[:7] == "Error: " {
+		t.Errorf("result must not start with 'Error: ', got: %q", got)
+	}
+}
+
+func TestFriendlyAPIError_accessDeniedNoPrefix(t *testing.T) {
+	// 403 result must NOT start with "Error: " either.
+	err := errors.New("response code 403")
+	got := friendlyAPIError("failed to get project", err)
+	if len(got) >= 7 && got[:7] == "Error: " {
+		t.Errorf("access denied message must not start with 'Error: ', got: %q", got)
+	}
+}

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -174,7 +174,7 @@ func handleGetMailingListService(ctx context.Context, req *mcp.CallToolRequest, 
 		logger.ErrorContext(ctx, "GetGrpsioService failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get mailing list service: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get mailing list service", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -273,7 +273,7 @@ func handleGetMailingList(ctx context.Context, req *mcp.CallToolRequest, args Ge
 		logger.ErrorContext(ctx, "GetGrpsioMailingList failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get mailing list: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get mailing list", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -382,7 +382,7 @@ func handleGetMailingListMember(ctx context.Context, req *mcp.CallToolRequest, a
 		logger.ErrorContext(ctx, "GetGrpsioMailingListMember failed", "error", err, "mailing_list_uid", args.MailingListUID, "member_uid", args.MemberUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get mailing list member: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get mailing list member", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -469,7 +469,7 @@ func handleSearchMailingLists(ctx context.Context, req *mcp.CallToolRequest, arg
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search mailing lists: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search mailing lists", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -578,7 +578,7 @@ func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolReques
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search mailing list members: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search mailing list members", err)},
 			},
 			IsError: true,
 		}, nil, nil

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -342,7 +342,7 @@ func handleSearchMeetings(ctx context.Context, req *mcp.CallToolRequest, args Se
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search meetings: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search meetings", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -437,7 +437,7 @@ func handleGetMeeting(ctx context.Context, req *mcp.CallToolRequest, args GetMee
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get meeting: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get meeting", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -551,7 +551,7 @@ func handleSearchMeetingRegistrants(ctx context.Context, req *mcp.CallToolReques
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search meeting registrants: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search meeting registrants", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -646,7 +646,7 @@ func handleGetMeetingRegistrant(ctx context.Context, req *mcp.CallToolRequest, a
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get meeting registrant: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get meeting registrant", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -787,7 +787,7 @@ func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolReque
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search %s: %s", resourceLabel, err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search "+resourceLabel, err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -881,7 +881,7 @@ func handleGetPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest,
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get %s: %s", resourceLabel, err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get "+resourceLabel, err)},
 			},
 			IsError: true,
 		}, nil, nil

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -337,7 +337,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		logger.ErrorContext(ctx, "ListProjectMemberships failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search members: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search members", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -435,7 +435,7 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 		logger.ErrorContext(ctx, "GetProjectMembership failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get member membership: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get member membership", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -509,7 +509,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 		logger.ErrorContext(ctx, "ListProjectTiers failed", "error", err, "project_uid", args.ProjectUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to list project tiers: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to list project tiers", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -598,7 +598,7 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 		logger.ErrorContext(ctx, "GetProjectTier failed", "error", err, "project_uid", args.ProjectUID, "tier_uid", args.TierUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get project tier: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get project tier", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -682,7 +682,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 		logger.ErrorContext(ctx, "ListMembershipKeyContacts failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get membership key contacts: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get membership key contacts", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -781,7 +781,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 		logger.ErrorContext(ctx, "GetMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get membership key contact: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get membership key contact", err)},
 			},
 			IsError: true,
 		}, nil, nil

--- a/internal/tools/member_write.go
+++ b/internal/tools/member_write.go
@@ -174,7 +174,7 @@ func handleCreateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		logger.ErrorContext(ctx, "CreateMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error: failed to create key contact: %s", err.Error())}},
+			Content: []mcp.Content{&mcp.TextContent{Text: friendlyAPIError("failed to create key contact", err)}},
 			IsError: true,
 		}, nil, nil
 	}
@@ -251,7 +251,7 @@ func handleUpdateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		logger.ErrorContext(ctx, "UpdateMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error: failed to update key contact: %s", err.Error())}},
+			Content: []mcp.Content{&mcp.TextContent{Text: friendlyAPIError("failed to update key contact", err)}},
 			IsError: true,
 		}, nil, nil
 	}
@@ -324,7 +324,7 @@ func handleDeleteMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		logger.ErrorContext(ctx, "DeleteMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error: failed to delete key contact: %s", err.Error())}},
+			Content: []mcp.Content{&mcp.TextContent{Text: friendlyAPIError("failed to delete key contact", err)}},
 			IsError: true,
 		}, nil, nil
 	}

--- a/internal/tools/project.go
+++ b/internal/tools/project.go
@@ -124,7 +124,7 @@ func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args Se
 		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to search projects: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to search projects", err)},
 			},
 			IsError: true,
 		}, nil, nil
@@ -207,7 +207,7 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 		logger.ErrorContext(ctx, "GetOneProjectBase failed", "error", err, "uid", args.UID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to get project: %s", err.Error())},
+				&mcp.TextContent{Text: friendlyAPIError("failed to get project", err)},
 			},
 			IsError: true,
 		}, nil, nil


### PR DESCRIPTION
## Summary

Closes ARCH-375 (epic: ARCH-319)

Tool responses from downstream APIs that return HTTP 403 previously surfaced the raw internal error string:

```
Error: failed to get project: [project-service get-one-project-base]: invalid response code 403
```

This is not useful to end users and exposes internal service names. This PR replaces that with a user-friendly, actionable message:

```
Failed to get project: you do not have enough access to complete this operation. Request support @ https://support.lfx.dev
```

## Changes

- **`internal/tools/helpers.go`** — adds `friendlyAPIError(op, err)` helper and `accessDeniedMessage` constant. Detects `"response code 403"` anywhere in the error string, capitalizes the `op` prefix, and returns the friendly message. Non-403 errors pass through unchanged (just with the capitalized op prefix).
- **All tool handlers** (`project`, `member`, `member_write`, `committee`, `committee_write`, `mailing_list`, `meeting`) — replaced `fmt.Sprintf("Error: failed to ...: %s", err.Error())` with `friendlyAPIError("failed to ...", err)` at every downstream API call error site.
- **`internal/tools/helpers_test.go`** — new unit tests covering 403 detection, embedded 403, 404/500 pass-through, and absence of the old `"Error: "` prefix.

The raw error is still logged server-side at ERROR level (no change to observability).