### PR TITLE
docs: sync Available Tools section with all implemented tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that c
 - **Explore projects** — Search and retrieve details for any LFX project
 - **Manage committees** — Search, create, update, and delete committees and their members across projects
 - **Work with mailing lists** — Search mailing lists and their subscribers
-- **Query members** — Search memberships by tier, status, organization, and more; get key contacts
-- **Track meetings** — Find upcoming meetings, registrants, past participants, transcripts, and AI-generated summaries
+- **Query members** — Search memberships by tier, status, organization, and more; get and manage key contacts
+- **Track meetings** — Find upcoming meetings, registrants, past participants, and AI-generated summaries
+- **Manage Discord roles** — List roles, find users, check and assign roles in a project's Discord guild
+- **Send emails** — Browse email templates and send templated emails via LFX mail servers
+- **Query with LFX Lens** — Ask natural-language questions about project data (events, contributors, health, and more)
+- **Search B2B organizations** — Find organizations and list their project memberships
 
 ## Connecting to the LFX MCP Server
 
@@ -152,11 +156,17 @@ Before hitting **Connect**, follow the **Open Auth Settings** button, then selec
 
 ### Members
 
-| Tool                          | Description                                                                     |
-|-------------------------------|---------------------------------------------------------------------------------|
-| `search_members`              | Search and filter members (memberships) by status, tier, organization, and more |
-| `get_member_membership`       | Get a single member's membership details by member and membership ID            |
-| `get_membership_key_contacts` | Get key contacts (primary contacts, board members) for a membership             |
+| Tool                              | Description                                                                     |
+|-----------------------------------|---------------------------------------------------------------------------------|
+| `search_members`                  | Search and filter members (memberships) by status, tier, organization, and more |
+| `get_member_membership`           | Get a single member's membership details by member and membership ID            |
+| `list_project_tiers`              | List all membership tiers (e.g. Gold, Silver, Bronze) defined for a project     |
+| `get_project_tier`                | Get a single membership tier by project and tier UID                            |
+| `get_membership_key_contacts`     | Get key contacts (primary contacts, board members) for a membership             |
+| `get_membership_key_contact`      | Get a single key contact by project, membership, and contact UID                |
+| `create_membership_key_contact`   | Add a key contact to a membership                                               |
+| `update_membership_key_contact`   | Update an existing key contact on a membership                                  |
+| `delete_membership_key_contact`   | Remove a key contact from a membership                                          |
 
 ### Meetings
 
@@ -171,12 +181,42 @@ Before hitting **Connect**, follow the **Open Auth Settings** button, then selec
 
 | Tool                               | Description                                                             |
 |------------------------------------|-------------------------------------------------------------------------|
+| `search_past_meetings`             | Search past meetings; filter by project, committee, date range          |
+| `get_past_meeting`                 | Get a past meeting by UID                                               |
 | `search_past_meeting_participants` | Search past meeting participants; filter by meeting, committee, project |
 | `get_past_meeting_participant`     | Get a past meeting participant by UID                                   |
-| `search_past_meeting_transcripts`  | Search past meeting transcripts; filter by meeting, committee, project  |
-| `get_past_meeting_transcript`      | Get a past meeting transcript by UID                                    |
 | `search_past_meeting_summaries`    | Search past meeting summaries; filter by meeting, committee, project    |
 | `get_past_meeting_summary`         | Get a past meeting summary by UID                                       |
+
+### Discord
+
+| Tool                    | Description                                                  |
+|-------------------------|--------------------------------------------------------------|
+| `list_discord_roles`    | List all roles in a project's Discord guild                  |
+| `find_discord_role`     | Find a Discord role by name                                  |
+| `find_discord_user`     | Find a Discord guild member by name and optional email       |
+| `check_discord_user_role` | Check whether a Discord user already has a specific role   |
+| `assign_discord_role`   | Assign a Discord role to a user                              |
+
+### Email
+
+| Tool                    | Description                                                  |
+|-------------------------|--------------------------------------------------------------|
+| `list_email_templates`  | List all available email templates for a project             |
+| `send_email`            | Send a templated email via LFX mail servers                  |
+
+### LFX Lens
+
+| Tool              | Description                                                                                         |
+|-------------------|-----------------------------------------------------------------------------------------------------|
+| `query_lfx_lens`  | Ask natural-language questions about a project's data (events, contributors, health, value, and more) |
+
+### B2B Organizations
+
+| Tool                       | Description                                                   |
+|----------------------------|---------------------------------------------------------------|
+| `search_b2b_orgs`          | Search and list B2B organizations                             |
+| `list_b2b_org_memberships` | List all project memberships for a B2B organization           |
 
 ### Utility
 


### PR DESCRIPTION
## Summary

- Add 5 new tool sections to the README: Discord, Email, LFX Lens, B2B Organizations, and expanded Members
- Document 18 previously implemented but undocumented tools
- Remove 2 tools listed in the README that were never implemented (`search_past_meeting_transcripts`, `get_past_meeting_transcript`)
- Update the "What You Can Do" summary bullets to reflect the full current capability set

## Test plan

- [ ] Verify all tool names in the README match the `Name:` fields in `internal/tools/` source files
- [ ] Verify the two removed transcript tools do not appear anywhere in `internal/tools/` or `main.go`