### PR TITLE
feat: improve Helm chart production robustness (PDB, topology spread, graceful shutdown)

### DIFF
--- a/charts/lfx-mcp/templates/deployment.yaml
+++ b/charts/lfx-mcp/templates/deployment.yaml
@@ -23,6 +23,18 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name | default .Chart.Name }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "lfx-mcp.selectorLabels" $ | nindent 14 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: app
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/lfx-mcp/templates/pdb.yaml
+++ b/charts/lfx-mcp/templates/pdb.yaml
@@ -1,13 +1,15 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- $hasMin := hasKey .Values.podDisruptionBudget "minAvailable" }}
-{{- $hasMax := hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+{{- $minVal := .Values.podDisruptionBudget.minAvailable }}
+{{- $maxVal := .Values.podDisruptionBudget.maxUnavailable }}
+{{- $hasMin := and (hasKey .Values.podDisruptionBudget "minAvailable") (not (kindIs "invalid" $minVal)) }}
+{{- $hasMax := and (hasKey .Values.podDisruptionBudget "maxUnavailable") (not (kindIs "invalid" $maxVal)) }}
 {{- if and $hasMin $hasMax }}
   {{- fail "podDisruptionBudget: cannot set both minAvailable and maxUnavailable" }}
 {{- end }}
 {{- if not (or $hasMin $hasMax) }}
-  {{- fail "podDisruptionBudget: either minAvailable or maxUnavailable must be set" }}
+  {{- fail "podDisruptionBudget: either minAvailable or maxUnavailable must be set when enabled is true" }}
 {{- end }}
 ---
 apiVersion: policy/v1
@@ -22,9 +24,9 @@ spec:
     matchLabels:
       {{- include "lfx-mcp.selectorLabels" . | nindent 6 }}
   {{- if $hasMin }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ $minVal }}
   {{- end }}
   {{- if $hasMax }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ $maxVal }}
   {{- end }}
 {{- end }}

--- a/charts/lfx-mcp/templates/pdb.yaml
+++ b/charts/lfx-mcp/templates/pdb.yaml
@@ -1,0 +1,30 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- $hasMin := hasKey .Values.podDisruptionBudget "minAvailable" }}
+{{- $hasMax := hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+{{- if and $hasMin $hasMax }}
+  {{- fail "podDisruptionBudget: cannot set both minAvailable and maxUnavailable" }}
+{{- end }}
+{{- if not (or $hasMin $hasMax) }}
+  {{- fail "podDisruptionBudget: either minAvailable or maxUnavailable must be set" }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "lfx-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lfx-mcp.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lfx-mcp.selectorLabels" . | nindent 6 }}
+  {{- if $hasMin }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if $hasMax }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -13,16 +13,18 @@ image:
 # replicaCount is the number of replicas for the deployment.
 replicaCount: 1
 
-# resources is the configuration for container resource limits and requests.
-resources:
-  # limits is the maximum amount of resources the container can use.
-  limits:
-    cpu: 500m
-    memory: 256Mi
-  # requests is the amount of resources the container requests.
-  requests:
-    cpu: 50m
-    memory: 64Mi
+# resources is the configuration for container resource requests and limits.
+# No defaults are set here — resource sizing is environment-specific and
+# should be configured via your values overrides (e.g. ArgoCD values files).
+# Example:
+#   resources:
+#     requests:
+#       cpu: 5m
+#       memory: 16Mi
+#     limits:
+#       cpu: 50m
+#       memory: 64Mi
+resources: {}
 
 # service is the configuration for the Kubernetes service.
 service:

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -13,9 +13,23 @@ image:
 # replicaCount is the number of replicas for the deployment.
 replicaCount: 1
 
+# terminationGracePeriodSeconds is the duration the pod has to terminate gracefully after
+# receiving SIGTERM. The Go HTTP server shuts down with a 10-second timeout, so 30 seconds
+# provides ample margin for in-flight requests to complete and OTel spans to flush.
+terminationGracePeriodSeconds: 30
+
+# topologySpreadConstraints controls how pods are spread across topology domains (e.g. nodes).
+# The default spreads pods evenly across nodes using a soft constraint (ScheduleAnyway) so
+# that scheduling is never blocked on small clusters. Override to DoNotSchedule in your
+# values overrides for strict HA in production.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+
 # resources is the configuration for container resource requests and limits.
 # No defaults are set here — resource sizing is environment-specific and
-# should be configured via your values overrides (e.g. ArgoCD values files).
+# should be configured via your values overrides.
 # Example:
 #   resources:
 #     requests:
@@ -57,7 +71,7 @@ podAnnotations: {}
 
 # podDisruptionBudget configures the PodDisruptionBudget for the deployment.
 # Set enabled: true and either minAvailable or maxUnavailable (not both) via
-# the ArgoCD values files to protect the service during node disruptions.
+# the values overrides to protect the service during node disruptions.
 podDisruptionBudget:
   # enabled controls whether the PodDisruptionBudget resource is created.
   enabled: false
@@ -84,7 +98,7 @@ app:
   tokenEndpoint: ""
   # otel contains OpenTelemetry exporter configuration.
   # All values default to empty (no-op tracer) so the chart is deployment-environment agnostic.
-  # The ArgoCD values files supply the environment-specific endpoint and sample ratio.
+  # The values overrides supply the environment-specific endpoint and sample ratio.
   otel:
     # endpoint is the OTLP gRPC collector endpoint (e.g. "http://$(HOST_IP):4317").
     # Leave empty to disable tracing (installs a no-op provider).
@@ -99,7 +113,7 @@ app:
     tracesSamplerArg: ""
   # extraEnv is a list of additional environment variables to inject into the container.
   # Used to supply HOST_IP (from the pod's status.hostIP) and the derived OTEL endpoint.
-  # Example (set in ArgoCD values, not here):
+  # Example (set in your values overrides, not here):
   #   extraEnv:
   #     - name: HOST_IP
   #       valueFrom:

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -53,6 +53,17 @@ ingress:
 #     ad.datadoghq.com/app.logs: '[{"service": "lfx-mcp", "source": "go"}]'
 podAnnotations: {}
 
+# podDisruptionBudget configures the PodDisruptionBudget for the deployment.
+# Set enabled: true and either minAvailable or maxUnavailable (not both) via
+# the ArgoCD values files to protect the service during node disruptions.
+podDisruptionBudget:
+  # enabled controls whether the PodDisruptionBudget resource is created.
+  enabled: false
+  # minAvailable is the minimum number of pods that must remain available during a disruption.
+  # minAvailable: 1
+  # maxUnavailable is the maximum number of pods that may be unavailable during a disruption.
+  # maxUnavailable: 1
+
 # app is the configuration for the application.
 app:
   # debug enables debug logging.


### PR DESCRIPTION
## Summary

- Adds `charts/lfx-mcp/templates/pdb.yaml` — a `PodDisruptionBudget` template consistent with the pattern in `lfx-v2-mailing-list-service`, using the chart's `selectorLabels` helper and validating that exactly one of `minAvailable`/`maxUnavailable` is set when enabled.
- Adds `topologySpreadConstraints` support to `charts/lfx-mcp/templates/deployment.yaml` — spreads pods evenly across nodes with a soft `ScheduleAnyway` constraint by default (override to `DoNotSchedule` for strict HA).
- Adds `terminationGracePeriodSeconds` to the deployment template (default: 30s) to give the Go HTTP server's 10-second shutdown timeout ample margin to drain in-flight requests and flush OTel spans.
- Updates `charts/lfx-mcp/values.yaml`:
  - Removes hardcoded resource requests/limits (replaced with an empty `resources: {}` and documented example); resource sizing is environment-specific and belongs in values overrides.
  - Adds `podDisruptionBudget` stanza (`enabled: false` as the safe chart default; enabled with `minAvailable: 2` via the ArgoCD global values in the companion PR).
  - Adds `topologySpreadConstraints` stanza with a default soft node-spread constraint.
  - Adds `terminationGracePeriodSeconds` with a default of 30.

## Context

This is the first of two PRs for ARCH-383. The companion PR in `lfx-v2-argocd` ([#511](https://github.com/linuxfoundation/lfx-v2-argocd/pull/511)) sets `replicaCount: 3`, enables the PDB (`minAvailable: 2`), and sets resource requests/limits matching all other LFX Go services. It must be merged **after** this one, since the PDB template and topology spread support must exist in the chart before ArgoCD can reconcile those values.

## Jira

Issue: ARCH-383

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)