### PR TITLE
feat: implement committees-as-groups feature flag (ARCH-398)

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -60,6 +60,9 @@ type Config struct {
 	OnboardingAPIAudience string `koanf:"onboarding_api_audience"`
 	LensAPIURL            string `koanf:"lens_api_url"`
 	LensAPIAudience       string `koanf:"lens_api_audience"`
+
+	// Feature flags.
+	CommitteesAsGroups bool `koanf:"committees_as_groups"`
 }
 
 // HTTPConfig holds HTTP transport configuration.
@@ -85,6 +88,21 @@ var (
 )
 
 const errKey = "error"
+
+// committeeToGroupToolNames maps committee-mode tool names to their group-mode equivalents.
+var committeeToGroupToolNames = map[string]string{
+	"search_committees":         "search_groups",
+	"get_committee":             "get_group",
+	"get_committee_member":      "get_group_member",
+	"search_committee_members":  "search_group_members",
+	"create_committee":          "create_group",
+	"update_committee":          "update_group",
+	"update_committee_settings": "update_group_settings",
+	"delete_committee":          "delete_group",
+	"create_committee_member":   "create_group_member",
+	"update_committee_member":   "update_group_member",
+	"delete_committee_member":   "delete_group_member",
+}
 
 // defaultTools is the list of tools enabled by default.
 var defaultTools = []string{
@@ -170,6 +188,7 @@ func main() {
 	f.String("tools", strings.Join(defaultTools, ","), "Comma-separated list of tools to enable")
 	f.Bool("debug", false, "Enable debug logging")
 	f.Bool("debug_traffic", false, "Enable HTTP request/response debug logging for outbound LFX API calls")
+	f.Bool("committees_as_groups", false, "Rebrand committee tools to use 'group' terminology (feature flag)")
 	f.String("onboarding_api_url", "", "Base URL of the member onboarding service")
 	f.String("onboarding_api_audience", "", "Auth0 resource server audience for the member onboarding API")
 	f.String("lens_api_url", "", "Base URL of the LFX Lens service")
@@ -578,9 +597,22 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 	isStaff := callerToken == nil || tools.IsLFStaff(callerToken)
 
 	// Register tools based on configuration and caller scopes.
+	// Build a reverse map so group-mode names in LFXMCP_TOOLS are resolved to their
+	// canonical committee-mode names before any registration checks.
+	groupToCommitteeToolNames := make(map[string]string, len(committeeToGroupToolNames))
+	for committee, group := range committeeToGroupToolNames {
+		groupToCommitteeToolNames[group] = committee
+	}
+
 	enabledTools := make(map[string]bool)
 	for _, tool := range cfg.Tools {
-		enabledTools[strings.TrimSpace(tool)] = true
+		name := strings.TrimSpace(tool)
+		// Normalize group-mode names to committee-mode so registration logic only
+		// needs to check committee-mode keys regardless of which form was in config.
+		if canonical, ok := groupToCommitteeToolNames[name]; ok {
+			name = canonical
+		}
+		enabledTools[name] = true
 	}
 
 	if enabledTools["hello_world"] && canRead {
@@ -596,37 +628,37 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 		tools.RegisterGetProject(server)
 	}
 	if enabledTools["search_committees"] && canRead {
-		tools.RegisterSearchCommittees(server)
+		tools.RegisterSearchCommittees(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["get_committee"] && canRead {
-		tools.RegisterGetCommittee(server)
+		tools.RegisterGetCommittee(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["get_committee_member"] && canRead {
-		tools.RegisterGetCommitteeMember(server)
+		tools.RegisterGetCommitteeMember(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["search_committee_members"] && canRead {
-		tools.RegisterSearchCommitteeMembers(server)
+		tools.RegisterSearchCommitteeMembers(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["create_committee"] && canManage {
-		tools.RegisterCreateCommittee(server)
+		tools.RegisterCreateCommittee(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["update_committee"] && canManage {
-		tools.RegisterUpdateCommittee(server)
+		tools.RegisterUpdateCommittee(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["update_committee_settings"] && canManage {
-		tools.RegisterUpdateCommitteeSettings(server)
+		tools.RegisterUpdateCommitteeSettings(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["delete_committee"] && canManage {
-		tools.RegisterDeleteCommittee(server)
+		tools.RegisterDeleteCommittee(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["create_committee_member"] && canManage {
-		tools.RegisterCreateCommitteeMember(server)
+		tools.RegisterCreateCommitteeMember(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["update_committee_member"] && canManage {
-		tools.RegisterUpdateCommitteeMember(server)
+		tools.RegisterUpdateCommitteeMember(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["delete_committee_member"] && canManage {
-		tools.RegisterDeleteCommitteeMember(server)
+		tools.RegisterDeleteCommitteeMember(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["get_mailing_list_service"] && canRead {
 		tools.RegisterGetMailingListService(server)
@@ -671,13 +703,13 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 		tools.RegisterDeleteMembershipKeyContact(server)
 	}
 	if enabledTools["search_meetings"] && canRead {
-		tools.RegisterSearchMeetings(server)
+		tools.RegisterSearchMeetings(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["get_meeting"] && canRead {
 		tools.RegisterGetMeeting(server)
 	}
 	if enabledTools["search_meeting_registrants"] && canRead {
-		tools.RegisterSearchMeetingRegistrants(server)
+		tools.RegisterSearchMeetingRegistrants(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["get_meeting_registrant"] && canRead {
 		tools.RegisterGetMeetingRegistrant(server)
@@ -695,7 +727,7 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 		tools.RegisterGetPastMeetingSummary(server)
 	}
 	if enabledTools["search_past_meetings"] && canRead {
-		tools.RegisterSearchPastMeetings(server)
+		tools.RegisterSearchPastMeetings(server, cfg.CommitteesAsGroups)
 	}
 	if enabledTools["get_past_meeting"] && canRead {
 		tools.RegisterGetPastMeeting(server)

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -104,6 +104,16 @@ var committeeToGroupToolNames = map[string]string{
 	"delete_committee_member":   "delete_group_member",
 }
 
+// groupToCommitteeToolNames is the reverse of committeeToGroupToolNames, mapping
+// group-mode tool names back to their canonical committee-mode equivalents.
+var groupToCommitteeToolNames = func() map[string]string {
+	m := make(map[string]string, len(committeeToGroupToolNames))
+	for committee, group := range committeeToGroupToolNames {
+		m[group] = committee
+	}
+	return m
+}()
+
 // defaultTools is the list of tools enabled by default.
 var defaultTools = []string{
 	"search_projects",
@@ -597,13 +607,6 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 	isStaff := callerToken == nil || tools.IsLFStaff(callerToken)
 
 	// Register tools based on configuration and caller scopes.
-	// Build a reverse map so group-mode names in LFXMCP_TOOLS are resolved to their
-	// canonical committee-mode names before any registration checks.
-	groupToCommitteeToolNames := make(map[string]string, len(committeeToGroupToolNames))
-	for committee, group := range committeeToGroupToolNames {
-		groupToCommitteeToolNames[group] = committee
-	}
-
 	enabledTools := make(map[string]bool)
 	for _, tool := range cfg.Tools {
 		name := strings.TrimSpace(tool)

--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -35,8 +35,21 @@ func SetCommitteeConfig(cfg *CommitteeConfig) {
 	committeeConfig = cfg
 }
 
-// RegisterSearchCommittees registers the search_committees tool with the MCP server.
-func RegisterSearchCommittees(server *mcp.Server) {
+// RegisterSearchCommittees registers the search_committees (or search_groups) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "search_groups" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterSearchCommittees(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "search_groups",
+			Description: "Search for LFX groups (also called committees) by name using the LFX query service. Optionally filter by project UID.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Search Groups",
+				ReadOnlyHint: true,
+			},
+		}, handleSearchCommitteesGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_committees",
 		Description: "Search for LFX committees by name using the LFX query service. Optionally filter by project UID.",
@@ -47,8 +60,21 @@ func RegisterSearchCommittees(server *mcp.Server) {
 	}, handleSearchCommittees)
 }
 
-// RegisterGetCommittee registers the get_committee tool with the MCP server.
-func RegisterGetCommittee(server *mcp.Server) {
+// RegisterGetCommittee registers the get_committee (or get_group) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "get_group" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterGetCommittee(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "get_group",
+			Description: "Get an LFX group's (also called committee) base info and settings by its UID. Privileged group settings may be omitted if the caller lacks sufficient permissions.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Group",
+				ReadOnlyHint: true,
+			},
+		}, handleGetCommitteeGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_committee",
 		Description: "Get an LFX committee's base info and settings by its UID. Privileged committee settings may be omitted if the caller lacks sufficient permissions.",
@@ -59,8 +85,21 @@ func RegisterGetCommittee(server *mcp.Server) {
 	}, handleGetCommittee)
 }
 
-// RegisterGetCommitteeMember registers the get_committee_member tool with the MCP server.
-func RegisterGetCommitteeMember(server *mcp.Server) {
+// RegisterGetCommitteeMember registers the get_committee_member (or get_group_member) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "get_group_member" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterGetCommitteeMember(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "get_group_member",
+			Description: "Get a specific group (also called committee) member by group UID and member UID.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Group Member",
+				ReadOnlyHint: true,
+			},
+		}, handleGetCommitteeMemberGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_committee_member",
 		Description: "Get a specific committee member by committee UID and member UID.",
@@ -71,8 +110,21 @@ func RegisterGetCommitteeMember(server *mcp.Server) {
 	}, handleGetCommitteeMember)
 }
 
-// RegisterSearchCommitteeMembers registers the search_committee_members tool with the MCP server.
-func RegisterSearchCommitteeMembers(server *mcp.Server) {
+// RegisterSearchCommitteeMembers registers the search_committee_members (or search_group_members) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "search_group_members" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterSearchCommitteeMembers(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "search_group_members",
+			Description: "Search for LFX group (also called committee) members. Optionally filter by group UID, project UID, and/or name. At least one filter is recommended but not required.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Search Group Members",
+				ReadOnlyHint: true,
+			},
+		}, handleSearchCommitteeMembersGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_committee_members",
 		Description: "Search for LFX committee members. Optionally filter by committee UID, project UID, and/or name. At least one filter is recommended but not required.",
@@ -91,15 +143,34 @@ type SearchCommitteesArgs struct {
 	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
+// SearchGroupsArgs defines the input parameters for the search_groups tool (groups mode).
+type SearchGroupsArgs struct {
+	Name       string `json:"name,omitempty" jsonschema:"Name or partial name of the group to search for"`
+	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional project UID to filter groups by project"`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
 // GetCommitteeArgs defines the input parameters for the get_committee tool.
 type GetCommitteeArgs struct {
 	UID string `json:"uid" jsonschema:"The UID of the committee to retrieve"`
+}
+
+// GetGroupArgs defines the input parameters for the get_group tool (groups mode).
+type GetGroupArgs struct {
+	UID string `json:"uid" jsonschema:"The UID of the group to retrieve"`
 }
 
 // GetCommitteeMemberArgs defines the input parameters for the get_committee_member tool.
 type GetCommitteeMemberArgs struct {
 	CommitteeUID string `json:"committee_uid" jsonschema:"The UID of the committee"`
 	MemberUID    string `json:"member_uid" jsonschema:"The UID of the committee member"`
+}
+
+// GetGroupMemberArgs defines the input parameters for the get_group_member tool (groups mode).
+type GetGroupMemberArgs struct {
+	GroupUID  string `json:"group_uid" jsonschema:"The UID of the group"`
+	MemberUID string `json:"member_uid" jsonschema:"The UID of the group member"`
 }
 
 // SearchCommitteeMembersArgs defines the input parameters for the search_committee_members tool.
@@ -109,6 +180,49 @@ type SearchCommitteeMembersArgs struct {
 	Name         string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
 	PageSize     int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
+// SearchGroupMembersArgs defines the input parameters for the search_group_members tool (groups mode).
+type SearchGroupMembersArgs struct {
+	GroupUID   string `json:"group_uid,omitempty" jsonschema:"Optional UID of the group to filter members by"`
+	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional project UID to filter group members by project"`
+	Name       string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
+// handleSearchCommitteesGroupMode adapts group-mode args to the committee handler.
+func handleSearchCommitteesGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchGroupsArgs) (*mcp.CallToolResult, any, error) {
+	return handleSearchCommittees(ctx, req, SearchCommitteesArgs{
+		Name:       args.Name,
+		ProjectUID: args.ProjectUID,
+		PageSize:   args.PageSize,
+		PageToken:  args.PageToken,
+	})
+}
+
+// handleGetCommitteeGroupMode adapts group-mode args to the committee handler.
+func handleGetCommitteeGroupMode(ctx context.Context, req *mcp.CallToolRequest, args GetGroupArgs) (*mcp.CallToolResult, any, error) {
+	return handleGetCommittee(ctx, req, GetCommitteeArgs{UID: args.UID})
+}
+
+// handleGetCommitteeMemberGroupMode adapts group-mode args to the committee member handler.
+func handleGetCommitteeMemberGroupMode(ctx context.Context, req *mcp.CallToolRequest, args GetGroupMemberArgs) (*mcp.CallToolResult, any, error) {
+	return handleGetCommitteeMember(ctx, req, GetCommitteeMemberArgs{
+		CommitteeUID: args.GroupUID,
+		MemberUID:    args.MemberUID,
+	})
+}
+
+// handleSearchCommitteeMembersGroupMode adapts group-mode args to the committee members handler.
+func handleSearchCommitteeMembersGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchGroupMembersArgs) (*mcp.CallToolResult, any, error) {
+	return handleSearchCommitteeMembers(ctx, req, SearchCommitteeMembersArgs{
+		CommitteeUID: args.GroupUID,
+		ProjectUID:   args.ProjectUID,
+		Name:         args.Name,
+		PageSize:     args.PageSize,
+		PageToken:    args.PageToken,
+	})
 }
 
 // handleSearchCommittees implements the search_committees tool logic.

--- a/internal/tools/committee_write.go
+++ b/internal/tools/committee_write.go
@@ -133,8 +133,217 @@ type DeleteCommitteeMemberArgs struct {
 
 // --- Registration functions ---
 
-// RegisterCreateCommittee registers the create_committee tool with the MCP server.
-func RegisterCreateCommittee(server *mcp.Server) {
+// --- Group-mode arg structs ---
+
+// CreateGroupArgs defines the input parameters for the create_group tool (groups mode).
+type CreateGroupArgs struct {
+	ProjectUID            string  `json:"project_uid" jsonschema:"Project UID the group belongs to"`
+	Name                  string  `json:"name" jsonschema:"Name of the group"`
+	Category              string  `json:"category" jsonschema:"Category of the group"`
+	Description           *string `json:"description,omitempty" jsonschema:"Description of the group"`
+	Website               *string `json:"website,omitempty" jsonschema:"Website URL of the group"`
+	EnableVoting          bool    `json:"enable_voting,omitempty" jsonschema:"Whether voting is enabled"`
+	SSOGroupEnabled       bool    `json:"sso_group_enabled,omitempty" jsonschema:"Whether SSO group integration is enabled"`
+	RequiresReview        bool    `json:"requires_review,omitempty" jsonschema:"Whether the group requires review"`
+	Public                bool    `json:"public,omitempty" jsonschema:"Whether the group is publicly visible"`
+	CalendarPublic        *bool   `json:"calendar_public,omitempty" jsonschema:"Whether the group calendar is publicly visible"`
+	DisplayName           *string `json:"display_name,omitempty" jsonschema:"Display name of the group"`
+	ParentUID             *string `json:"parent_uid,omitempty" jsonschema:"UID of the parent group, if any"`
+	BusinessEmailRequired bool    `json:"business_email_required,omitempty" jsonschema:"Whether business email is required for members"`
+	MemberVisibility      string  `json:"member_visibility,omitempty" jsonschema:"Visibility level of member profiles to other members"`
+	ShowMeetingAttendees  bool    `json:"show_meeting_attendees,omitempty" jsonschema:"Whether to show meeting attendees by default"`
+}
+
+// UpdateGroupArgs defines the input parameters for the update_group tool (groups mode).
+// Only fields that are provided (non-nil) will be updated; omitted fields retain
+// their current values (fetch-then-merge semantics).
+type UpdateGroupArgs struct {
+	UID             string  `json:"uid" jsonschema:"UID of the group to update"`
+	ProjectUID      *string `json:"project_uid,omitempty" jsonschema:"Project UID the group belongs to"`
+	Name            *string `json:"name,omitempty" jsonschema:"Name of the group"`
+	Category        *string `json:"category,omitempty" jsonschema:"Category of the group"`
+	Description     *string `json:"description,omitempty" jsonschema:"Description of the group"`
+	Website         *string `json:"website,omitempty" jsonschema:"Website URL of the group"`
+	EnableVoting    *bool   `json:"enable_voting,omitempty" jsonschema:"Whether voting is enabled"`
+	SSOGroupEnabled *bool   `json:"sso_group_enabled,omitempty" jsonschema:"Whether SSO group integration is enabled"`
+	RequiresReview  *bool   `json:"requires_review,omitempty" jsonschema:"Whether the group requires review"`
+	Public          *bool   `json:"public,omitempty" jsonschema:"Whether the group is publicly visible"`
+	CalendarPublic  *bool   `json:"calendar_public,omitempty" jsonschema:"Whether the group calendar is publicly visible"`
+	DisplayName     *string `json:"display_name,omitempty" jsonschema:"Display name of the group"`
+	ParentUID       *string `json:"parent_uid,omitempty" jsonschema:"UID of the parent group, if any"`
+}
+
+// UpdateGroupSettingsArgs defines the input parameters for the update_group_settings tool (groups mode).
+// Only fields that are provided (non-nil) will be updated; omitted fields retain
+// their current values (fetch-then-merge semantics).
+type UpdateGroupSettingsArgs struct {
+	UID                   string  `json:"uid" jsonschema:"UID of the group whose settings to update"`
+	BusinessEmailRequired *bool   `json:"business_email_required,omitempty" jsonschema:"Whether business email is required for members"`
+	MemberVisibility      *string `json:"member_visibility,omitempty" jsonschema:"Visibility level of member profiles to other members"`
+	ShowMeetingAttendees  *bool   `json:"show_meeting_attendees,omitempty" jsonschema:"Whether to show meeting attendees by default"`
+}
+
+// DeleteGroupArgs defines the input parameters for the delete_group tool (groups mode).
+type DeleteGroupArgs struct {
+	UID string `json:"uid" jsonschema:"UID of the group to delete"`
+}
+
+// CreateGroupMemberArgs defines the input parameters for the create_group_member tool (groups mode).
+type CreateGroupMemberArgs struct {
+	GroupUID        string                           `json:"group_uid" jsonschema:"UID of the group to add the member to"`
+	Email           string                           `json:"email" jsonschema:"Primary email address of the member"`
+	AppointedBy     string                           `json:"appointed_by" jsonschema:"How the member was appointed"`
+	Status          string                           `json:"status" jsonschema:"Member status"`
+	FirstName       *string                          `json:"first_name,omitempty" jsonschema:"First name"`
+	LastName        *string                          `json:"last_name,omitempty" jsonschema:"Last name"`
+	JobTitle        *string                          `json:"job_title,omitempty" jsonschema:"Job title at organization"`
+	LinkedinProfile *string                          `json:"linkedin_profile,omitempty" jsonschema:"LinkedIn profile URL"`
+	Role            *CommitteeMemberRoleArgs         `json:"role,omitempty" jsonschema:"Group role information"`
+	Voting          *CommitteeMemberVotingArgs       `json:"voting,omitempty" jsonschema:"Voting information"`
+	Organization    *CommitteeMemberOrganizationArgs `json:"organization,omitempty" jsonschema:"Organization information"`
+}
+
+// UpdateGroupMemberArgs defines the input parameters for the update_group_member tool (groups mode).
+// Only fields that are provided (non-nil) will be updated; omitted fields retain
+// their current values (fetch-then-merge semantics).
+type UpdateGroupMemberArgs struct {
+	GroupUID        string                           `json:"group_uid" jsonschema:"UID of the group"`
+	MemberUID       string                           `json:"member_uid" jsonschema:"UID of the member to update"`
+	Email           *string                          `json:"email,omitempty" jsonschema:"Primary email address of the member"`
+	AppointedBy     *string                          `json:"appointed_by,omitempty" jsonschema:"How the member was appointed"`
+	Status          *string                          `json:"status,omitempty" jsonschema:"Member status"`
+	FirstName       *string                          `json:"first_name,omitempty" jsonschema:"First name"`
+	LastName        *string                          `json:"last_name,omitempty" jsonschema:"Last name"`
+	JobTitle        *string                          `json:"job_title,omitempty" jsonschema:"Job title at organization"`
+	LinkedinProfile *string                          `json:"linkedin_profile,omitempty" jsonschema:"LinkedIn profile URL"`
+	Role            *CommitteeMemberRoleArgs         `json:"role,omitempty" jsonschema:"Group role information"`
+	Voting          *CommitteeMemberVotingArgs       `json:"voting,omitempty" jsonschema:"Voting information"`
+	Organization    *CommitteeMemberOrganizationArgs `json:"organization,omitempty" jsonschema:"Organization information"`
+}
+
+// DeleteGroupMemberArgs defines the input parameters for the delete_group_member tool (groups mode).
+type DeleteGroupMemberArgs struct {
+	GroupUID  string `json:"group_uid" jsonschema:"UID of the group"`
+	MemberUID string `json:"member_uid" jsonschema:"UID of the member to delete"`
+}
+
+// --- Group-mode adapter handlers ---
+
+// handleCreateGroupMode adapts group-mode args to the committee create handler.
+func handleCreateGroupMode(ctx context.Context, req *mcp.CallToolRequest, args CreateGroupArgs) (*mcp.CallToolResult, any, error) {
+	return handleCreateCommittee(ctx, req, CreateCommitteeArgs{
+		ProjectUID:            args.ProjectUID,
+		Name:                  args.Name,
+		Category:              args.Category,
+		Description:           args.Description,
+		Website:               args.Website,
+		EnableVoting:          args.EnableVoting,
+		SSOGroupEnabled:       args.SSOGroupEnabled,
+		RequiresReview:        args.RequiresReview,
+		Public:                args.Public,
+		CalendarPublic:        args.CalendarPublic,
+		DisplayName:           args.DisplayName,
+		ParentUID:             args.ParentUID,
+		BusinessEmailRequired: args.BusinessEmailRequired,
+		MemberVisibility:      args.MemberVisibility,
+		ShowMeetingAttendees:  args.ShowMeetingAttendees,
+	})
+}
+
+// handleUpdateGroupMode adapts group-mode args to the committee update handler.
+func handleUpdateGroupMode(ctx context.Context, req *mcp.CallToolRequest, args UpdateGroupArgs) (*mcp.CallToolResult, any, error) {
+	return handleUpdateCommittee(ctx, req, UpdateCommitteeArgs{
+		UID:             args.UID,
+		ProjectUID:      args.ProjectUID,
+		Name:            args.Name,
+		Category:        args.Category,
+		Description:     args.Description,
+		Website:         args.Website,
+		EnableVoting:    args.EnableVoting,
+		SSOGroupEnabled: args.SSOGroupEnabled,
+		RequiresReview:  args.RequiresReview,
+		Public:          args.Public,
+		CalendarPublic:  args.CalendarPublic,
+		DisplayName:     args.DisplayName,
+		ParentUID:       args.ParentUID,
+	})
+}
+
+// handleUpdateGroupSettingsMode adapts group-mode args to the committee settings update handler.
+func handleUpdateGroupSettingsMode(ctx context.Context, req *mcp.CallToolRequest, args UpdateGroupSettingsArgs) (*mcp.CallToolResult, any, error) {
+	return handleUpdateCommitteeSettings(ctx, req, UpdateCommitteeSettingsArgs{
+		UID:                   args.UID,
+		BusinessEmailRequired: args.BusinessEmailRequired,
+		MemberVisibility:      args.MemberVisibility,
+		ShowMeetingAttendees:  args.ShowMeetingAttendees,
+	})
+}
+
+// handleDeleteGroupMode adapts group-mode args to the committee delete handler.
+func handleDeleteGroupMode(ctx context.Context, req *mcp.CallToolRequest, args DeleteGroupArgs) (*mcp.CallToolResult, any, error) {
+	return handleDeleteCommittee(ctx, req, DeleteCommitteeArgs{UID: args.UID})
+}
+
+// handleCreateGroupMemberMode adapts group-mode args to the committee member create handler.
+func handleCreateGroupMemberMode(ctx context.Context, req *mcp.CallToolRequest, args CreateGroupMemberArgs) (*mcp.CallToolResult, any, error) {
+	return handleCreateCommitteeMember(ctx, req, CreateCommitteeMemberArgs{
+		CommitteeUID:    args.GroupUID,
+		Email:           args.Email,
+		AppointedBy:     args.AppointedBy,
+		Status:          args.Status,
+		FirstName:       args.FirstName,
+		LastName:        args.LastName,
+		JobTitle:        args.JobTitle,
+		LinkedinProfile: args.LinkedinProfile,
+		Role:            args.Role,
+		Voting:          args.Voting,
+		Organization:    args.Organization,
+	})
+}
+
+// handleUpdateGroupMemberMode adapts group-mode args to the committee member update handler.
+func handleUpdateGroupMemberMode(ctx context.Context, req *mcp.CallToolRequest, args UpdateGroupMemberArgs) (*mcp.CallToolResult, any, error) {
+	return handleUpdateCommitteeMember(ctx, req, UpdateCommitteeMemberArgs{
+		CommitteeUID:    args.GroupUID,
+		MemberUID:       args.MemberUID,
+		Email:           args.Email,
+		AppointedBy:     args.AppointedBy,
+		Status:          args.Status,
+		FirstName:       args.FirstName,
+		LastName:        args.LastName,
+		JobTitle:        args.JobTitle,
+		LinkedinProfile: args.LinkedinProfile,
+		Role:            args.Role,
+		Voting:          args.Voting,
+		Organization:    args.Organization,
+	})
+}
+
+// handleDeleteGroupMemberMode adapts group-mode args to the committee member delete handler.
+func handleDeleteGroupMemberMode(ctx context.Context, req *mcp.CallToolRequest, args DeleteGroupMemberArgs) (*mcp.CallToolResult, any, error) {
+	return handleDeleteCommitteeMember(ctx, req, DeleteCommitteeMemberArgs{
+		CommitteeUID: args.GroupUID,
+		MemberUID:    args.MemberUID,
+	})
+}
+
+// --- Registration functions ---
+
+// RegisterCreateCommittee registers the create_committee (or create_group) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "create_group" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterCreateCommittee(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "create_group",
+			Description: "Create a new group (also called committee) under a project.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create Group",
+				DestructiveHint: boolPtr(false),
+			},
+		}, handleCreateGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "create_committee",
 		Description: "Create a new committee under a project.",
@@ -145,8 +354,22 @@ func RegisterCreateCommittee(server *mcp.Server) {
 	}, handleCreateCommittee)
 }
 
-// RegisterUpdateCommittee registers the update_committee tool with the MCP server.
-func RegisterUpdateCommittee(server *mcp.Server) {
+// RegisterUpdateCommittee registers the update_committee (or update_group) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "update_group" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterUpdateCommittee(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "update_group",
+			Description: "Update a group's (also called committee) base information (name, category, visibility, etc.). Only provided fields are changed; omitted fields keep their current values.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Group",
+				DestructiveHint: boolPtr(true),
+				IdempotentHint:  true,
+			},
+		}, handleUpdateGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_committee",
 		Description: "Update a committee's base information (name, category, visibility, etc.). Only provided fields are changed; omitted fields keep their current values.",
@@ -158,8 +381,22 @@ func RegisterUpdateCommittee(server *mcp.Server) {
 	}, handleUpdateCommittee)
 }
 
-// RegisterUpdateCommitteeSettings registers the update_committee_settings tool with the MCP server.
-func RegisterUpdateCommitteeSettings(server *mcp.Server) {
+// RegisterUpdateCommitteeSettings registers the update_committee_settings (or update_group_settings) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "update_group_settings" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterUpdateCommitteeSettings(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "update_group_settings",
+			Description: "Update a group's (also called committee) settings (member visibility, email requirements, meeting attendee defaults). Only provided fields are changed; omitted fields keep their current values.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Group Settings",
+				DestructiveHint: boolPtr(true),
+				IdempotentHint:  true,
+			},
+		}, handleUpdateGroupSettingsMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_committee_settings",
 		Description: "Update a committee's settings (member visibility, email requirements, meeting attendee defaults). Only provided fields are changed; omitted fields keep their current values.",
@@ -171,8 +408,21 @@ func RegisterUpdateCommitteeSettings(server *mcp.Server) {
 	}, handleUpdateCommitteeSettings)
 }
 
-// RegisterDeleteCommittee registers the delete_committee tool with the MCP server.
-func RegisterDeleteCommittee(server *mcp.Server) {
+// RegisterDeleteCommittee registers the delete_committee (or delete_group) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "delete_group" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterDeleteCommittee(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "delete_group",
+			Description: "Delete a group (also called committee) by its UID.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Delete Group",
+				DestructiveHint: boolPtr(true),
+			},
+		}, handleDeleteGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "delete_committee",
 		Description: "Delete a committee by its UID.",
@@ -183,8 +433,21 @@ func RegisterDeleteCommittee(server *mcp.Server) {
 	}, handleDeleteCommittee)
 }
 
-// RegisterCreateCommitteeMember registers the create_committee_member tool with the MCP server.
-func RegisterCreateCommitteeMember(server *mcp.Server) {
+// RegisterCreateCommitteeMember registers the create_committee_member (or create_group_member) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "create_group_member" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterCreateCommitteeMember(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "create_group_member",
+			Description: "Add a new member to a group (also called committee).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Create Group Member",
+				DestructiveHint: boolPtr(false),
+			},
+		}, handleCreateGroupMemberMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "create_committee_member",
 		Description: "Add a new member to a committee.",
@@ -195,8 +458,22 @@ func RegisterCreateCommitteeMember(server *mcp.Server) {
 	}, handleCreateCommitteeMember)
 }
 
-// RegisterUpdateCommitteeMember registers the update_committee_member tool with the MCP server.
-func RegisterUpdateCommitteeMember(server *mcp.Server) {
+// RegisterUpdateCommitteeMember registers the update_committee_member (or update_group_member) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "update_group_member" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterUpdateCommitteeMember(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "update_group_member",
+			Description: "Update an existing group (also called committee) member's information. Only provided fields are changed; omitted fields keep their current values.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Update Group Member",
+				DestructiveHint: boolPtr(true),
+				IdempotentHint:  true,
+			},
+		}, handleUpdateGroupMemberMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_committee_member",
 		Description: "Update an existing committee member's information. Only provided fields are changed; omitted fields keep their current values.",
@@ -208,8 +485,21 @@ func RegisterUpdateCommitteeMember(server *mcp.Server) {
 	}, handleUpdateCommitteeMember)
 }
 
-// RegisterDeleteCommitteeMember registers the delete_committee_member tool with the MCP server.
-func RegisterDeleteCommitteeMember(server *mcp.Server) {
+// RegisterDeleteCommitteeMember registers the delete_committee_member (or delete_group_member) tool with the MCP server.
+// When asGroups is true, the tool is registered under the "delete_group_member" name with group-oriented
+// descriptions; otherwise the standard committee terminology is used.
+func RegisterDeleteCommitteeMember(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "delete_group_member",
+			Description: "Remove a member from a group (also called committee).",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Delete Group Member",
+				DestructiveHint: boolPtr(true),
+			},
+		}, handleDeleteGroupMemberMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "delete_committee_member",
 		Description: "Remove a member from a committee.",

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -44,7 +44,21 @@ func SetMeetingConfig(cfg *MeetingConfig) {
 }
 
 // RegisterSearchMeetings registers the search_meetings tool with the MCP server.
-func RegisterSearchMeetings(server *mcp.Server) {
+// When asGroups is true, the tool description uses group-oriented language and
+// the committee_uid parameter is renamed to group_uid; otherwise the standard
+// committee terminology is used.
+func RegisterSearchMeetings(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "search_meetings",
+			Description: "Search for LFX meetings (group calls, also called committee calls, working group sessions) using the query service. IMPORTANT: When the user asks about events, or for event data (conferences, registrations, attendees, speakers, sponsorships), use query_lfx_semantic_layer (preferred) or query_lfx_lens if semantic layer struggles.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Search Meetings",
+				ReadOnlyHint: true,
+			},
+		}, handleSearchMeetingsGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_meetings",
 		Description: "Search for LFX meetings (committee calls, working group sessions) using the query service. IMPORTANT: When the user asks about events, or for event data (conferences, registrations, attendees, speakers, sponsorships), use query_lfx_semantic_layer (preferred) or query_lfx_lens if semantic layer struggles.",
@@ -68,7 +82,21 @@ func RegisterGetMeeting(server *mcp.Server) {
 }
 
 // RegisterSearchMeetingRegistrants registers the search_meeting_registrants tool with the MCP server.
-func RegisterSearchMeetingRegistrants(server *mcp.Server) {
+// When asGroups is true, the tool description uses group-oriented language and
+// the committee_uid parameter is renamed to group_uid; otherwise the standard
+// committee terminology is used.
+func RegisterSearchMeetingRegistrants(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "search_meeting_registrants",
+			Description: "Search for LFX meeting registrants using the query service. Supports filtering by meeting, group (also known as committee), project, date range, and other fields.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Search Meeting Registrants",
+				ReadOnlyHint: true,
+			},
+		}, handleSearchMeetingRegistrantsGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_meeting_registrants",
 		Description: "Search for LFX meeting registrants using the query service. Supports filtering by meeting, committee, project, date range, and other fields.",
@@ -140,7 +168,21 @@ func RegisterGetPastMeetingSummary(server *mcp.Server) {
 }
 
 // RegisterSearchPastMeetings registers the search_past_meetings tool with the MCP server.
-func RegisterSearchPastMeetings(server *mcp.Server) {
+// When asGroups is true, the tool description uses group-oriented language and
+// the committee_uid parameter is renamed to group_uid; otherwise the standard
+// committee terminology is used.
+func RegisterSearchPastMeetings(server *mcp.Server, asGroups bool) {
+	if asGroups {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "search_past_meetings",
+			Description: "Search for LFX past meetings (v1_past_meeting) using the query service. Supports filtering by project, group (also known as committee), meeting ID, date range, and name.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Search Past Meetings",
+				ReadOnlyHint: true,
+			},
+		}, handleSearchPastMeetingsGroupMode)
+		return
+	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_past_meetings",
 		Description: "Search for LFX past meetings (v1_past_meeting) using the query service. Supports filtering by project, committee, meeting ID, date range, and name.",
@@ -177,6 +219,20 @@ type SearchMeetingsArgs struct {
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
+// SearchMeetingsGroupArgs is the groups-mode variant of SearchMeetingsArgs.
+type SearchMeetingsGroupArgs struct {
+	Name       string   `json:"name,omitempty" jsonschema:"Name or partial name of the meeting to search for"`
+	ProjectUID string   `json:"project_uid,omitempty" jsonschema:"Filter meetings by project UID (ignored when group_uid is set)"`
+	GroupUID   string   `json:"group_uid,omitempty" jsonschema:"Filter meetings by group UID (also known as committee UID)"`
+	DateField  string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set)"`
+	DateFrom   string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
+	DateTo     string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
+	Filters    []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. visibility:public or status:active)"`
+	Sort       string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize   int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken  string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
 // GetMeetingArgs defines the input parameters for the get_meeting tool.
 type GetMeetingArgs struct {
 	UID string `json:"uid" jsonschema:"The UID of the meeting to retrieve"`
@@ -191,6 +247,17 @@ type SearchMeetingRegistrantsArgs struct {
 	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
 	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
+// SearchMeetingRegistrantsGroupArgs is the groups-mode variant of SearchMeetingRegistrantsArgs.
+type SearchMeetingRegistrantsGroupArgs struct {
+	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter registrants by meeting ID"`
+	GroupUID  string   `json:"group_uid,omitempty" jsonschema:"Filter registrants by group UID (also known as committee UID; ignored when meeting_id is set)"`
+	Name      string   `json:"name,omitempty" jsonschema:"Name or partial name of the registrant to search for"`
+	Filters   []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. host:true or type:committee)"`
+	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize  int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // GetMeetingRegistrantArgs defines the input parameters for the get_meeting_registrant tool.
@@ -886,9 +953,71 @@ type SearchPastMeetingsArgs struct {
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
+// SearchPastMeetingsGroupArgs is the groups-mode variant of SearchPastMeetingsArgs.
+type SearchPastMeetingsGroupArgs struct {
+	Name       string   `json:"name,omitempty" jsonschema:"Name or partial name of the past meeting to search for"`
+	ProjectUID string   `json:"project_uid,omitempty" jsonschema:"Filter past meetings by project UID (via parent_ref; ~70% coverage)"`
+	GroupUID   string   `json:"group_uid,omitempty" jsonschema:"Filter past meetings by group UID (also known as committee UID; via tag; ~29% coverage)"`
+	MeetingID  string   `json:"meeting_id,omitempty" jsonschema:"Filter past meetings by meeting ID (via tag; ~87% coverage)"`
+	DateField  string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default data.start_time); also accepts data.end_time"`
+	DateFrom   string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
+	DateTo     string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
+	Filters    []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort       string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	PageSize   int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken  string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+}
+
 // GetPastMeetingArgs defines the input parameters for the get_past_meeting tool.
 type GetPastMeetingArgs struct {
 	UID string `json:"uid" jsonschema:"The UID of the past meeting to retrieve"`
+}
+
+// handleSearchPastMeetings implements the search_past_meetings tool logic.
+// handleSearchMeetingsGroupMode adapts group-mode args to the meetings handler.
+func handleSearchMeetingsGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchMeetingsGroupArgs) (*mcp.CallToolResult, any, error) {
+	return handleSearchMeetings(ctx, req, SearchMeetingsArgs{
+		Name:         args.Name,
+		ProjectUID:   args.ProjectUID,
+		CommitteeUID: args.GroupUID,
+		DateField:    args.DateField,
+		DateFrom:     args.DateFrom,
+		DateTo:       args.DateTo,
+		Filters:      args.Filters,
+		Sort:         args.Sort,
+		PageSize:     args.PageSize,
+		PageToken:    args.PageToken,
+	})
+}
+
+// handleSearchMeetingRegistrantsGroupMode adapts group-mode args to the meeting registrants handler.
+func handleSearchMeetingRegistrantsGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchMeetingRegistrantsGroupArgs) (*mcp.CallToolResult, any, error) {
+	return handleSearchMeetingRegistrants(ctx, req, SearchMeetingRegistrantsArgs{
+		MeetingID:    args.MeetingID,
+		CommitteeUID: args.GroupUID,
+		Name:         args.Name,
+		Filters:      args.Filters,
+		Sort:         args.Sort,
+		PageSize:     args.PageSize,
+		PageToken:    args.PageToken,
+	})
+}
+
+// handleSearchPastMeetingsGroupMode adapts group-mode args to the past meetings handler.
+func handleSearchPastMeetingsGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingsGroupArgs) (*mcp.CallToolResult, any, error) {
+	return handleSearchPastMeetings(ctx, req, SearchPastMeetingsArgs{
+		Name:         args.Name,
+		ProjectUID:   args.ProjectUID,
+		CommitteeUID: args.GroupUID,
+		MeetingID:    args.MeetingID,
+		DateField:    args.DateField,
+		DateFrom:     args.DateFrom,
+		DateTo:       args.DateTo,
+		Filters:      args.Filters,
+		Sort:         args.Sort,
+		PageSize:     args.PageSize,
+		PageToken:    args.PageToken,
+	})
 }
 
 // handleSearchPastMeetings implements the search_past_meetings tool logic.

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -973,7 +973,6 @@ type GetPastMeetingArgs struct {
 	UID string `json:"uid" jsonschema:"The UID of the past meeting to retrieve"`
 }
 
-// handleSearchPastMeetings implements the search_past_meetings tool logic.
 // handleSearchMeetingsGroupMode adapts group-mode args to the meetings handler.
 func handleSearchMeetingsGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchMeetingsGroupArgs) (*mcp.CallToolResult, any, error) {
 	return handleSearchMeetings(ctx, req, SearchMeetingsArgs{


### PR DESCRIPTION
## Summary

Implements the `CommitteesAsGroups` feature flag (`LFXMCP_COMMITTEES_AS_GROUPS`, default `false`) that rebrands committee-related MCP tools to use "group"/"groups" terminology while retaining "committee" as a synonym in descriptions for LLM discoverability.

## Changes

### `cmd/lfx-mcp-server/main.go`
- Added `CommitteesAsGroups bool` to `Config` (koanf: `committees_as_groups`, env: `LFXMCP_COMMITTEES_AS_GROUPS`)
- Added `--committees_as_groups` CLI flag
- Added `committeeToGroupToolNames` map for the 11 committee tools
- In `newServer()`: normalizes group-mode tool names in `LFXMCP_TOOLS` back to canonical committee names so all registration checks remain consistent; `defaultTools` continues to use committee names as canonical
- Passes `cfg.CommitteesAsGroups` to all 11 committee and 3 meeting `Register*` calls

### `internal/tools/committee.go` and `committee_write.go`
- All 11 `Register*` functions accept `asGroups bool`
- When `true`: tool names change (e.g. `search_committees` → `search_groups`), titles and descriptions use group language with committee as synonym
- Added group-mode arg structs with `group_uid` JSON fields (e.g. `GetGroupMemberArgs`, `CreateGroupMemberArgs`)
- Added thin adapter handlers mapping group args → committee args

### `internal/tools/meeting.go`
- `RegisterSearchMeetings`, `RegisterSearchMeetingRegistrants`, `RegisterSearchPastMeetings` accept `asGroups bool`
- Tool names unchanged; when flag is on, `committee_uid` parameter renames to `group_uid` with updated descriptions
- Added group-mode arg structs and adapter handlers

## Behavior

| Flag | Tool names | Param names | Descriptions |
|------|-----------|-------------|--------------|
| `false` (default) | `search_committees`, `get_committee`, … | `committee_uid` | Unchanged |
| `true` | `search_groups`, `get_group`, … | `group_uid` | Group-first, committee as synonym |

Users may specify either the committee or group tool name in `LFXMCP_TOOLS` regardless of flag state — both are accepted.

## Issue

Issue: ARCH-398