### PR TITLE
Fix nil TokenInfo handling and add OTel tracing for Lens/Onboarding clients

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -363,7 +363,9 @@ func main() {
 					onboardingClient, err := serviceapi.NewClient(serviceapi.Config{
 						BaseURL:     cfg.OnboardingAPIURL,
 						TokenSource: ccClient,
-						HTTPClient:  &http.Client{Timeout: 30 * time.Second},
+						// Wrap with OTel transport so onboarding API calls appear as
+						// child spans under the active request trace.
+						HTTPClient:  &http.Client{Timeout: 30 * time.Second, Transport: otelhttp.NewTransport(http.DefaultTransport)},
 						DebugLogger: debugLogger,
 					})
 					if err != nil {
@@ -388,7 +390,9 @@ func main() {
 					lensClient, err := serviceapi.NewClient(serviceapi.Config{
 						BaseURL:     cfg.LensAPIURL,
 						TokenSource: ccClient,
-						HTTPClient:  &http.Client{Timeout: 120 * time.Second},
+						// Wrap with OTel transport so Lens API calls appear as child
+						// spans under the active request trace.
+						HTTPClient:  &http.Client{Timeout: 120 * time.Second, Transport: otelhttp.NewTransport(http.DefaultTransport)},
 						DebugLogger: debugLogger,
 					})
 					if err != nil {

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -80,6 +80,13 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 	// relation check is omitted because it does not exist for non-onboarded
 	// projects, which would incorrectly block legitimate staff queries.
 
+	// Derive a user ID for the Lens API. In stdio mode TokenInfo is nil
+	// (unauthenticated local use), so fall back to a stable anonymous value.
+	userID := AnonymousUserID
+	if req.Extra.TokenInfo != nil && req.Extra.TokenInfo.UserID != "" {
+		userID = req.Extra.TokenInfo.UserID
+	}
+
 	additionalData, err := json.Marshal(lensWorkflowAdditional{
 		Foundation: lensFoundation{Slug: args.ProjectSlug},
 	})
@@ -90,8 +97,8 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 	body, statusCode, err := lensConfig.ServiceClient.PostMultipart(ctx, "/lfx-lens/mcp/query", map[string]string{
 		"message":         args.Input,
 		"additional_data": string(additionalData),
-		"user_id":         req.Extra.TokenInfo.UserID,
-		"session_id":      req.Extra.TokenInfo.UserID + "-" + time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		"user_id":         userID,
+		"session_id":      userID + "-" + time.Now().UTC().Format("2006-01-02T15:04:05Z"),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("lens API call failed: %w", err)

--- a/internal/tools/service.go
+++ b/internal/tools/service.go
@@ -19,9 +19,13 @@ import (
 // membership (lf-staff group). Uses the lfxPrefix namespace per convention.
 const ClaimLFStaff = "http://lfx.dev/claims/lf_staff"
 
-// Relation constants for V2 access-check. These are the service API equivalents
-// of ScopeRead / ScopeManage — they define what project-level relationship is
-// required, but enforcement happens inside the tool handler via the V2
+// AnonymousUserID is the sentinel user ID used when no authenticated user is
+// present (e.g., stdio mode). Matches the convention used across LFX services
+// such as Heimdall.
+const AnonymousUserID = "_anonymous"
+
+// Relation constants for V2 access-check. These define what project-level
+// relationship is required, enforced inside tool handlers via the V2
 // access-check endpoint (not at dispatch like MCP scopes).
 const (
 	// RelationWriter is required for tools that mutate project resources


### PR DESCRIPTION
Follow-up to #65, addressing Copilot review comments and the OTel tracing gap found during audit.

## Changes

**`internal/tools/lens.go`** — safe anonymous fallback for `user_id`/`session_id` when `TokenInfo` is nil (stdio / unauthenticated mode). Falls back to `AnonymousUserID` (`_anonymous`) rather than panicking.

**`internal/tools/service.go`** — adds `AnonymousUserID = "_anonymous"` const matching the convention used across LFX services (Heimdall etc.). Also cleans up the stale `const` block comment left after `RelationAuditor` was removed.

**`cmd/lfx-mcp-server/main.go`** — wraps the Lens and Onboarding `serviceapi` HTTP clients with `otelhttp.NewTransport` so their outbound API calls appear as child spans in distributed traces. M2M token fetches (`ClientCredentialsClient`) and `AccessCheckClient` are intentionally left untraced as they are infrastructure/cached operations without a meaningful request-scoped span.

Jira: [ARCH-391](https://linuxfoundation.atlassian.net/browse/ARCH-391)

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[ARCH-391]: https://linuxfoundation.atlassian.net/browse/ARCH-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ