### PR TITLE
feat: add pagination guidance for query_lfx_lens tool

### DIFF
--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -57,7 +57,9 @@ Important: questions just about contributors/activities (without maintainer join
 
 Use search_projects first to find the project slug.
 
-This tool runs synchronously. Queries take 15–30 seconds — please wait for the result without retrying.`,
+This tool runs synchronously. Queries take 15–30 seconds — please wait for the result without retrying.
+Tips: 
+- This tool has a limit of 200 rows per request. If you are looking for more rows, specify the pagination. E.g. all registrations for an event.`,
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "LFX Lens Query",
 			ReadOnlyHint: true,

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -43,8 +43,8 @@ func RegisterQueryLFXLens(server *mcp.Server) {
 Always use this tool for:
 - All membership questions (e.g. "current members", "membership revenue by tier", "churn rate")
 - Maintainer names or maintainer+activities data joins, where activities data is the code activities model
-	with code contributions, PRs, commits etc (e.g. "top maintainers by contributions", "who maintains Kubernetes?").
-	IMPORTANT: activities data (contributors, PRs, code contributions etc) not involving maintainers should use the semantic layer.
+  with code contributions, PRs, commits etc (e.g. "top maintainers by contributions", "who maintains Kubernetes?").
+  IMPORTANT: activities data (contributors, PRs, code contributions etc) not involving maintainers should use query_lfx_semantic_layer.
 - Maintainer time series and trends (the maintainer model lacks good time granularity)
 - Event sponsorships (the semantic layer should be used for events and event registration data not related to sponsorships)
 

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -58,8 +58,8 @@ Important: questions just about contributors/activities (without maintainer join
 Use search_projects first to find the project slug.
 
 This tool runs synchronously. Queries take 15–30 seconds — please wait for the result without retrying.
-Tips: 
-- This tool has a limit of 200 rows per request. If you are looking for more rows, specify the pagination. E.g. all registrations for an event.`,
+Tips:
+- This tool returns at most 200 rows per request. If you need more results, explicitly request pagination, for example "page 2", "next 200 rows", or "use LIMIT/OFFSET pagination with a stable ORDER BY" (e.g. all registrations for an event).`,
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "LFX Lens Query",
 			ReadOnlyHint: true,

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -43,7 +43,8 @@ func RegisterQueryLFXLens(server *mcp.Server) {
 Always use this tool for:
 - All membership questions (e.g. "current members", "membership revenue by tier", "churn rate")
 - Maintainer names or maintainer+activities data joins, where activities data is the code activities model
-	with code contributions, PRs, commits etc (e.g. "top maintainers by contributions", "who maintains Kubernetes?")
+	with code contributions, PRs, commits etc (e.g. "top maintainers by contributions", "who maintains Kubernetes?").
+	IMPORTANT: activities data (contributors, PRs, code contributions etc) not involving maintainers should use the semantic layer.
 - Maintainer time series and trends (the maintainer model lacks good time granularity)
 - Event sponsorships (the semantic layer should be used for events and event registration data not related to sponsorships)
 
@@ -186,6 +187,7 @@ Actions:
 
 Tips:
 - Contributors and code-related data (commits, PRs, insertions, deletions) are in the activities model — search for "activities" in list_metrics.
+  IMPORTANT: questions about contributors and code related questions not involving maintainers should prefer this tool.
 - Events metrics use project_name rather than project_slug for filtering.
 - Questions about The Linux Foundation (slug is tlf) still need to be scoped with the correct where clause.`,
 		Annotations: &mcp.ToolAnnotations{

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -187,7 +187,7 @@ Actions:
 
 Tips:
 - Contributors and code-related data (commits, PRs, insertions, deletions) are in the activities model — search for "activities" in list_metrics.
-  IMPORTANT: questions about contributors and code related questions not involving maintainers should prefer this tool.
+  IMPORTANT: Questions about contributors and code-related topics that do not involve maintainers should prefer this tool.
 - Events metrics use project_name rather than project_slug for filtering.
 - Questions about The Linux Foundation (slug is tlf) still need to be scoped with the correct where clause.`,
 		Annotations: &mcp.ToolAnnotations{


### PR DESCRIPTION
## Summary
- Adds a tip to the `query_lfx_lens` tool description advising callers about the 200-row limit and how to use pagination for larger result sets (e.g. all registrations for an event).

## Test plan
- [ ] Verify tool description appears correctly via `tools/list`
- [ ] Confirm pagination hint is visible to MCP clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)