### PR TITLE
fix: strip v1 user_id from mailing list member responses

### DIFF
--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -334,6 +334,9 @@ func handleGetMailingListMember(ctx context.Context, req *mcp.CallToolRequest, a
 		}, nil, nil
 	}
 
+	// Mask v1 user ID — see LFXV2-1466.
+	result.UserID = nil
+
 	prettyJSON, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal mailing list member result", "error", err)
@@ -533,6 +536,14 @@ func handleSearchMailingListMembers(ctx context.Context, req *mcp.CallToolReques
 	type searchResult struct {
 		Resources []*querysvc.Resource `json:"resources"`
 		PageToken *string              `json:"page_token,omitempty"`
+	}
+
+	// Strip v1 user_id and internal source field from indexed data — see LFXV2-1466.
+	for _, r := range result.Resources {
+		if data, ok := r.Data.(map[string]any); ok {
+			delete(data, "user_id")
+			delete(data, "source")
+		}
 	}
 
 	out := searchResult{


### PR DESCRIPTION
## Summary

- Strip v1 `UserID` from `get_mailing_list_member` responses (nil the field before serialization)
- Strip `user_id` and `source` from `search_mailing_list_members` query service results (delete from `Resource.Data` map)

These are internal/legacy fields that should not be exposed to MCP consumers. The upstream fix is tracked in LFXV2-1466.

Note: `get_mailing_list` is currently broken due to LFXV2-1466 — the upstream mailing-list-service returns `project_uid: ""` (empty string) which fails Goa client-side UUID validation. That fix is upstream, not addressed here.

ARCH-388

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)