### PR TITLE
feat(tools): rationalize membership view fields for search_members and list_b2b_org_memberships

### DIFF
--- a/internal/tools/b2b_org.go
+++ b/internal/tools/b2b_org.go
@@ -42,7 +42,65 @@ type b2bOrgView struct {
 	UpdatedAt     *string  `json:"updated_at,omitempty"`
 }
 
-// toB2bOrgView converts a B2bOrgResponse to the MCP view.
+// b2bOrgMembershipView is a filtered view of ProjectMembershipResponse for
+// MCP responses from the list_b2b_org_memberships tool (org drill-down).
+// Omitted fields: b2b_org_uid (redundant input), company_name/logo/domain
+// (always the same org for every result), tier_family (always "Membership"),
+// tier_product_type (always null), and membership_type (raw Salesforce record
+// type ID). project_uid and project_slug are included because this is a
+// cross-project view and callers need to identify which project each
+// membership belongs to.
+type b2bOrgMembershipView struct {
+	UID              *string  `json:"uid,omitempty"`
+	TierUID          *string  `json:"tier_uid,omitempty"`
+	ProjectUID       *string  `json:"project_uid,omitempty"`
+	ProjectSlug      *string  `json:"project_slug,omitempty"`
+	Status           *string  `json:"status,omitempty"`
+	Year             *string  `json:"year,omitempty"`
+	Tier             *string  `json:"tier,omitempty"`
+	AutoRenew        *bool    `json:"auto_renew,omitempty"`
+	RenewalType      *string  `json:"renewal_type,omitempty"`
+	Price            *float64 `json:"price,omitempty"`
+	AnnualFullPrice  *float64 `json:"annual_full_price,omitempty"`
+	PaymentFrequency *string  `json:"payment_frequency,omitempty"`
+	PaymentTerms     *string  `json:"payment_terms,omitempty"`
+	AgreementDate    *string  `json:"agreement_date,omitempty"`
+	PurchaseDate     *string  `json:"purchase_date,omitempty"`
+	StartDate        *string  `json:"start_date,omitempty"`
+	EndDate          *string  `json:"end_date,omitempty"`
+	TierName         *string  `json:"tier_name,omitempty"`
+	CreatedAt        *string  `json:"created_at,omitempty"`
+	UpdatedAt        *string  `json:"updated_at,omitempty"`
+}
+
+// toB2bOrgMembershipView converts a ProjectMembershipResponse to the filtered
+// MCP view for list_b2b_org_memberships, dropping b2b_org_uid (redundant
+// input) and company fields (same org for every row in an org-scoped query).
+func toB2bOrgMembershipView(m *memberservice.ProjectMembershipResponse) b2bOrgMembershipView {
+	return b2bOrgMembershipView{
+		UID:              m.UID,
+		TierUID:          m.TierUID,
+		ProjectUID:       m.ProjectUID,
+		ProjectSlug:      m.ProjectSlug,
+		Status:           m.Status,
+		Year:             m.Year,
+		Tier:             m.Tier,
+		AutoRenew:        m.AutoRenew,
+		RenewalType:      m.RenewalType,
+		Price:            m.Price,
+		AnnualFullPrice:  m.AnnualFullPrice,
+		PaymentFrequency: m.PaymentFrequency,
+		PaymentTerms:     m.PaymentTerms,
+		AgreementDate:    m.AgreementDate,
+		PurchaseDate:     m.PurchaseDate,
+		StartDate:        m.StartDate,
+		EndDate:          m.EndDate,
+		TierName:         m.TierName,
+		CreatedAt:        m.CreatedAt,
+		UpdatedAt:        m.UpdatedAt,
+	}
+}
+
 func toB2bOrgView(o *memberservice.B2bOrgResponse) b2bOrgView {
 	return b2bOrgView{
 		UID:           o.UID,
@@ -243,9 +301,9 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 		}, nil, nil
 	}
 
-	views := make([]membershipView, 0, len(result.Memberships))
+	views := make([]b2bOrgMembershipView, 0, len(result.Memberships))
 	for _, m := range result.Memberships {
-		views = append(views, toMembershipView(m))
+		views = append(views, toB2bOrgMembershipView(m))
 	}
 
 	// Warn if any membership has a project_slug but no project_uid, which
@@ -261,7 +319,7 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 	}
 
 	type listResult struct {
-		Memberships []membershipView            `json:"memberships"`
+		Memberships []b2bOrgMembershipView      `json:"memberships"`
 		Metadata    *memberservice.ListMetadata `json:"metadata,omitempty"`
 	}
 	output := listResult{

--- a/internal/tools/b2b_org.go
+++ b/internal/tools/b2b_org.go
@@ -101,6 +101,7 @@ func toB2bOrgMembershipView(m *memberservice.ProjectMembershipResponse) b2bOrgMe
 	}
 }
 
+// toB2bOrgView converts a B2bOrgResponse to the MCP view.
 func toB2bOrgView(o *memberservice.B2bOrgResponse) b2bOrgView {
 	return b2bOrgView{
 		UID:           o.UID,

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -81,12 +81,16 @@ type membershipTierView struct {
 }
 
 // membershipView is a filtered view of ProjectMembershipResponse for MCP
-// responses. Redundant fields omitted: project_uid (required input),
-// tier_family (always "Membership"), tier_product_type (always null), and
-// membership_type (a raw Salesforce record type ID, not useful to callers).
+// responses from the search_members tool (project drill-down). Omitted fields:
+// project_uid and project_slug (redundant — same for every result in a
+// project-scoped query), tier_family (always "Membership"), tier_product_type
+// (always null), and membership_type (a raw Salesforce record type ID, not
+// useful to callers). Company fields are renamed with a b2b_org_ prefix to
+// align with b2b tool naming conventions.
 type membershipView struct {
 	UID              *string  `json:"uid,omitempty"`
 	TierUID          *string  `json:"tier_uid,omitempty"`
+	B2bOrgUID        *string  `json:"b2b_org_uid,omitempty"`
 	Status           *string  `json:"status,omitempty"`
 	Year             *string  `json:"year,omitempty"`
 	Tier             *string  `json:"tier,omitempty"`
@@ -100,9 +104,9 @@ type membershipView struct {
 	PurchaseDate     *string  `json:"purchase_date,omitempty"`
 	StartDate        *string  `json:"start_date,omitempty"`
 	EndDate          *string  `json:"end_date,omitempty"`
-	CompanyName      *string  `json:"company_name,omitempty"`
-	CompanyLogoURL   *string  `json:"company_logo_url,omitempty"`
-	CompanyDomain    *string  `json:"company_domain,omitempty"`
+	B2bOrgName       *string  `json:"b2b_org_name,omitempty"`
+	B2bOrgLogoURL    *string  `json:"b2b_org_logo_url,omitempty"`
+	B2bOrgDomain     *string  `json:"b2b_org_domain,omitempty"`
 	TierName         *string  `json:"tier_name,omitempty"`
 	CreatedAt        *string  `json:"created_at,omitempty"`
 	UpdatedAt        *string  `json:"updated_at,omitempty"`
@@ -141,11 +145,13 @@ func toMembershipTierView(t *memberservice.MembershipTierResponse) membershipTie
 }
 
 // toMembershipView converts a ProjectMembershipResponse to the filtered MCP
-// view, dropping redundant fields.
+// view for search_members, dropping project_uid/slug (redundant in a
+// project-scoped query) and renaming company fields to b2b_org_ prefix.
 func toMembershipView(m *memberservice.ProjectMembershipResponse) membershipView {
 	return membershipView{
 		UID:              m.UID,
 		TierUID:          m.TierUID,
+		B2bOrgUID:        m.B2bOrgUID,
 		Status:           m.Status,
 		Year:             m.Year,
 		Tier:             m.Tier,
@@ -159,9 +165,9 @@ func toMembershipView(m *memberservice.ProjectMembershipResponse) membershipView
 		PurchaseDate:     m.PurchaseDate,
 		StartDate:        m.StartDate,
 		EndDate:          m.EndDate,
-		CompanyName:      m.CompanyName,
-		CompanyLogoURL:   m.CompanyLogoURL,
-		CompanyDomain:    m.CompanyDomain,
+		B2bOrgName:       m.CompanyName,
+		B2bOrgLogoURL:    m.CompanyLogoURL,
+		B2bOrgDomain:     m.CompanyDomain,
 		TierName:         m.TierName,
 		CreatedAt:        m.CreatedAt,
 		UpdatedAt:        m.UpdatedAt,


### PR DESCRIPTION
## Summary

- **`search_members`** (project drill-down): add `b2b_org_uid` to enable drill-down to `list_b2b_org_memberships`; rename `company_name/logo_url/domain` → `b2b_org_name/logo_url/domain` to align with b2b tool naming; keep `project_uid`/`project_slug` omitted (redundant — same for every result).
- **`list_b2b_org_memberships`** (org drill-down): add `project_uid` and `project_slug` for cross-project identification; omit `b2b_org_uid` (redundant input) and all company/b2b_org identity fields (always the same org for every row). Uses a new dedicated `b2bOrgMembershipView` struct instead of the shared `membershipView`.

## Jira

[ARCH-380](https://linuxfoundation.atlassian.net/browse/ARCH-380) — child of ARCH-319, related to ARCH-379 and LFXV2-1382

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[ARCH-380]: https://linuxfoundation.atlassian.net/browse/ARCH-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ