### PR TITLE
fix(charts): set serviceAccountName in deployment pod spec

### DIFF
--- a/charts/lfx-mcp/templates/deployment.yaml
+++ b/charts/lfx-mcp/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Chart.Name }}
       containers:
         - name: app
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
## Summary

The service account template was added in PR #38 but the deployment template was never updated to reference it, so pods were still running under the default service account.

Adds `serviceAccountName` to the pod spec in `deployment.yaml`, matching the pattern used in `lfx-v1-sync-helper`.

## Jira

[ARCH-376](https://linuxfoundation.atlassian.net/browse/ARCH-376) — Fix deployment template to use service account

[ARCH-376]: https://linuxfoundation.atlassian.net/browse/ARCH-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ