### PR TITLE
feat: add background polling mode to query_lfx_lens tool

### DIFF
--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -35,7 +35,7 @@ func SetLensConfig(cfg *LensConfig) {
 func RegisterQueryLFXLens(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "query_lfx_lens",
-		Description: `Ask natural language questions about a project's data. LFX Lens covers: events, education, activity, contributors, maintainers, affiliations, organizations, project health, and project value. It handles data exploration, SQL generation, and interpretation. Use search_projects first to find the project slug.
+		Description: `Ask natural language questions about a project's data. LFX Lens covers: events, education, activity, contributors, maintainers, affiliations, organizations, project health, and project value. It handles data exploration, SQL generation and execution. Use search_projects first to find the project slug.
 
 This tool works in two modes:
 1. START a query: pass project_slug and input. Returns run_id, session_id, and status=PENDING.

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/linuxfoundation/lfx-mcp/internal/serviceapi"
@@ -33,8 +34,14 @@ func SetLensConfig(cfg *LensConfig) {
 // RegisterQueryLFXLens registers the query_lfx_lens tool.
 func RegisterQueryLFXLens(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "query_lfx_lens",
-		Description: "Ask natural language questions about a project's data. LFX Lens covers the following domains: events, education, activity, contributors, maintainers, affiliations, organizations, project health, and project value. It can answer both straightforward text-to-SQL queries and more exploratory, multi-step data questions. Pass your question directly — Lens handles data exploration, SQL generation, and interpretation for each domain. Use search_projects first to find the project slug.",
+		Name: "query_lfx_lens",
+		Description: `Ask natural language questions about a project's data. LFX Lens covers: events, education, activity, contributors, maintainers, affiliations, organizations, project health, and project value. It handles data exploration, SQL generation, and interpretation. Use search_projects first to find the project slug.
+
+This tool works in two modes:
+1. START a query: pass project_slug and input. Returns run_id, session_id, and status=PENDING.
+2. POLL for results: pass run_id and session_id from the start response. Returns status and content.
+
+After starting a query, wait 10 seconds, then call this tool again with run_id and session_id to poll. If status is PENDING or RUNNING, wait 5 seconds and poll again. If status is COMPLETED, the content field has the answer. If status is ERROR, the content field has the error details.`,
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "LFX Lens Query",
 			ReadOnlyHint: true,
@@ -45,9 +52,13 @@ func RegisterQueryLFXLens(server *mcp.Server) {
 // --- Tool args ---
 
 // QueryLFXLensArgs defines the input for query_lfx_lens.
+// To start a query: provide project_slug and input.
+// To poll for results: provide run_id and session_id.
 type QueryLFXLensArgs struct {
-	ProjectSlug string `json:"project_slug" jsonschema:"Project slug from search_projects (e.g. 'cncf')"`
-	Input       string `json:"input" jsonschema:"Natural language query about the project (e.g. 'How many active maintainers does this project have?')"`
+	ProjectSlug string `json:"project_slug,omitempty" jsonschema:"Project slug from search_projects (e.g. 'cncf'). Required to start a query."`
+	Input       string `json:"input,omitempty" jsonschema:"Natural language query about the project. Required to start a query."`
+	RunID       string `json:"run_id,omitempty" jsonschema:"Run ID from a previous call. Pass this to poll for results."`
+	SessionID   string `json:"session_id,omitempty" jsonschema:"Session ID from a previous call. Pass this to poll for results."`
 }
 
 // lensWorkflowAdditional is the additional_data payload sent to the Lens workflow endpoint.
@@ -60,11 +71,13 @@ type lensFoundation struct {
 	Slug string `json:"slug"`
 }
 
-// lensQueryResponse is the JSON response from the Lens query endpoint.
+// lensQueryResponse is the unified JSON response from start and poll endpoints.
 type lensQueryResponse struct {
-	Content   string `json:"content"`
-	Status    string `json:"status"`
-	SessionID string `json:"session_id"`
+	Content    string `json:"content,omitempty"`
+	Status     string `json:"status"`
+	SessionID  string `json:"session_id"`
+	RunID      string `json:"run_id,omitempty"`
+	WorkflowID string `json:"workflow_id,omitempty"`
 }
 
 // --- Tool handlers ---
@@ -74,18 +87,23 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		return nil, nil, fmt.Errorf("LFX Lens tools not configured")
 	}
 
-	// No project-level access-check: the tool is already restricted to LF
-	// staff at registration time (isStaff gate in newServer), and LF staff
-	// are being granted auditor on all projects. The self-service auditor
-	// relation check is omitted because it does not exist for non-onboarded
-	// projects, which would incorrectly block legitimate staff queries.
+	// Poll mode: run_id and session_id provided
+	if args.RunID != "" && args.SessionID != "" {
+		return pollLFXLensQuery(ctx, args.RunID, args.SessionID)
+	}
 
-	// Derive a user ID for the Lens API. In stdio mode TokenInfo is nil
-	// (unauthenticated local use), so fall back to a stable anonymous value.
+	// Start mode: project_slug and input required
+	if args.ProjectSlug == "" || args.Input == "" {
+		return nil, nil, fmt.Errorf("project_slug and input are required to start a query, or run_id and session_id to poll")
+	}
+
+	// Derive a user ID for the Lens API.
 	userID := AnonymousUserID
 	if req.Extra.TokenInfo != nil && req.Extra.TokenInfo.UserID != "" {
 		userID = req.Extra.TokenInfo.UserID
 	}
+
+	sessionID := userID + "-" + time.Now().UTC().Format("2006-01-02T15:04:05Z")
 
 	additionalData, err := json.Marshal(lensWorkflowAdditional{
 		Foundation: lensFoundation{Slug: args.ProjectSlug},
@@ -98,7 +116,8 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		"message":         args.Input,
 		"additional_data": string(additionalData),
 		"user_id":         userID,
-		"session_id":      userID + "-" + time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		"session_id":      sessionID,
+		"background":      "true",
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("lens API call failed: %w", err)
@@ -109,10 +128,53 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 
 	var resp lensQueryResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse Lens response: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse Lens start response: %w", err)
 	}
 
+	text := fmt.Sprintf("Query started. Status: %s\nrun_id: %s\nsession_id: %s\n\nWait 10 seconds, then call this tool again with run_id and session_id to get the results.",
+		resp.Status, resp.RunID, resp.SessionID)
+
 	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: resp.Content}},
+		Content: []mcp.Content{&mcp.TextContent{Text: text}},
 	}, nil, nil
+}
+
+// pollLFXLensQuery polls for the result of a background workflow run.
+func pollLFXLensQuery(ctx context.Context, runID, sessionID string) (*mcp.CallToolResult, any, error) {
+	pollPath := fmt.Sprintf("/lfx-lens/mcp/query/poll/%s", runID)
+	pollQuery := url.Values{"session_id": {sessionID}}
+
+	body, statusCode, err := lensConfig.ServiceClient.Get(ctx, pollPath, pollQuery)
+	if err != nil {
+		return nil, nil, fmt.Errorf("lens poll request failed: %w", err)
+	}
+	if statusCode == http.StatusNotFound {
+		return nil, nil, fmt.Errorf("run not found: %s", runID)
+	}
+	if statusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("lens poll returned status %d: %s", statusCode, string(body))
+	}
+
+	var resp lensQueryResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse poll response: %w", err)
+	}
+
+	switch resp.Status {
+	case "COMPLETED":
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: resp.Content}},
+		}, nil, nil
+	case "ERROR":
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Workflow error: %s", resp.Content)}},
+			IsError: true,
+		}, nil, nil
+	default:
+		text := fmt.Sprintf("Status: %s\nrun_id: %s\nsession_id: %s\n\nThe query is still running. Wait 5 seconds and poll again with run_id and session_id.",
+			resp.Status, runID, sessionID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
+		}, nil, nil
+	}
 }


### PR DESCRIPTION
## Summary
- `query_lfx_lens` now works in two modes via a single tool: **start** (sends `background=true`, returns `run_id`/`session_id`) and **poll** (calls the new poll endpoint with `run_id`/`session_id`)
- The LLM drives the polling loop based on instructions in the tool response (wait 10s, then poll every 5s)
- Unified response struct (`lensQueryResponse`) to match the new unified Lens API response shape
- Depends on linuxfoundation/lfx-lens#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)