### PR TITLE
Remove self-service auditor check from LFX Lens MCP tool

### DIFF
--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -74,11 +74,11 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		return nil, nil, fmt.Errorf("LFX Lens tools not configured")
 	}
 
-	// Project-level authorization — auditor relation required.
-	ctx, err := lensConfig.AuthorizeProject(ctx, req, args.ProjectSlug, RelationAuditor)
-	if err != nil {
-		return nil, nil, err
-	}
+	// No project-level access-check: the tool is already restricted to LF
+	// staff at registration time (isStaff gate in newServer), and LF staff
+	// are being granted auditor on all projects. The self-service auditor
+	// relation check is omitted because it does not exist for non-onboarded
+	// projects, which would incorrectly block legitimate staff queries.
 
 	additionalData, err := json.Marshal(lensWorkflowAdditional{
 		Foundation: lensFoundation{Slug: args.ProjectSlug},

--- a/internal/tools/service.go
+++ b/internal/tools/service.go
@@ -27,10 +27,6 @@ const (
 	// RelationWriter is required for tools that mutate project resources
 	// (e.g., member onboarding).
 	RelationWriter = "writer"
-
-	// RelationAuditor is required for tools that read privileged project
-	// data (e.g., LFX Lens analytics).
-	RelationAuditor = "auditor"
 )
 
 // --- Shared service tool infrastructure ---


### PR DESCRIPTION
## Summary

- Removes the per-project `auditor` OpenFGA access-check from `handleLFXLensQuery`
- Removes the now-unused `RelationAuditor` constant from `service.go`
- The `isStaff` gate at registration time remains as the sole authorization gate

## Rationale

LFX Lens via MCP is restricted to LF staff at registration time (`isStaff` gate in `newServer`). The per-project auditor access-check was also running, but:

1. Self-service permissions (and therefore auditor relations) don't exist for non-onboarded projects
2. This incorrectly blocked LF staff from querying Lens on those projects
3. LF staff are planned to have auditor on all projects anyway
4. The `isStaff` check is sufficient — there is no reason to require the auditor relation check on top of it

Jira: [ARCH-391](https://linuxfoundation.atlassian.net/browse/ARCH-391)

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[ARCH-391]: https://linuxfoundation.atlassian.net/browse/ARCH-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ