### PR TITLE
docs: add LF enterprise Claude connector instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,21 @@ Add the following to your `~/.config/opencode/opencode.json`:
 
 See the [OpenCode MCP documentation](https://opencode.ai/docs/mcp-servers) for more details.
 
-### Claude
+### Claude (LF enterprise)
 
-Add the LFX MCP Server in **Settings → Integrations → Add Integration**:
+If you use the Linux Foundation's enterprise Claude.ai organization, the LFX MCP Server is already provisioned as a connector — you do not need to add it manually.
+
+1. In Claude.ai, open **Settings → Connectors**.
+2. Find **LFX MCP Server** in the list of available connectors.
+3. Click **Connect**.
+4. Sign in with your **LFID** when prompted.
+5. Click **Authorize** to grant access; you will be redirected back to Claude.
+
+The connector is now active for your account.
+
+### Claude (personal account)
+
+Add the LFX MCP Server in **Settings → Connectors → Add Custom Connector **:
 
 - **URL:** `https://mcp.lfx.dev/mcp`
 - **Client ID:** `Ef9tuU5wcJJIXmNGvZyGUkZFfD8CZWar`


### PR DESCRIPTION
## Summary

- Adds a new `### Claude (LF enterprise)` subsection to the README documenting the pre-provisioned LFX MCP Server connector flow for users on the Linux Foundation's enterprise Claude.ai organization (Settings → Connectors → LFX MCP Server → Connect → LFID SSO → Authorize).
- Renames the existing `### Claude` heading to `### Claude (personal account)` so the manual integration path (URL + Client ID) is clearly distinguished from the enterprise connector path.

## Test plan

- [ ] Open `README.md` and confirm the new `### Claude (LF enterprise)` subsection renders correctly between the OpenCode and personal-account Claude sections.
- [ ] Confirm the renamed `### Claude (personal account)` subsection still has the correct URL (`https://mcp.lfx.dev/mcp`) and Client ID (`Ef9tuU5wcJJIXmNGvZyGUkZFfD8CZWar`).
- [ ] Confirm the documented steps match the current Claude.ai enterprise connector UI.