### PR TITLE
fix: clean up internal details from tool field schema descriptions

### DIFF
--- a/internal/tools/b2b_org.go
+++ b/internal/tools/b2b_org.go
@@ -19,7 +19,7 @@ type SearchB2bOrgsArgs struct {
 	SearchName string `json:"search_name,omitempty" jsonschema:"Search B2B organizations by name (case-insensitive substring match)."`
 	Sort       string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
 	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 1000)"`
-	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque cursor from a previous response to fetch the next page"`
+	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // ListB2bOrgMembershipsArgs defines the input parameters for the list_b2b_org_memberships tool.
@@ -27,7 +27,7 @@ type ListB2bOrgMembershipsArgs struct {
 	B2bOrgUID string `json:"b2b_org_uid" jsonschema:"B2B organization UID (required)"`
 	Sort      string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
 	PageSize  int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 1000)"`
-	PageToken string `json:"page_token,omitempty" jsonschema:"Opaque cursor from a previous response to fetch the next page"`
+	PageToken string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // b2bOrgView is a filtered view of B2bOrgResponse for MCP responses.

--- a/internal/tools/b2b_org.go
+++ b/internal/tools/b2b_org.go
@@ -27,7 +27,7 @@ type ListB2bOrgMembershipsArgs struct {
 	B2bOrgUID string `json:"b2b_org_uid" jsonschema:"B2B organization UID (required)"`
 	Sort      string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
 	PageSize  int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 1000)"`
-	PageToken string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+	PageToken string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous list response"`
 }
 
 // b2bOrgView is a filtered view of B2bOrgResponse for MCP responses.

--- a/internal/tools/mailing_list.go
+++ b/internal/tools/mailing_list.go
@@ -56,7 +56,7 @@ type SearchMailingListMembersArgs struct {
 	MailingListID string `json:"mailing_list_id,omitempty" jsonschema:"Optional Groups.io numeric group ID of the mailing list to filter members by (e.g. 145670)"`
 	ProjectUID    string `json:"project_uid,omitempty" jsonschema:"Optional project UID to filter mailing list members by project"`
 	Name          string `json:"name,omitempty" jsonschema:"Name or partial name of the member to search for"`
-	PageSize      int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10)"`
+	PageSize      int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken     string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
@@ -64,7 +64,7 @@ type SearchMailingListMembersArgs struct {
 type SearchMailingListsArgs struct {
 	Name       string `json:"name,omitempty" jsonschema:"Name or partial name of the mailing list to search for"`
 	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Optional project UID to filter mailing lists by project"`
-	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10)"`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -956,14 +956,14 @@ type SearchPastMeetingsArgs struct {
 // SearchPastMeetingsGroupArgs is the groups-mode variant of SearchPastMeetingsArgs.
 type SearchPastMeetingsGroupArgs struct {
 	Name       string   `json:"name,omitempty" jsonschema:"Name or partial name of the past meeting to search for"`
-	ProjectUID string   `json:"project_uid,omitempty" jsonschema:"Filter past meetings by project UID (via parent_ref; ~70% coverage)"`
-	GroupUID   string   `json:"group_uid,omitempty" jsonschema:"Filter past meetings by group UID (also known as committee UID; via tag; ~29% coverage)"`
-	MeetingID  string   `json:"meeting_id,omitempty" jsonschema:"Filter past meetings by meeting ID (via tag; ~87% coverage)"`
-	DateField  string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default data.start_time); also accepts data.end_time"`
+	ProjectUID string   `json:"project_uid,omitempty" jsonschema:"Filter past meetings by project UID"`
+	GroupUID   string   `json:"group_uid,omitempty" jsonschema:"Filter past meetings by group UID (also known as committee UID)"`
+	MeetingID  string   `json:"meeting_id,omitempty" jsonschema:"Filter past meetings by meeting ID"`
+	DateField  string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set); also accepts end_time"`
 	DateFrom   string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
 	DateTo     string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
 	Filters    []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort       string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	Sort       string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize   int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken  string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
@@ -1089,7 +1089,7 @@ func handleSearchPastMeetings(ctx context.Context, req *mcp.CallToolRequest, arg
 	if args.DateFrom != "" || args.DateTo != "" {
 		dateField := args.DateField
 		if dateField == "" {
-			dateField = "data.start_time"
+			dateField = "start_time"
 		}
 		payload.DateField = &dateField
 		if args.DateFrom != "" {

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -143,7 +143,7 @@ func RegisterGetPastMeetingSummary(server *mcp.Server) {
 func RegisterSearchPastMeetings(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_past_meetings",
-		Description: "Search for LFX past meetings (v1_past_meeting) using the query service. Supports filtering by project, committee, meeting ID, date range, and name.",
+		Description: "Search for LFX past meetings using the query service. Supports filtering by project, committee, meeting ID, date range, and name.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meetings",
 			ReadOnlyHint: true,
@@ -155,7 +155,7 @@ func RegisterSearchPastMeetings(server *mcp.Server) {
 func RegisterGetPastMeeting(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_past_meeting",
-		Description: "Get an LFX past meeting (v1_past_meeting) by its UID using the query service.",
+		Description: "Get an LFX past meeting by its UID using the query service.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Past Meeting",
 			ReadOnlyHint: true,
@@ -172,7 +172,7 @@ type SearchMeetingsArgs struct {
 	DateFrom     string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
 	DateTo       string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
 	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. visibility:public or status:active)"`
-	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
@@ -188,7 +188,7 @@ type SearchMeetingRegistrantsArgs struct {
 	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter registrants by committee UID (ignored when meeting_id is set)"`
 	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the registrant to search for"`
 	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. host:true or type:committee)"`
-	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
@@ -200,10 +200,10 @@ type GetMeetingRegistrantArgs struct {
 
 // SearchPastMeetingParticipantsArgs defines the input parameters for the search_past_meeting_participants tool.
 type SearchPastMeetingParticipantsArgs struct {
-	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter participants by meeting ID (best available; ~25% of participants may not be reachable by this filter)"`
+	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter participants by meeting ID"`
 	Name      string   `json:"name,omitempty" jsonschema:"Name or partial name of the participant to search for"`
 	Filters   []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize  int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
@@ -218,7 +218,7 @@ type SearchPastMeetingSummariesArgs struct {
 	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter summaries by meeting ID"`
 	Name      string   `json:"name,omitempty" jsonschema:"Name or partial name of the summary to search for"`
 	Filters   []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize  int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
@@ -279,7 +279,7 @@ func handleSearchMeetings(ctx context.Context, req *mcp.CallToolRequest, args Se
 	}
 
 	// committee_uid takes precedence over project_uid when both are provided
-	// because committee is indexed as a parent_ref for v1_meeting.
+	// because committee resolves to a more specific parent reference.
 	if args.CommitteeUID != "" {
 		parentRef := "committee:" + args.CommitteeUID
 		payload.Parent = &parentRef
@@ -874,14 +874,14 @@ func handleGetPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest,
 // SearchPastMeetingsArgs defines the input parameters for the search_past_meetings tool.
 type SearchPastMeetingsArgs struct {
 	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the past meeting to search for"`
-	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter past meetings by project UID (via parent_ref; ~70% coverage)"`
-	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter past meetings by committee UID (via tag; ~29% coverage)"`
-	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter past meetings by meeting ID (via tag; ~87% coverage)"`
-	DateField    string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default data.start_time); also accepts data.end_time"`
+	ProjectUID   string   `json:"project_uid,omitempty" jsonschema:"Filter past meetings by project UID"`
+	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter past meetings by committee UID"`
+	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter past meetings by meeting ID"`
+	DateField    string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set); also accepts end_time"`
 	DateFrom     string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
 	DateTo       string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
 	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
+	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -36,7 +36,7 @@ type SearchMembersArgs struct {
 	TierUID    string `json:"tier_uid,omitempty" jsonschema:"Filter by membership tier UID (UUID from list_project_tiers)"`
 	Sort       string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
 	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
-	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque cursor from a previous response to fetch the next page"`
+	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // GetMemberMembershipArgs defines the input parameters for the get_member_membership tool.


### PR DESCRIPTION
## Summary

Closes ARCH-395.

Cleans up `jsonschema` tag descriptions across meeting, member, B2B org, and mailing list tools to remove internal implementation details and normalize wording across all tools.

### Changes

**`meeting.go`**
- Removed `via parent_ref`, `via tag`, and coverage percentage caveats (`~70%`, `~29%`, `~87%`) from `SearchPastMeetingsArgs` field descriptions
- Removed `best available; ~25% of participants may not be reachable by this filter` caveat from `SearchPastMeetingParticipantsArgs.MeetingID` — limitation accepted silently
- Removed `data.` prefix from `SearchPastMeetingsArgs.DateField` description; aligned wording with `SearchMeetingsArgs.DateField`
- Converted all five meeting `sort` fields from `enum=` annotation style to free-text prose (matching `b2b_org.go` / `member.go`)
- Removed user-facing `v1_past_meeting` type name references from `RegisterSearchPastMeetings` and `RegisterGetPastMeeting` tool descriptions
- Cleaned up internal comment in `handleSearchMeetings` that referenced `v1_meeting` and `parent_ref`

**`b2b_org.go`**
- Normalized `page_token` wording to `Opaque pagination token from a previous search response`

**`member.go`**
- Normalized `page_token` wording to `Opaque pagination token from a previous search response`

**`mailing_list.go`**
- Added missing `max 100` qualifier to both `page_size` fields

### Acceptance Criteria Check
- ✅ No `data.` prefixes in any user-facing field description
- ✅ No indexer terms (`parent_ref`, `tag`) in field descriptions
- ✅ No coverage percentage caveats in field descriptions
- ✅ All `sort` fields use consistent free-text prose style
- ✅ All `page_token` fields use consistent wording
- ✅ All `page_size` fields document their maximum value

Issue: ARCH-395