### PR TITLE
feat: bump MCP SDK to v1.5.0, add SchemaCache, document stateless arch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The LFX MCP Server is a Model Context Protocol (MCP) implementation that provide
 - **Language**: Go 1.26.0+
 - **Protocol**: Model Context Protocol (MCP) 2024-11-05
 - **SDK**: Official MCP Go SDK v1.5.0+
-- **Transport**: JSON-RPC 2.0 over stdio
+- **Transport**: JSON-RPC 2.0 over stdio and Streamable HTTP
 - **Schema**: Automatic JSON schema generation via struct tags
 
 ## Architecture Overview
@@ -53,7 +53,7 @@ The HTTP server is designed to run across multiple pods without coordination:
 
 - **`Stateless: true`** is set on `StreamableHTTPHandler` (`main.go`). This instructs the SDK to skip session-ID validation and use a temporary session per request, so any pod can handle any request.
 - **Per-request server factory**: `newServer()` is called for each incoming HTTP request, so no MCP-level state accumulates across requests.
-- **`SchemaCache`**: A package-level `schemaCache` is shared across per-request server instances. This avoids re-running reflection-based JSON schema generation for every request — schemas are computed once at startup and reused.
+- **`SchemaCache`**: A package-level `schemaCache` is shared across per-request server instances. This avoids re-running reflection-based JSON schema generation for every request — schemas are computed on first use and then reused across subsequent requests in the same pod.
 - **Streamable HTTP vs. old SSE transport**: Responses may use SSE framing (`text/event-stream`) within a single request/response cycle. This is not the deprecated long-lived SSE transport, so no connection affinity is needed between requests.
 - **No sticky sessions required**: Because all state is either per-request or independently cached per pod, round-robin load balancing works without Kubernetes session affinity.
 - **In-memory caches are all safe**: Token exchange, slug resolver, client credentials, and JWKS caches are performance-only; each pod warms independently and misses trigger upstream re-fetches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ The LFX MCP Server is a Model Context Protocol (MCP) implementation that provide
 
 - **Language**: Go 1.26.0+
 - **Protocol**: Model Context Protocol (MCP) 2024-11-05
-- **SDK**: Official MCP Go SDK v1.4.0+
+- **SDK**: Official MCP Go SDK v1.5.0+
 - **Transport**: JSON-RPC 2.0 over stdio
 - **Schema**: Automatic JSON schema generation via struct tags
 
@@ -46,6 +46,21 @@ Client (Claude, etc.) → JSON-RPC 2.0 → stdio transport → MCP Server → To
 3. **Type Safety**: Strong typing with automatic schema generation
 4. **Testability**: Simple stdio testing via JSON-RPC messages
 5. **Observability**: Structured JSON logging with optional debug mode
+
+### Multi-Pod Scaling (Stateless Architecture)
+
+The HTTP server is designed to run across multiple pods without coordination:
+
+- **`Stateless: true`** is set on `StreamableHTTPHandler` (`main.go`). This instructs the SDK to skip session-ID validation and use a temporary session per request, so any pod can handle any request.
+- **Per-request server factory**: `newServer()` is called for each incoming HTTP request, so no MCP-level state accumulates across requests.
+- **`SchemaCache`**: A package-level `schemaCache` is shared across per-request server instances. This avoids re-running reflection-based JSON schema generation for every request — schemas are computed once at startup and reused.
+- **Streamable HTTP vs. old SSE transport**: Responses may use SSE framing (`text/event-stream`) within a single request/response cycle. This is not the deprecated long-lived SSE transport, so no connection affinity is needed between requests.
+- **No sticky sessions required**: Because all state is either per-request or independently cached per pod, round-robin load balancing works without Kubernetes session affinity.
+- **In-memory caches are all safe**: Token exchange, slug resolver, client credentials, and JWKS caches are performance-only; each pod warms independently and misses trigger upstream re-fetches.
+
+**Stateless mode limitation**: The server cannot make client callbacks (e.g., `ListRoots`, `CreateMessage`, `Elicit`) in stateless mode. We do not use any of these currently. If sampling or elicitation features are ever needed, stateless mode would need to be reconsidered.
+
+**Reference**: [SDK distributed example](https://github.com/modelcontextprotocol/go-sdk/blob/v1.5.0/examples/server/distributed/main.go) — uses the same `Stateless: true` + per-request factory + round-robin pattern.
 
 ## Development Workflow
 

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -132,6 +132,11 @@ var defaultTools = []string{
 
 var logger *slog.Logger
 
+// schemaCache is shared across per-request server instances in HTTP/stateless mode.
+// It caches the reflection-based JSON schema for each tool argument type so that
+// schemas are computed only once rather than on every incoming request.
+var schemaCache = mcp.NewSchemaCache()
+
 func main() {
 	k := koanf.New(".")
 
@@ -536,7 +541,8 @@ func newServer(cfg Config, serviceName string) *mcp.Server {
 		Name:    "lfx-mcp-server",
 		Version: Version,
 	}, &mcp.ServerOptions{
-		Logger: logger,
+		Logger:      logger,
+		SchemaCache: schemaCache,
 	})
 
 	// Add middleware for OTel instrumentation and logging of all MCP method calls.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/linuxfoundation/lfx-v2-member-service v0.5.0
 	github.com/linuxfoundation/lfx-v2-project-service v0.6.0
 	github.com/linuxfoundation/lfx-v2-query-service v0.4.13
-	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/remychantenay/slog-otel v1.3.5
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
-github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
+github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
+github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Summary

- Bump `github.com/modelcontextprotocol/go-sdk` from v1.4.1 → v1.5.0
- Add a shared `SchemaCache` to eliminate repeated reflection-based JSON schema generation on every HTTP request (~20+ tool argument types re-reflected per request previously)
- Document the stateless multi-pod architecture in `AGENTS.md`

## Changes

**`go.mod` / `go.sum`**: SDK version bump.

**`cmd/lfx-mcp-server/main.go`**: Added a package-level `schemaCache = mcp.NewSchemaCache()` shared across all per-request server instances in HTTP/stateless mode. Wired into `newServer()` via `ServerOptions.SchemaCache`. Schemas for all registered tool argument types are now computed once and reused rather than re-derived on every incoming request.

**`AGENTS.md`**: Added a "Multi-Pod Scaling (Stateless Architecture)" section covering: `Stateless: true`, per-request server factory, `SchemaCache` sharing, Streamable HTTP vs. old SSE clarification, no sticky sessions required, and the stateless mode limitation on client callbacks. Also updated the SDK version reference to v1.5.0+.

## Jira

[ARCH-385](https://linuxfoundation.atlassian.net/browse/ARCH-385) — lfx-mcp: Evaluate multi-pod scaling readiness (stateless mode, SchemaCache, session affinity)

---
🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[ARCH-385]: https://linuxfoundation.atlassian.net/browse/ARCH-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ