### PR TITLE
fix(committee): strip unreliable total_members field from responses

### DIFF
--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -184,6 +184,16 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 		PageToken *string              `json:"page_token,omitempty"`
 	}
 
+	// Strip the unreliable total_members field from indexed committee data. The
+	// query service index does not maintain an accurate member count, so this
+	// field is always zero regardless of actual membership. Removing it prevents
+	// MCP clients from incorrectly concluding that a committee has no members.
+	for _, r := range result.Resources {
+		if data, ok := r.Data.(map[string]any); ok {
+			delete(data, "total_members")
+		}
+	}
+
 	out := searchResult{
 		Resources: result.Resources,
 		PageToken: result.PageToken,
@@ -283,6 +293,14 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 		logger.ErrorContext(ctx, "getting privileged committee settings failed, returning base only", "error", err, "uid", args.UID)
 	} else {
 		committeeSettings = settingsResult.CommitteeSettings
+	}
+
+	// Strip the unreliable TotalMembers field from the committee base. The
+	// service does not populate this count reliably, so it is always zero
+	// regardless of actual membership. Removing it prevents MCP clients from
+	// incorrectly concluding that a committee has no members.
+	if baseResult.CommitteeBase != nil {
+		baseResult.CommitteeBase.TotalMembers = nil
 	}
 
 	type committeeResult struct {


### PR DESCRIPTION
## Summary

- Strip `total_members` from `search_committees` results (map key delete on the query service indexed data).
- Nil out `TotalMembers` from `get_committee` results (struct field on the committee service base).

## Problem

`total_members` is always `0` across all committees in both the query service (`search_committees`) and the committee service (`get_committee`), even when `search_committee_members` returns many active members. Verified against TLF and AAIF projects.

This is a regression of LFXV2-754, whose fix incremented/decremented the count on new member add/remove operations but never backfilled existing committees. Upstream regression tracked in LFXV2-1513.

The misleading zero causes MCP clients to skip member lookups entirely, producing incorrect results (e.g., a Governing Board appearing to have no members).

## Approach

Same pattern as the prior LFXV2-1466 workaround (removed in 74d48a09): strip/nil the field at the MCP layer until the upstream fix and backfill lands.

`total_voting_repos` is left untouched — the committee service conditionally omits it when zero (`if TotalVotingRepos > 0`), so zero/absent is semantically correct for most committees.

## Related

- Upstream bug: LFXV2-1513
- Prior fix (regressed): LFXV2-754
- ARCH ticket: ARCH-337

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)