### PR TITLE
fix(ARCH-375): improve 403 error message to mention resource may not exist

### DIFF
--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -92,7 +92,7 @@ func strPtr(s string) *string {
 
 // accessDeniedMessage is the user-facing message returned when a downstream
 // API call is rejected with HTTP 403.
-const accessDeniedMessage = "you do not have enough access to complete this operation. Request support @ https://support.lfx.dev"
+const accessDeniedMessage = "this resource may not exist or you may not have enough access to complete this operation. Request support @ https://support.lfx.dev"
 
 // friendlyAPIError formats an API error for display in a tool result.
 // If the error contains "response code 403" it returns a user-friendly


### PR DESCRIPTION
## Summary

Follow-up to #46 — refines the access-denied message for HTTP 403 responses to clarify that the resource may not exist, which is the more common cause of a 403 in practice.

**Before:** `you do not have enough access to complete this operation. Request support @ https://support.lfx.dev`

**After:** `this resource may not exist or you may not have enough access to complete this operation. Request support @ https://support.lfx.dev`

## Jira

[ARCH-375](https://linuxfoundation.atlassian.net/browse/ARCH-375)

[ARCH-375]: https://linuxfoundation.atlassian.net/browse/ARCH-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ