### PR TITLE
fix: correct committee_uid filtering across meeting search tools

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -121,10 +121,10 @@ var defaultTools = []string{
 	"get_meeting_registrant",
 	"search_past_meeting_participants",
 	"get_past_meeting_participant",
-	"search_past_meeting_transcripts",
-	"get_past_meeting_transcript",
 	"search_past_meeting_summaries",
 	"get_past_meeting_summary",
+	"search_past_meetings",
+	"get_past_meeting",
 	// "list_membership_actions", // TODO: uncomment when guided onboarding flow is ready.
 	"list_discord_roles",
 	"find_discord_role",
@@ -687,17 +687,17 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 	if enabledTools["get_past_meeting_participant"] && canRead {
 		tools.RegisterGetPastMeetingParticipant(server)
 	}
-	if enabledTools["search_past_meeting_transcripts"] && canRead {
-		tools.RegisterSearchPastMeetingTranscripts(server)
-	}
-	if enabledTools["get_past_meeting_transcript"] && canRead {
-		tools.RegisterGetPastMeetingTranscript(server)
-	}
 	if enabledTools["search_past_meeting_summaries"] && canRead {
 		tools.RegisterSearchPastMeetingSummaries(server)
 	}
 	if enabledTools["get_past_meeting_summary"] && canRead {
 		tools.RegisterGetPastMeetingSummary(server)
+	}
+	if enabledTools["search_past_meetings"] && canRead {
+		tools.RegisterSearchPastMeetings(server)
+	}
+	if enabledTools["get_past_meeting"] && canRead {
+		tools.RegisterGetPastMeeting(server)
 	}
 	if enabledTools["search_b2b_orgs"] && canRead {
 		tools.RegisterSearchB2bOrgs(server)

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -23,11 +23,11 @@ const meetingRegistrantResourceType = "v1_meeting_registrant"
 // pastMeetingParticipantResourceType is the resource type filter for past meeting participant queries.
 const pastMeetingParticipantResourceType = "v1_past_meeting_participant"
 
-// pastMeetingTranscriptResourceType is the resource type filter for past meeting transcript queries.
-const pastMeetingTranscriptResourceType = "v1_past_meeting_transcript"
-
 // pastMeetingSummaryResourceType is the resource type filter for past meeting summary queries.
 const pastMeetingSummaryResourceType = "v1_past_meeting_summary"
+
+// pastMeetingResourceType is the resource type filter for past meeting queries.
+const pastMeetingResourceType = "v1_past_meeting"
 
 // MeetingConfig holds configuration shared by meeting tools.
 type MeetingConfig struct {
@@ -95,7 +95,7 @@ func RegisterGetMeetingRegistrant(server *mcp.Server) {
 func RegisterSearchPastMeetingParticipants(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_past_meeting_participants",
-		Description: "Search for LFX past meeting participants using the query service. Supports filtering by meeting, committee, project, and other fields.",
+		Description: "Search for LFX past meeting participants using the query service. Supports filtering by meeting ID and name.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meeting Participants",
 			ReadOnlyHint: true,
@@ -115,35 +115,11 @@ func RegisterGetPastMeetingParticipant(server *mcp.Server) {
 	}, handleGetPastMeetingParticipant)
 }
 
-// RegisterSearchPastMeetingTranscripts registers the search_past_meeting_transcripts tool with the MCP server.
-func RegisterSearchPastMeetingTranscripts(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "search_past_meeting_transcripts",
-		Description: "Search for LFX past meeting transcripts using the query service. Supports filtering by meeting, committee, project, and other fields.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:        "Search Past Meeting Transcripts",
-			ReadOnlyHint: true,
-		},
-	}, handleSearchPastMeetingTranscripts)
-}
-
-// RegisterGetPastMeetingTranscript registers the get_past_meeting_transcript tool with the MCP server.
-func RegisterGetPastMeetingTranscript(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_past_meeting_transcript",
-		Description: "Get an LFX past meeting transcript by its UID using the query service.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:        "Get Past Meeting Transcript",
-			ReadOnlyHint: true,
-		},
-	}, handleGetPastMeetingTranscript)
-}
-
 // RegisterSearchPastMeetingSummaries registers the search_past_meeting_summaries tool with the MCP server.
 func RegisterSearchPastMeetingSummaries(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_past_meeting_summaries",
-		Description: "Search for LFX past meeting summaries using the query service. Supports filtering by meeting, committee, project, and other fields.",
+		Description: "Search for LFX past meeting summaries using the query service. Supports filtering by meeting ID and name.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meeting Summaries",
 			ReadOnlyHint: true,
@@ -161,6 +137,30 @@ func RegisterGetPastMeetingSummary(server *mcp.Server) {
 			ReadOnlyHint: true,
 		},
 	}, handleGetPastMeetingSummary)
+}
+
+// RegisterSearchPastMeetings registers the search_past_meetings tool with the MCP server.
+func RegisterSearchPastMeetings(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "search_past_meetings",
+		Description: "Search for LFX past meetings (v1_past_meeting) using the query service. Supports filtering by project, committee, meeting ID, date range, and name.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Search Past Meetings",
+			ReadOnlyHint: true,
+		},
+	}, handleSearchPastMeetings)
+}
+
+// RegisterGetPastMeeting registers the get_past_meeting tool with the MCP server.
+func RegisterGetPastMeeting(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_past_meeting",
+		Description: "Get an LFX past meeting (v1_past_meeting) by its UID using the query service.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Past Meeting",
+			ReadOnlyHint: true,
+		},
+	}, handleGetPastMeeting)
 }
 
 // SearchMeetingsArgs defines the input parameters for the search_meetings tool.
@@ -184,9 +184,8 @@ type GetMeetingArgs struct {
 
 // SearchMeetingRegistrantsArgs defines the input parameters for the search_meeting_registrants tool.
 type SearchMeetingRegistrantsArgs struct {
-	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter registrants by meeting ID"`
-	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter registrants by committee UID"`
-	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter registrants by project UID"`
+	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter registrants by meeting ID; takes precedence over committee_uid"`
+	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter registrants by committee UID (ignored when meeting_id is set)"`
 	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the registrant to search for"`
 	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. host:true or type:committee)"`
 	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
@@ -201,14 +200,12 @@ type GetMeetingRegistrantArgs struct {
 
 // SearchPastMeetingParticipantsArgs defines the input parameters for the search_past_meeting_participants tool.
 type SearchPastMeetingParticipantsArgs struct {
-	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter participants by meeting ID"`
-	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter participants by committee UID"`
-	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter participants by project UID"`
-	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the participant to search for"`
-	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
-	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
-	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter participants by meeting ID (best available; ~25% of participants may not be reachable by this filter)"`
+	Name      string   `json:"name,omitempty" jsonschema:"Name or partial name of the participant to search for"`
+	Filters   []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize  int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // GetPastMeetingParticipantArgs defines the input parameters for the get_past_meeting_participant tool.
@@ -216,33 +213,14 @@ type GetPastMeetingParticipantArgs struct {
 	UID string `json:"uid" jsonschema:"The UID of the past meeting participant to retrieve"`
 }
 
-// SearchPastMeetingTranscriptsArgs defines the input parameters for the search_past_meeting_transcripts tool.
-type SearchPastMeetingTranscriptsArgs struct {
-	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter transcripts by meeting ID"`
-	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter transcripts by committee UID"`
-	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter transcripts by project UID"`
-	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the transcript to search for"`
-	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
-	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
-	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
-}
-
-// GetPastMeetingTranscriptArgs defines the input parameters for the get_past_meeting_transcript tool.
-type GetPastMeetingTranscriptArgs struct {
-	UID string `json:"uid" jsonschema:"The UID of the past meeting transcript to retrieve"`
-}
-
 // SearchPastMeetingSummariesArgs defines the input parameters for the search_past_meeting_summaries tool.
 type SearchPastMeetingSummariesArgs struct {
-	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter summaries by meeting ID"`
-	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter summaries by committee UID"`
-	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter summaries by project UID"`
-	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the summary to search for"`
-	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
-	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
-	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter summaries by meeting ID"`
+	Name      string   `json:"name,omitempty" jsonschema:"Name or partial name of the summary to search for"`
+	Filters   []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize  int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // GetPastMeetingSummaryArgs defines the input parameters for the get_past_meeting_summary tool.
@@ -300,17 +278,14 @@ func handleSearchMeetings(ctx context.Context, req *mcp.CallToolRequest, args Se
 		payload.Name = &args.Name
 	}
 
-	if args.ProjectUID != "" {
+	// committee_uid takes precedence over project_uid when both are provided
+	// because committee is indexed as a parent_ref for v1_meeting.
+	if args.CommitteeUID != "" {
+		parentRef := "committee:" + args.CommitteeUID
+		payload.Parent = &parentRef
+	} else if args.ProjectUID != "" {
 		parentRef := "project:" + args.ProjectUID
 		payload.Parent = &parentRef
-	}
-
-	var tags []string
-	if args.CommitteeUID != "" {
-		tags = append(tags, fmt.Sprintf("committee_uid:%s", args.CommitteeUID))
-	}
-	if len(tags) > 0 {
-		payload.Tags = tags
 	}
 
 	if args.DateFrom != "" || args.DateTo != "" {
@@ -518,18 +493,14 @@ func handleSearchMeetingRegistrants(ctx context.Context, req *mcp.CallToolReques
 		Sort:     sort,
 	}
 
-	var tags []string
+	// meeting_id takes precedence over committee_uid because Parent can only be
+	// set once; prefer the more specific filter.
 	if args.MeetingID != "" {
-		tags = append(tags, fmt.Sprintf("meeting_id:%s", args.MeetingID))
-	}
-	if args.CommitteeUID != "" {
-		tags = append(tags, fmt.Sprintf("committee_uid:%s", args.CommitteeUID))
-	}
-	if args.ProjectUID != "" {
-		tags = append(tags, fmt.Sprintf("project_uid:%s", args.ProjectUID))
-	}
-	if len(tags) > 0 {
-		payload.Tags = tags
+		parentRef := "meeting:" + args.MeetingID
+		payload.Parent = &parentRef
+	} else if args.CommitteeUID != "" {
+		parentRef := "committee:" + args.CommitteeUID
+		payload.Parent = &parentRef
 	}
 
 	if args.Name != "" {
@@ -544,7 +515,7 @@ func handleSearchMeetingRegistrants(ctx context.Context, req *mcp.CallToolReques
 		payload.PageToken = &args.PageToken
 	}
 
-	logger.InfoContext(ctx, "searching meeting registrants", "meeting_id", args.MeetingID, "committee_uid", args.CommitteeUID, "project_uid", args.ProjectUID, "name", args.Name, "page_size", pageSize)
+	logger.InfoContext(ctx, "searching meeting registrants", "meeting_id", args.MeetingID, "committee_uid", args.CommitteeUID, "name", args.Name, "page_size", pageSize)
 
 	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {
@@ -683,7 +654,7 @@ func handleGetMeetingRegistrant(ctx context.Context, req *mcp.CallToolRequest, a
 
 // handleSearchPastMeetingParticipants implements the search_past_meeting_participants tool logic.
 func handleSearchPastMeetingParticipants(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingParticipantsArgs) (*mcp.CallToolResult, any, error) {
-	return handleSearchPastMeetingResource(ctx, req, pastMeetingParticipantResourceType, "past meeting participants", args.MeetingID, args.CommitteeUID, args.ProjectUID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
+	return handleSearchPastMeetingResource(ctx, req, pastMeetingParticipantResourceType, "past meeting participants", args.MeetingID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
 }
 
 // handleGetPastMeetingParticipant implements the get_past_meeting_participant tool logic.
@@ -691,19 +662,9 @@ func handleGetPastMeetingParticipant(ctx context.Context, req *mcp.CallToolReque
 	return handleGetPastMeetingResource(ctx, req, pastMeetingParticipantResourceType, "past meeting participant", args.UID)
 }
 
-// handleSearchPastMeetingTranscripts implements the search_past_meeting_transcripts tool logic.
-func handleSearchPastMeetingTranscripts(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingTranscriptsArgs) (*mcp.CallToolResult, any, error) {
-	return handleSearchPastMeetingResource(ctx, req, pastMeetingTranscriptResourceType, "past meeting transcripts", args.MeetingID, args.CommitteeUID, args.ProjectUID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
-}
-
-// handleGetPastMeetingTranscript implements the get_past_meeting_transcript tool logic.
-func handleGetPastMeetingTranscript(ctx context.Context, req *mcp.CallToolRequest, args GetPastMeetingTranscriptArgs) (*mcp.CallToolResult, any, error) {
-	return handleGetPastMeetingResource(ctx, req, pastMeetingTranscriptResourceType, "past meeting transcript", args.UID)
-}
-
 // handleSearchPastMeetingSummaries implements the search_past_meeting_summaries tool logic.
 func handleSearchPastMeetingSummaries(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingSummariesArgs) (*mcp.CallToolResult, any, error) {
-	return handleSearchPastMeetingResource(ctx, req, pastMeetingSummaryResourceType, "past meeting summaries", args.MeetingID, args.CommitteeUID, args.ProjectUID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
+	return handleSearchPastMeetingResource(ctx, req, pastMeetingSummaryResourceType, "past meeting summaries", args.MeetingID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
 }
 
 // handleGetPastMeetingSummary implements the get_past_meeting_summary tool logic.
@@ -712,7 +673,7 @@ func handleGetPastMeetingSummary(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 // handleSearchPastMeetingResource is a shared implementation for searching past meeting resource types.
-func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest, resourceType, resourceLabel, meetingID, committeeUID, projectUID, name string, filters []string, sort string, pageSize int, pageToken string) (*mcp.CallToolResult, any, error) {
+func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest, resourceType, resourceLabel, meetingID, name string, filters []string, sort string, pageSize int, pageToken string) (*mcp.CallToolResult, any, error) {
 	logger := newToolLogger(ctx, req)
 
 	if meetingConfig == nil {
@@ -758,12 +719,6 @@ func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolReque
 	if meetingID != "" {
 		tags = append(tags, fmt.Sprintf("meeting_id:%s", meetingID))
 	}
-	if committeeUID != "" {
-		tags = append(tags, fmt.Sprintf("committee_uid:%s", committeeUID))
-	}
-	if projectUID != "" {
-		tags = append(tags, fmt.Sprintf("project_uid:%s", projectUID))
-	}
 	if len(tags) > 0 {
 		payload.Tags = tags
 	}
@@ -780,7 +735,7 @@ func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolReque
 		payload.PageToken = &pageToken
 	}
 
-	logger.InfoContext(ctx, "searching "+resourceLabel, "meeting_id", meetingID, "committee_uid", committeeUID, "project_uid", projectUID, "name", name, "page_size", pageSize)
+	logger.InfoContext(ctx, "searching "+resourceLabel, "meeting_id", meetingID, "name", name, "page_size", pageSize)
 
 	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {
@@ -914,4 +869,173 @@ func handleGetPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest,
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
 	}, nil, nil
+}
+
+// SearchPastMeetingsArgs defines the input parameters for the search_past_meetings tool.
+type SearchPastMeetingsArgs struct {
+	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the past meeting to search for"`
+	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter past meetings by project UID (via parent_ref; ~70% coverage)"`
+	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter past meetings by committee UID (via tag; ~29% coverage)"`
+	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter past meetings by meeting ID (via tag; ~87% coverage)"`
+	DateField    string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default data.start_time); also accepts data.end_time"`
+	DateFrom     string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
+	DateTo       string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
+	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
+// GetPastMeetingArgs defines the input parameters for the get_past_meeting tool.
+type GetPastMeetingArgs struct {
+	UID string `json:"uid" jsonschema:"The UID of the past meeting to retrieve"`
+}
+
+// handleSearchPastMeetings implements the search_past_meetings tool logic.
+func handleSearchPastMeetings(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingsArgs) (*mcp.CallToolResult, any, error) {
+	logger := newToolLogger(ctx, req)
+
+	if meetingConfig == nil {
+		logger.ErrorContext(ctx, "meeting tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: meeting tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = meetingConfig.Clients.WithMCPToken(ctx, mcpToken)
+	clients := meetingConfig.Clients
+
+	pageSize := args.PageSize
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	sort := args.Sort
+	if sort == "" {
+		sort = "name_asc"
+	}
+
+	resourceType := pastMeetingResourceType
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
+		PageSize: pageSize,
+		Sort:     sort,
+	}
+
+	if args.Name != "" {
+		payload.Name = &args.Name
+	}
+
+	// project_uid uses parent_ref; committee_uid and meeting_id use tags and can coexist.
+	if args.ProjectUID != "" {
+		parentRef := "project:" + args.ProjectUID
+		payload.Parent = &parentRef
+	}
+
+	var tags []string
+	if args.CommitteeUID != "" {
+		tags = append(tags, fmt.Sprintf("committee_uid:%s", args.CommitteeUID))
+	}
+	if args.MeetingID != "" {
+		tags = append(tags, fmt.Sprintf("meeting_id:%s", args.MeetingID))
+	}
+	if len(tags) > 0 {
+		payload.Tags = tags
+	}
+
+	if args.DateFrom != "" || args.DateTo != "" {
+		dateField := args.DateField
+		if dateField == "" {
+			dateField = "data.start_time"
+		}
+		payload.DateField = &dateField
+		if args.DateFrom != "" {
+			payload.DateFrom = &args.DateFrom
+		}
+		if args.DateTo != "" {
+			payload.DateTo = &args.DateTo
+		}
+	}
+
+	if len(args.Filters) > 0 {
+		payload.Filters = args.Filters
+	}
+
+	if args.PageToken != "" {
+		payload.PageToken = &args.PageToken
+	}
+
+	logger.InfoContext(ctx, "searching past meetings",
+		"name", args.Name,
+		"project_uid", args.ProjectUID,
+		"committee_uid", args.CommitteeUID,
+		"meeting_id", args.MeetingID,
+		"page_size", pageSize,
+	)
+
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
+	if err != nil {
+		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: friendlyAPIError("failed to search past meetings", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	type searchResult struct {
+		Resources []*querysvc.Resource `json:"resources"`
+		PageToken *string              `json:"page_token,omitempty"`
+	}
+
+	out := searchResult{
+		Resources: result.Resources,
+		PageToken: result.PageToken,
+	}
+
+	var pageWarning string
+	if result.PageToken != nil && len(result.Resources) < pageSize {
+		pageWarning = "WARNING: some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters"
+	}
+
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to marshal search result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.InfoContext(ctx, "search_past_meetings succeeded", "count", len(result.Resources))
+
+	content := []mcp.Content{}
+	if pageWarning != "" {
+		content = append(content, &mcp.TextContent{Text: pageWarning})
+	}
+	content = append(content, &mcp.TextContent{Text: string(prettyJSON)})
+	return &mcp.CallToolResult{Content: content}, nil, nil
+}
+
+// handleGetPastMeeting implements the get_past_meeting tool logic.
+func handleGetPastMeeting(ctx context.Context, req *mcp.CallToolRequest, args GetPastMeetingArgs) (*mcp.CallToolResult, any, error) {
+	return handleGetPastMeetingResource(ctx, req, pastMeetingResourceType, "past meeting", args.UID)
 }

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -166,7 +166,7 @@ func RegisterGetPastMeeting(server *mcp.Server) {
 // SearchMeetingsArgs defines the input parameters for the search_meetings tool.
 type SearchMeetingsArgs struct {
 	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the meeting to search for"`
-	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter meetings by project UID"`
+	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter meetings by project UID (ignored when committee_uid is set)"`
 	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter meetings by committee UID"`
 	DateField    string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set)"`
 	DateFrom     string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
@@ -184,7 +184,7 @@ type GetMeetingArgs struct {
 
 // SearchMeetingRegistrantsArgs defines the input parameters for the search_meeting_registrants tool.
 type SearchMeetingRegistrantsArgs struct {
-	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter registrants by meeting ID; takes precedence over committee_uid"`
+	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter registrants by meeting ID"`
 	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter registrants by committee UID (ignored when meeting_id is set)"`
 	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the registrant to search for"`
 	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. host:true or type:committee)"`


### PR DESCRIPTION
## Summary

- **`search_meetings`**: `committee_uid` now uses `parent_ref` (`committee:<uid>`) instead of a tag, matching the actual index; when both `committee_uid` and `project_uid` are provided, `committee_uid` takes precedence.
- **`search_meeting_registrants`**: `meeting_id` and `committee_uid` switched from tags to `parent_ref`; `project_uid` parameter removed (not indexed).
- **`search_past_meeting_participants`** / **`search_past_meeting_summaries`**: `committee_uid` and `project_uid` parameters removed (not indexed in these resource types).
- **Transcript tools removed**: `search_past_meeting_transcripts` and `get_past_meeting_transcript` deleted entirely — transcript data is not reliably indexed.
- **New tools**: `search_past_meetings` and `get_past_meeting` added for the `v1_past_meeting` resource type (previously unserved). Uses `parent_ref` for `project_uid`, tags for `committee_uid`/`meeting_id`, and `data.start_time` as the default date field.

## Jira

[ARCH-393](https://linuxfoundation.atlassian.net/browse/ARCH-393) — Fix committee_uid filtering across meeting search tools

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[ARCH-393]: https://linuxfoundation.atlassian.net/browse/ARCH-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ