### PR TITLE
feat: register resolve_slug_lfx_lens tool with staff check

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -134,6 +134,7 @@ var defaultTools = []string{
 	"list_email_templates",
 	"send_email",
 	"query_lfx_lens",
+	"resolve_slug_lfx_lens",
 	"search_b2b_orgs",
 	"list_b2b_org_memberships",
 }
@@ -734,6 +735,9 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 	}
 	if enabledTools["query_lfx_lens"] && canRead && isStaff {
 		tools.RegisterQueryLFXLens(server)
+	}
+	if enabledTools["resolve_slug_lfx_lens"] && canRead && isStaff {
+		tools.RegisterResolveSlugLFXLens(server)
 	}
 
 	return server

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -30,6 +30,18 @@ func SetLensConfig(cfg *LensConfig) {
 
 // --- Tool registration ---
 
+// RegisterResolveSlugLFXLens registers the resolve_slug_lfx_lens tool.
+func RegisterResolveSlugLFXLens(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "resolve_slug_lfx_lens",
+		Description: "Resolve a project name to its canonical slug using fuzzy matching. Returns the top 3 matches ranked by similarity. Use this when you have a project name but need the exact slug for other LFX Lens tools.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Resolve Slug (LFX Lens)",
+			ReadOnlyHint: true,
+		},
+	}, handleResolveLensSlug)
+}
+
 // RegisterQueryLFXLens registers the query_lfx_lens tool.
 func RegisterQueryLFXLens(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
@@ -43,6 +55,11 @@ func RegisterQueryLFXLens(server *mcp.Server) {
 }
 
 // --- Tool args ---
+
+// ResolveLensSlugArgs defines the input for resolve_slug_lfx_lens.
+type ResolveLensSlugArgs struct {
+	Name string `json:"name" jsonschema:"Project name to resolve into a slug (e.g. 'Kubernetes', 'Linux Kernel')"`
+}
 
 // QueryLFXLensArgs defines the input for query_lfx_lens.
 type QueryLFXLensArgs struct {
@@ -65,6 +82,19 @@ type lensQueryResponse struct {
 	Content   string `json:"content"`
 	Status    string `json:"status"`
 	SessionID string `json:"session_id"`
+}
+
+// lensSlugMatch is a single fuzzy-match result from the resolve-slug endpoint.
+type lensSlugMatch struct {
+	Slug       string  `json:"slug"`
+	Name       string  `json:"name"`
+	Similarity float64 `json:"similarity"`
+}
+
+// lensResolveSlugResponse is the JSON response from the resolve-slug endpoint.
+type lensResolveSlugResponse struct {
+	Query   string          `json:"query"`
+	Matches []lensSlugMatch `json:"matches"`
 }
 
 // --- Tool handlers ---
@@ -114,5 +144,41 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: resp.Content}},
+	}, nil, nil
+}
+
+func handleResolveLensSlug(ctx context.Context, req *mcp.CallToolRequest, args ResolveLensSlugArgs) (*mcp.CallToolResult, any, error) {
+	if lensConfig == nil {
+		return nil, nil, fmt.Errorf("LFX Lens tools not configured")
+	}
+
+	body, statusCode, err := lensConfig.ServiceClient.PostMultipart(ctx, "/lfx-lens/resolve-slug", map[string]string{
+		"name": args.Name,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("lens API call failed: %w", err)
+	}
+	if statusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("lens service returned status %d: %s", statusCode, string(body))
+	}
+
+	var resp lensResolveSlugResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse resolve-slug response: %w", err)
+	}
+
+	// Format matches as readable text for the LLM.
+	var text string
+	if len(resp.Matches) == 0 {
+		text = fmt.Sprintf("No matches found for %q.", args.Name)
+	} else {
+		text = fmt.Sprintf("Top matches for %q:\n", args.Name)
+		for i, m := range resp.Matches {
+			text += fmt.Sprintf("%d. slug=%q  name=%q  similarity=%.1f\n", i+1, m.Slug, m.Name, m.Similarity)
+		}
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: text}},
 	}, nil, nil
 }

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -46,7 +46,7 @@ func RegisterResolveSlugLFXLens(server *mcp.Server) {
 func RegisterQueryLFXLens(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "query_lfx_lens",
-		Description: "Ask natural language questions about a project's data. LFX Lens covers the following domains: events, education, activity, contributors, maintainers, affiliations, organizations, project health, and project value. It can answer both straightforward text-to-SQL queries and more exploratory, multi-step data questions. Pass your question directly — Lens handles data exploration, SQL generation, and interpretation for each domain. Use search_projects first to find the project slug.",
+		Description: "Ask natural language questions about a project's data. LFX Lens covers the following domains: events, education, activity, contributors, maintainers, affiliations, organizations, project health, and project value. It can answer both straightforward text-to-SQL queries and more exploratory, multi-step data questions. Pass your question directly — Lens handles data exploration, SQL generation, and interpretation for each domain. Use resolve_slug_lfx_lens first to find the project slug.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "LFX Lens Query",
 			ReadOnlyHint: true,


### PR DESCRIPTION
## Summary
- Adds `resolve_slug_lfx_lens` to the default tool list
- Registers the tool gated behind `canRead && isStaff`, matching the existing `query_lfx_lens` pattern
- Companion PR: linuxfoundation/lfx-lens#15 (adds the `/lfx-lens/resolve-slug` endpoint)

## Test plan
- [x] Tested locally with MCP server against local lfx-lens — slug resolution works end-to-end with Auth0 M2M auth
- [ ] Verify tool only appears for LF staff users
- [ ] Verify non-staff users don't see the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)