### PR TITLE
feat: add LFX Lens and Member Onboarding service API config to Helm chart

### DIFF
--- a/charts/lfx-mcp/templates/deployment.yaml
+++ b/charts/lfx-mcp/templates/deployment.yaml
@@ -72,6 +72,22 @@ spec:
               value: {{ .Values.app.tokenEndpoint | quote }}
             - name: LFXMCP_LFX_API_URL
               value: {{ .Values.app.lfxAPIURL | quote }}
+            {{- if .Values.app.lensApiUrl }}
+            - name: LFXMCP_LENS_API_URL
+              value: {{ .Values.app.lensApiUrl | quote }}
+            {{- end }}
+            {{- if .Values.app.lensApiAudience }}
+            - name: LFXMCP_LENS_API_AUDIENCE
+              value: {{ .Values.app.lensApiAudience | quote }}
+            {{- end }}
+            {{- if .Values.app.memberOnboardingApiUrl }}
+            - name: LFXMCP_ONBOARDING_API_URL
+              value: {{ .Values.app.memberOnboardingApiUrl | quote }}
+            {{- end }}
+            {{- if .Values.app.memberOnboardingApiAudience }}
+            - name: LFXMCP_ONBOARDING_API_AUDIENCE
+              value: {{ .Values.app.memberOnboardingApiAudience | quote }}
+            {{- end }}
             - name: LFXMCP_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/lfx-mcp/values.yaml
+++ b/charts/lfx-mcp/values.yaml
@@ -96,6 +96,14 @@ app:
   lfxAPIURL: ""
   # tokenEndpoint is the OAuth2 token endpoint URL used for client credentials.
   tokenEndpoint: ""
+  # lensApiUrl is the base URL of the LFX Lens service.
+  lensApiUrl: ""
+  # lensApiAudience is the Auth0 resource server audience for the LFX Lens API.
+  lensApiAudience: ""
+  # memberOnboardingApiUrl is the base URL of the member onboarding service.
+  memberOnboardingApiUrl: ""
+  # memberOnboardingApiAudience is the Auth0 resource server audience for the member onboarding API.
+  memberOnboardingApiAudience: ""
   # otel contains OpenTelemetry exporter configuration.
   # All values default to empty (no-op tracer) so the chart is deployment-environment agnostic.
   # The values overrides supply the environment-specific endpoint and sample ratio.


### PR DESCRIPTION
## Summary
- Add `lensApiUrl`, `lensApiAudience`, `memberOnboardingApiUrl`, and `memberOnboardingApiAudience` to the Helm chart values and deployment template
- These are already configured in the ArgoCD values overrides but were not wired through to env vars, so both service tools were silently disabled

## Test plan
- [ ] After merge + deploy, verify `LFXMCP_LENS_API_URL` and `LFXMCP_ONBOARDING_API_URL` appear in the MCP pod env
- [ ] Verify `lfx_lens_query` and `onboarding_list_memberships` tools are no longer reported as "not configured"

🤖 Generated with [Claude Code](https://claude.com/claude-code)