### PR TITLE
refactor: rename tools to verb-first convention (ARCH-387)

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -124,8 +124,8 @@ var defaultTools = []string{
 	"get_past_meeting_transcript",
 	"search_past_meeting_summaries",
 	"get_past_meeting_summary",
-	"onboarding_list_memberships",
-	"lfx_lens_query",
+	"list_membership_actions",
+	"query_lfx_lens",
 	"search_b2b_orgs",
 	"list_b2b_org_memberships",
 }
@@ -679,11 +679,11 @@ func newServer(cfg Config, serviceName string) *mcp.Server {
 	}
 
 	// Service API tools.
-	if enabledTools["onboarding_list_memberships"] {
-		tools.RegisterOnboardingListMemberships(server)
+	if enabledTools["list_membership_actions"] {
+		tools.RegisterListMembershipActions(server)
 	}
-	if enabledTools["lfx_lens_query"] {
-		tools.RegisterLFXLensQuery(server)
+	if enabledTools["query_lfx_lens"] {
+		tools.RegisterQueryLFXLens(server)
 	}
 
 	return server

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -30,13 +30,13 @@ func SetLensConfig(cfg *LensConfig) {
 
 // --- Tool registration ---
 
-// RegisterLFXLensQuery registers the lfx_lens_query tool.
-func RegisterLFXLensQuery(server *mcp.Server) {
+// RegisterQueryLFXLens registers the query_lfx_lens tool.
+func RegisterQueryLFXLens(server *mcp.Server) {
 	AddServiceTool(server, &mcp.Tool{
-		Name:        "lfx_lens_query",
+		Name:        "query_lfx_lens",
 		Description: "Ask natural language questions about a project's data. LFX Lens covers the following domains: events, education, activity, contributors, maintainers, affiliations, organizations, project health, and project value. It can answer both straightforward text-to-SQL queries and more exploratory, multi-step data questions. Pass your question directly — Lens handles data exploration, SQL generation, and interpretation for each domain. Use search_projects first to find the project slug.",
 		Annotations: &mcp.ToolAnnotations{
-			Title:        "LFX Lens Query",
+			Title:        "Query LFX Lens",
 			ReadOnlyHint: true,
 		},
 	}, ReadScopes(), handleLFXLensQuery)
@@ -44,7 +44,7 @@ func RegisterLFXLensQuery(server *mcp.Server) {
 
 // --- Tool args ---
 
-// LFXLensQueryArgs defines the input for lfx_lens_query.
+// LFXLensQueryArgs defines the input for query_lfx_lens.
 type LFXLensQueryArgs struct {
 	ProjectSlug string `json:"project_slug" jsonschema:"Project slug from search_projects (e.g. 'cncf')"`
 	Input       string `json:"input" jsonschema:"Natural language query about the project (e.g. 'How many active maintainers does this project have?')"`

--- a/internal/tools/onboarding.go
+++ b/internal/tools/onboarding.go
@@ -28,29 +28,29 @@ func SetOnboardingConfig(cfg *OnboardingConfig) {
 
 // --- Tool registration ---
 
-// RegisterOnboardingListMemberships registers the onboarding_list_memberships tool.
-func RegisterOnboardingListMemberships(server *mcp.Server) {
+// RegisterListMembershipActions registers the list_membership_actions tool.
+func RegisterListMembershipActions(server *mcp.Server) {
 	AddServiceTool(server, &mcp.Tool{
-		Name:        "onboarding_list_memberships",
+		Name:        "list_membership_actions",
 		Description: "List memberships for a project with per-agent action and todo counts. Use search_projects first to find the project slug.",
 		Annotations: &mcp.ToolAnnotations{
-			Title:        "List Onboarding Memberships",
+			Title:        "List Membership Actions",
 			ReadOnlyHint: true,
 		},
-	}, WriteScopes(), handleOnboardingListMemberships)
+	}, WriteScopes(), handleListMembershipActions)
 }
 
 // --- Tool args ---
 
-// OnboardingListMembershipsArgs defines the input for onboarding_list_memberships.
-type OnboardingListMembershipsArgs struct {
+// ListMembershipActionsArgs defines the input for list_membership_actions.
+type ListMembershipActionsArgs struct {
 	ProjectSlug string `json:"project_slug" jsonschema:"Project slug from search_projects (e.g. 'agentic-ai-foundation')"`
 	Status      string `json:"status,omitempty" jsonschema:"Filter by status,enum=all,enum=pending,enum=in_progress,enum=closed"`
 }
 
 // --- Tool handlers ---
 
-func handleOnboardingListMemberships(ctx context.Context, req *mcp.CallToolRequest, args OnboardingListMembershipsArgs) (*mcp.CallToolResult, any, error) {
+func handleListMembershipActions(ctx context.Context, req *mcp.CallToolRequest, args ListMembershipActionsArgs) (*mcp.CallToolResult, any, error) {
 	if onboardingConfig == nil {
 		return nil, nil, fmt.Errorf("onboarding tools not configured")
 	}
@@ -89,7 +89,7 @@ func handleOnboardingListMemberships(ctx context.Context, req *mcp.CallToolReque
 		"project_slug": args.ProjectSlug,
 		"status":       status,
 		"memberships":  []any{},
-		"message":      fmt.Sprintf("[dry-run] Would list memberships for project %q with status %q", args.ProjectSlug, status),
+		"message":      fmt.Sprintf("[dry-run] Would list membership actions for project %q with status %q", args.ProjectSlug, status),
 	}
 	body, _ := json.Marshal(dummyResponse)
 


### PR DESCRIPTION
## Summary

Renames two MCP tools that had domain-prefix-before-verb naming, aligning them with the verb-first convention used by all other tools and by the GitHub MCP server.

- `onboarding_list_memberships` → `list_membership_actions` (domain prefix before verb; "memberships" was also misleading — this tool returns per-member onboarding action items/checklist data, not a membership directory)
- `lfx_lens_query` → `query_lfx_lens` (domain prefix before verb)

All other tools (`search_*`, `get_*`, `create_*`, `update_*`, `delete_*`, `list_*`) were already verb-first and are unchanged.

Register functions, type names, titles, `defaultTools` slice, and `enabledTools` guards are all updated to match.

## Jira

[ARCH-387](https://linuxfoundation.atlassian.net/browse/ARCH-387)

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[ARCH-387]: https://linuxfoundation.atlassian.net/browse/ARCH-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ