### PR TITLE
fix: set SpanKind=SERVER on MCP tool call spans

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Config holds all configuration for the LFX MCP server.
@@ -447,7 +448,7 @@ func mcpOTelMiddleware(serverLogger *slog.Logger, serviceName string) mcp.Middle
 					spanName = method + " " + params.Name
 				}
 			}
-			ctx, span := tracer.Start(ctx, spanName)
+			ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindServer))
 			defer span.End()
 
 			// Bind mcp.session.id and mcp.method.name onto a child logger and


### PR DESCRIPTION
## Summary

- Per the [OTel MCP semconv spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#server), MCP server spans SHOULD use `SpanKind = SERVER`
- `mcpOTelMiddleware` was calling `tracer.Start()` without a span kind option, defaulting to `INTERNAL`
- Pass `trace.WithSpanKind(trace.SpanKindServer)` and add the missing `go.opentelemetry.io/otel/trace` import

Jira: [ARCH-386](https://linuxfoundation.atlassian.net/browse/ARCH-386)

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[ARCH-386]: https://linuxfoundation.atlassian.net/browse/ARCH-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ