### PR TITLE
feat: run LFX Lens queries synchronously

### DIFF
--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -48,8 +48,8 @@ This tool runs synchronously and returns the full answer in one call. Queries ty
 
 // QueryLFXLensArgs defines the input for query_lfx_lens.
 type QueryLFXLensArgs struct {
-	ProjectSlug string `json:"project_slug" jsonschema:"Project slug from search_projects (e.g. 'cncf')."`
-	Input       string `json:"input" jsonschema:"Natural language query about the project."`
+	ProjectSlug string `json:"project_slug" jsonschema:"Project slug from search_projects (e.g. 'cncf') (required)"`
+	Input       string `json:"input" jsonschema:"Natural language query about the project (required)"`
 }
 
 // lensWorkflowAdditional is the additional_data payload sent to the Lens workflow endpoint.

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/linuxfoundation/lfx-mcp/internal/serviceapi"
@@ -37,11 +36,7 @@ func RegisterQueryLFXLens(server *mcp.Server) {
 		Name: "query_lfx_lens",
 		Description: `Ask natural language questions about a project's data. LFX Lens covers: events, education, activity, contributors, maintainers, affiliations, organizations, project health, and project value. It handles data exploration, SQL generation and execution. Use search_projects first to find the project slug.
 
-This tool works in two modes:
-1. START a query: pass project_slug and input. Returns run_id, session_id, and status=PENDING.
-2. POLL for results: pass run_id and session_id from the start response. Returns status and content.
-
-After starting a query, wait 10 seconds, then call this tool again with run_id and session_id to poll. If status is PENDING or RUNNING, wait 5 seconds and poll again. If status is COMPLETED, the content field has the answer. If status is ERROR, the content field has the error details.`,
+This tool runs synchronously and returns the full answer in one call. Queries typically take 30–60 seconds — please wait for the result without retrying.`,
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "LFX Lens Query",
 			ReadOnlyHint: true,
@@ -52,13 +47,9 @@ After starting a query, wait 10 seconds, then call this tool again with run_id a
 // --- Tool args ---
 
 // QueryLFXLensArgs defines the input for query_lfx_lens.
-// To start a query: provide project_slug and input.
-// To poll for results: provide run_id and session_id.
 type QueryLFXLensArgs struct {
-	ProjectSlug string `json:"project_slug,omitempty" jsonschema:"Project slug from search_projects (e.g. 'cncf'). Required to start a query."`
-	Input       string `json:"input,omitempty" jsonschema:"Natural language query about the project. Required to start a query."`
-	RunID       string `json:"run_id,omitempty" jsonschema:"Run ID from a previous call. Pass this to poll for results."`
-	SessionID   string `json:"session_id,omitempty" jsonschema:"Session ID from a previous call. Pass this to poll for results."`
+	ProjectSlug string `json:"project_slug" jsonschema:"Project slug from search_projects (e.g. 'cncf')."`
+	Input       string `json:"input" jsonschema:"Natural language query about the project."`
 }
 
 // lensWorkflowAdditional is the additional_data payload sent to the Lens workflow endpoint.
@@ -89,17 +80,10 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		return nil, nil, fmt.Errorf("LFX Lens tools not configured")
 	}
 
-	// Poll mode: run_id and session_id provided
-	if args.RunID != "" && args.SessionID != "" {
-		return pollLFXLensQuery(ctx, args.RunID, args.SessionID)
-	}
-
-	// Start mode: project_slug and input required
 	if args.ProjectSlug == "" || args.Input == "" {
-		return nil, nil, fmt.Errorf("project_slug and input are required to start a query, or run_id and session_id to poll")
+		return nil, nil, fmt.Errorf("project_slug and input are required")
 	}
 
-	// Derive a user ID for the Lens API.
 	userID := AnonymousUserID
 	if req.Extra.TokenInfo != nil && req.Extra.TokenInfo.UserID != "" {
 		userID = req.Extra.TokenInfo.UserID
@@ -121,7 +105,7 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		"user_id":         userID,
 		"session_id":      sessionID,
 		"stream":          "false",
-		"background":      "true",
+		"background":      "false",
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("lens API call failed: %w", err)
@@ -132,53 +116,17 @@ func handleLFXLensQuery(ctx context.Context, req *mcp.CallToolRequest, args Quer
 
 	var resp lensQueryResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse Lens start response: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse Lens response: %w", err)
 	}
 
-	text := fmt.Sprintf("Query started. Status: %s\nrun_id: %s\nsession_id: %s\n\nWait 10 seconds, then call this tool again with run_id and session_id to get the results.",
-		resp.Status, resp.RunID, resp.SessionID)
-
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: text}},
-	}, nil, nil
-}
-
-// pollLFXLensQuery polls for the result of a background workflow run.
-func pollLFXLensQuery(ctx context.Context, runID, sessionID string) (*mcp.CallToolResult, any, error) {
-	pollPath := fmt.Sprintf("/workflows/%s/runs/%s", lensWorkflowID, runID)
-	pollQuery := url.Values{"session_id": {sessionID}}
-
-	body, statusCode, err := lensConfig.ServiceClient.Get(ctx, pollPath, pollQuery)
-	if err != nil {
-		return nil, nil, fmt.Errorf("lens poll request failed: %w", err)
-	}
-	if statusCode == http.StatusNotFound {
-		return nil, nil, fmt.Errorf("run not found: %s", runID)
-	}
-	if statusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("lens poll returned status %d: %s", statusCode, string(body))
-	}
-
-	var resp lensQueryResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse poll response: %w", err)
-	}
-
-	switch resp.Status {
-	case "COMPLETED":
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: resp.Content}},
-		}, nil, nil
-	case "ERROR":
+	if resp.Status == "ERROR" {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Workflow error: %s", resp.Content)}},
 			IsError: true,
 		}, nil, nil
-	default:
-		text := fmt.Sprintf("Status: %s\nrun_id: %s\nsession_id: %s\n\nThe query is still running. Wait 5 seconds and poll again with run_id and session_id.",
-			resp.Status, runID, sessionID)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: text}},
-		}, nil, nil
 	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: resp.Content}},
+	}, nil, nil
 }


### PR DESCRIPTION
## Summary

- **Replace start+poll with a single synchronous call** — passes `background=false` to agno's built-in workflow endpoint and waits for the result directly
- **Simplify tool args** — `run_id` and `session_id` removed; only `project_slug` and `input` needed
- **Update tool description** — notes queries run synchronously and may take up to a minute

The lens HTTP client already has a 120s timeout so no changes needed there.

## Test plan

- [ ] Build and test locally with lfx-lens running
- [ ] Verify Cursor/Claude Desktop receives the full result in one tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)