### PR TITLE
fix: use accessDeniedMessage for slug resolution failures

### DIFF
--- a/internal/lfxv2/slug_resolver.go
+++ b/internal/lfxv2/slug_resolver.go
@@ -6,12 +6,18 @@ package lfxv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
 	querysvc "github.com/linuxfoundation/lfx-v2-query-service/gen/query_svc"
 )
+
+// ErrProjectNotFound is returned by Resolve when the query service returns
+// no results for the given slug. Callers can use errors.Is to distinguish this
+// "not found" case from transport or other operational errors.
+var ErrProjectNotFound = errors.New("project not found")
 
 // SlugResolver resolves project slugs to V2 UUIDs with in-memory caching.
 //
@@ -77,7 +83,7 @@ func (r *SlugResolver) queryProjectUUID(ctx context.Context, clients *Clients, s
 	}
 
 	if result == nil || len(result.Resources) == 0 {
-		return "", fmt.Errorf("project not found for slug %q", slug)
+		return "", fmt.Errorf("%w for slug %q", ErrProjectNotFound, slug)
 	}
 
 	id := result.Resources[0].ID

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -6,9 +6,12 @@ package tools
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 
+	"github.com/linuxfoundation/lfx-mcp/internal/lfxv2"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -94,7 +97,19 @@ func strPtr(s string) *string {
 // API call is rejected with HTTP 403.
 const accessDeniedMessage = "this resource may not exist or you may not have enough access to complete this operation. Request support @ https://support.lfx.dev"
 
-// friendlyAPIError formats an API error for display in a tool result.
+// slugResolveError maps a slug resolver error to a user-facing error.
+// When the error is ErrProjectNotFound (the slug returned no results from the
+// query service), it surfaces accessDeniedMessage consistent with other
+// access-denied paths. All other errors (transport failures, context
+// cancellation, etc.) are wrapped and returned as-is so operators can
+// diagnose operational issues.
+func slugResolveError(slug string, err error) error {
+	if errors.Is(err, lfxv2.ErrProjectNotFound) {
+		return fmt.Errorf("failed to get project %q: %s", slug, accessDeniedMessage)
+	}
+	return fmt.Errorf("failed to resolve project slug %q: %w", slug, err)
+}
+
 // If the error contains "response code 403" it returns a user-friendly
 // access-denied message instead of the raw internal error string.
 // The op argument is a short description of the operation (e.g.

--- a/internal/tools/helpers_test.go
+++ b/internal/tools/helpers_test.go
@@ -5,7 +5,11 @@ package tools
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/linuxfoundation/lfx-mcp/internal/lfxv2"
 )
 
 func TestFriendlyAPIError_403(t *testing.T) {
@@ -60,5 +64,39 @@ func TestFriendlyAPIError_accessDeniedNoPrefix(t *testing.T) {
 	got := friendlyAPIError("failed to get project", err)
 	if len(got) >= 7 && got[:7] == "Error: " {
 		t.Errorf("access denied message must not start with 'Error: ', got: %q", got)
+	}
+}
+
+func TestSlugResolveError_notFound(t *testing.T) {
+	// ErrProjectNotFound must map to accessDeniedMessage, not the raw sentinel.
+	err := fmt.Errorf("%w for slug %q", lfxv2.ErrProjectNotFound, "aaif")
+	got := slugResolveError("aaif", err)
+	if !strings.Contains(got.Error(), accessDeniedMessage) {
+		t.Errorf("expected accessDeniedMessage in error, got: %q", got)
+	}
+	// Must not expose internal implementation detail ("resolve", "not found", etc.).
+	if strings.Contains(got.Error(), "resolve") || strings.Contains(got.Error(), "not found") {
+		t.Errorf("internal slug resolution detail must not leak to user, got: %q", got)
+	}
+}
+
+func TestSlugResolveError_transportError(t *testing.T) {
+	// Non-not-found errors must NOT be rewritten to accessDeniedMessage.
+	err := errors.New("connection refused")
+	got := slugResolveError("aaif", err)
+	if strings.Contains(got.Error(), accessDeniedMessage) {
+		t.Errorf("transport error must not become accessDeniedMessage, got: %q", got)
+	}
+	if !strings.Contains(got.Error(), "connection refused") {
+		t.Errorf("transport error text must be preserved, got: %q", got)
+	}
+}
+
+func TestSlugResolveError_contextCanceled(t *testing.T) {
+	// Context errors must NOT be rewritten to accessDeniedMessage.
+	err := fmt.Errorf("query failed: %w", errors.New("context canceled"))
+	got := slugResolveError("tlf", err)
+	if strings.Contains(got.Error(), accessDeniedMessage) {
+		t.Errorf("context error must not become accessDeniedMessage, got: %q", got)
 	}
 }

--- a/internal/tools/service.go
+++ b/internal/tools/service.go
@@ -83,7 +83,7 @@ func (s *ServiceAuth) AuthorizeProject(ctx context.Context, req *mcp.CallToolReq
 	projectUUID, err := s.SlugResolver.Resolve(ctx, clients, slug)
 	if err != nil {
 		logger.Error("failed to resolve project slug", "error", err, "slug", slug)
-		return ctx, fmt.Errorf("failed to resolve project slug %q: %s", slug, accessDeniedMessage)
+		return ctx, slugResolveError(slug, err)
 	}
 
 	// Get exchanged V2 token for access-check.

--- a/internal/tools/service.go
+++ b/internal/tools/service.go
@@ -83,7 +83,7 @@ func (s *ServiceAuth) AuthorizeProject(ctx context.Context, req *mcp.CallToolReq
 	projectUUID, err := s.SlugResolver.Resolve(ctx, clients, slug)
 	if err != nil {
 		logger.Error("failed to resolve project slug", "error", err, "slug", slug)
-		return ctx, fmt.Errorf("failed to resolve project slug %q: %w", slug, err)
+		return ctx, fmt.Errorf("failed to resolve project slug %q: %s", slug, accessDeniedMessage)
 	}
 
 	// Get exchanged V2 token for access-check.


### PR DESCRIPTION
## Summary

When the V2 query service returns no results for a project slug, the user previously saw a raw `"project not found for slug X"` error. This is misleading — the project may exist in LFX but simply not be onboarded into LFX v2 yet (e.g. `cncf`).

This change surfaces the same `accessDeniedMessage` used for 403 responses instead, keeping the UX consistent. The actual internal error (slug + cause) is still logged server-side for operators.

## Changes

- `internal/tools/service.go`: wrap slug resolution failures with `accessDeniedMessage` instead of propagating the raw error string

## Jira

ARCH-390

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)