### PR TITLE
refactor: remove generic filters param from meeting search tools; fix past meeting filters; add validate-search-filters skill

### DIFF
--- a/.agents/skills/validate-search-filters/SKILL.md
+++ b/.agents/skills/validate-search-filters/SKILL.md
@@ -29,11 +29,8 @@ and optionally apply fixes.
   that the mechanism works.
 - `payload.Parent` in the query service is a single string. A tool that
   accepts both `project_uid` and `committee_uid` can only send one at a time.
-- `handleSearchPastMeetingResource` is a shared handler used only by
-  `v1_past_meeting_summary` (and `v1_past_meeting_transcript` if added).
-  `v1_past_meeting_participant` has its own dedicated handler
-  `handleSearchPastMeetingParticipants`. Changes to the shared handler affect
-  all resource types that use it simultaneously.
+- `handleSearchPastMeetingParticipants` and `handleSearchPastMeetingSummaries`
+  are dedicated handlers — each owns its own filter logic independently.
 - When sampling documents, use `"size": 3` to keep output small. Use
   `_source` filtering to request only `tags` and `parent_refs` fields.
 
@@ -254,9 +251,6 @@ each broken filter:
   `payload.Parent = "<type>:<uid>"`.
 - **Wrong tag key**: use the key that actually appears in the index.
 - **Not indexed**: remove the parameter from the args struct and handler.
-- **Shared handler impact**: if the fix is in `handleSearchPastMeetingResource`,
-  verify that the change is correct for all resource types that use it
-  (`v1_past_meeting_participant`, `v1_past_meeting_summary`, and any others).
 
 After applying fixes, run `make build` to confirm compilation succeeds.
 

--- a/.agents/skills/validate-search-filters/SKILL.md
+++ b/.agents/skills/validate-search-filters/SKILL.md
@@ -5,9 +5,10 @@ license: MIT
 compatibility: Requires kubectl configured against the LFX v2 Kubernetes cluster (dev or prod) with aws-vault access. The OpenSearch cluster is an AWS-managed OpenSearch Service domain reachable only from within the cluster network — queries are tunnelled through the NATS box pod using kubectl exec.
 ---
 
-Validate every search tool filter parameter in `internal/tools/` against the
-live OpenSearch `resources` index and the upstream indexer-contract
-documentation. Produce a per-filter verdict table and optionally apply fixes.
+Validate every filter parameter across all tools that use the query service SDK
+in `internal/tools/` against the live OpenSearch `resources` index and the
+upstream indexer-contract documentation. Produce a per-filter verdict table
+and optionally apply fixes.
 
 ## Gotchas
 
@@ -18,7 +19,7 @@ documentation. Produce a per-filter verdict table and optionally apply fixes.
   in namespace `lfx`.
 - Discover the OpenSearch URL dynamically from the indexer deployment env var
   `OPENSEARCH_URL`. The index name is in `OPENSEARCH_INDEX` (currently
-  `resources`).
+  `resources`). Combine them into `OPENSEARCH_BASEURL` as shown in Step 1.
 - `tags` entries may have empty values (e.g. `"committee_uid:"`,
   `"project_uid:"`) — these are indexed but useless for filtering. A tag key
   is only valid evidence when at least one document has a non-empty value for
@@ -44,11 +45,16 @@ NATS_POD=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
   -l 'app.kubernetes.io/component=nats-box,app.kubernetes.io/instance=lfx-platform' \
   -o jsonpath='{.items[0].metadata.name}')
 
-# Resolve OpenSearch URL and index from the indexer deployment.
-OS_ENV=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
+# Resolve OpenSearch URL and index from the indexer deployment env vars.
+OPENSEARCH_URL=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
   get deploy -n lfx lfx-v2-indexer-service \
-  -o jsonpath='{.spec.template.spec.containers[0].env}')
-# Extract OPENSEARCH_URL and OPENSEARCH_INDEX from OS_ENV (jq or grep).
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPENSEARCH_URL")].value}')
+OPENSEARCH_INDEX=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
+  get deploy -n lfx lfx-v2-indexer-service \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPENSEARCH_INDEX")].value}')
+
+# Build the base URL used in all search queries below.
+OPENSEARCH_BASEURL="$OPENSEARCH_URL/$OPENSEARCH_INDEX"
 
 # Verify connectivity — halt if this returns an error or empty body.
 aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
@@ -75,11 +81,18 @@ parameter is sent to the query service. The mechanisms are:
 | `payload.Name = "<value>"` | `Name` | `name` (text search) |
 | `payload.DateField` / `DateFrom` / `DateTo` | date range | date fields |
 
-Current search tools and their structured filter parameters (update this list
-if new tools are added):
+Current tools using the query service SDK and their structured filter parameters
+(update this list if new tools are added):
 
 | Tool | Resource type | Parameter | Mechanism | Sent as |
 |---|---|---|---|---|
+| `search_projects` | `project` | `parent_uid` | Parent | `project:<uid>` |
+| `search_committees` | `committee` | `project_uid` | Parent | `project:<uid>` |
+| `search_committee_members` | `committee_member` | `committee_uid` | Tag | `committee_uid:<uid>` |
+| `search_committee_members` | `committee_member` | `project_uid` | Tag | `project_uid:<uid>` |
+| `search_mailing_lists` | `groupsio_mailing_list` | `project_uid` | Parent | `project:<uid>` |
+| `search_mailing_list_members` | `groupsio_member` | `mailing_list_id` | Tag | `mailing_list_uid:<id>` |
+| `search_mailing_list_members` | `groupsio_member` | `project_uid` | Tag | `project_uid:<uid>` |
 | `search_meetings` | `v1_meeting` | `committee_uid` | Parent (preferred) | `committee:<uid>` |
 | `search_meetings` | `v1_meeting` | `project_uid` | Parent (fallback) | `project:<uid>` |
 | `search_meeting_registrants` | `v1_meeting_registrant` | `meeting_id` | Parent (preferred) | `meeting:<id>` |
@@ -102,21 +115,25 @@ Known contract URLs:
 - `v1_meeting`, `v1_meeting_registrant`, `v1_past_meeting_participant`,
   `v1_past_meeting_transcript`, `v1_past_meeting_summary`:
   https://github.com/linuxfoundation/lfx-v2-meeting-service/blob/main/docs/indexer-contract.md
+- `project`, `committee`, `committee_member`, `groupsio_mailing_list`,
+  `groupsio_member`: search for `indexer-contract.md` in the relevant service
+  repos (e.g. `lfx-v2-project-service`, `lfx-v2-committee-service`,
+  `lfx-v2-mailing-list-service`) and add the URLs here when found.
 
 Fetch each URL and record which tag keys and parent_ref prefixes the contract
 defines for each resource type.
 
 ## Step 4 — Sample the live index
 
-For each resource type, run the following queries via the NATS box. Replace
-`$NATS_POD`, `$OPENSEARCH_URL`, and `$INDEX` with the values from Step 1.
+For each resource type, run the following queries via the NATS box. Use the
+`$NATS_POD` and `$OPENSEARCH_BASEURL` variables set in Step 1.
 
 **Sample tags and parent_refs from 3 documents:**
 
 ```bash
 aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
   exec -n lfx "$NATS_POD" -- \
-  curl -s -X GET "$OPENSEARCH_URL/$INDEX/_search" \
+  curl -s -X GET "$OPENSEARCH_BASEURL/_search" \
   -H 'Content-Type: application/json' \
   -d '{
     "size": 3,
@@ -132,7 +149,7 @@ aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
 ```bash
 aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
   exec -n lfx "$NATS_POD" -- \
-  curl -s -X GET "$OPENSEARCH_URL/$INDEX/_search" \
+  curl -s -X GET "$OPENSEARCH_BASEURL/_search" \
   -H 'Content-Type: application/json' \
   -d '{
     "size": 1,
@@ -156,7 +173,7 @@ aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
 ```bash
 aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
   exec -n lfx "$NATS_POD" -- \
-  curl -s -X GET "$OPENSEARCH_URL/$INDEX/_search" \
+  curl -s -X GET "$OPENSEARCH_BASEURL/_search" \
   -H 'Content-Type: application/json' \
   -d '{
     "size": 1,

--- a/.agents/skills/validate-search-filters/SKILL.md
+++ b/.agents/skills/validate-search-filters/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: validate-search-filters
+description: Validate MCP search tool filter parameters against the live OpenSearch resources index and upstream indexer-contract documentation. Use after any filter bug report or indexer contract change to identify broken, missing, or incorrectly implemented filter parameters.
+license: MIT
+compatibility: Requires kubectl configured against the LFX v2 Kubernetes cluster (dev or prod) with aws-vault access. The OpenSearch cluster is an AWS-managed OpenSearch Service domain reachable only from within the cluster network — queries are tunnelled through the NATS box pod using kubectl exec.
+---
+
+Validate every search tool filter parameter in `internal/tools/` against the
+live OpenSearch `resources` index and the upstream indexer-contract
+documentation. Produce a per-filter verdict table and optionally apply fixes.
+
+## Gotchas
+
+- The OpenSearch cluster is AWS-managed and not port-forward accessible. All
+  `curl` queries must be run via `kubectl exec` into the NATS box pod.
+- Discover the pod name dynamically — never hardcode it. Use the label
+  selector `app.kubernetes.io/component=nats-box,app.kubernetes.io/instance=lfx-platform`
+  in namespace `lfx`.
+- Discover the OpenSearch URL dynamically from the indexer deployment env var
+  `OPENSEARCH_URL`. The index name is in `OPENSEARCH_INDEX` (currently
+  `resources`).
+- `tags` entries may have empty values (e.g. `"committee_uid:"`,
+  `"project_uid:"`) — these are indexed but useless for filtering. A tag key
+  is only valid evidence when at least one document has a non-empty value for
+  it.
+- Mixed old/new data means partial `parent_refs` coverage is expected on some
+  resource types. A non-zero hit count on a prefix query is sufficient evidence
+  that the mechanism works.
+- `payload.Parent` in the query service is a single string. A tool that
+  accepts both `project_uid` and `committee_uid` can only send one at a time.
+- `handleSearchPastMeetingResource` is a shared handler used by
+  `v1_past_meeting_participant`, `v1_past_meeting_summary`, and
+  (if added) `v1_past_meeting_transcript`. Changes to its filter logic affect
+  all three resource types simultaneously.
+- When sampling documents, use `"size": 3` to keep output small. Use
+  `_source` filtering to request only `tags` and `parent_refs` fields.
+
+## Step 1 — Discover infrastructure
+
+```bash
+# Resolve the NATS box pod name.
+NATS_POD=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
+  get pod -n lfx \
+  -l 'app.kubernetes.io/component=nats-box,app.kubernetes.io/instance=lfx-platform' \
+  -o jsonpath='{.items[0].metadata.name}')
+
+# Resolve OpenSearch URL and index from the indexer deployment.
+OS_ENV=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
+  get deploy -n lfx lfx-v2-indexer-service \
+  -o jsonpath='{.spec.template.spec.containers[0].env}')
+# Extract OPENSEARCH_URL and OPENSEARCH_INDEX from OS_ENV (jq or grep).
+
+# Verify connectivity — halt if this returns an error or empty body.
+aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
+  exec -n lfx "$NATS_POD" -- \
+  curl -s "$OPENSEARCH_URL/"
+```
+
+If the connectivity check fails, stop and report: **OpenSearch unreachable —
+check cluster access and aws-vault session.**
+
+Substitute `lfx-prod` / `prod-lfx-v2` with `lfx-dev` / `dev-lfx-v2` if you
+need to target the dev cluster instead.
+
+## Step 2 — Enumerate search tools and their filter mappings
+
+Read every `*Args` struct in `internal/tools/` and record how each filter
+parameter is sent to the query service. The mechanisms are:
+
+| Mechanism | Query service field | Index field |
+|---|---|---|
+| `payload.Parent = "<type>:<uid>"` | `Parent` | `parent_refs` |
+| `payload.Tags = ["<key>:<value>"]` | `Tags` | `tags` |
+| `payload.Filters = ["<field>:<value>"]` | `Filters` | top-level doc fields |
+| `payload.Name = "<value>"` | `Name` | `name` (text search) |
+| `payload.DateField` / `DateFrom` / `DateTo` | date range | date fields |
+
+Current search tools and their structured filter parameters (update this list
+if new tools are added):
+
+| Tool | Resource type | Parameter | Mechanism | Sent as |
+|---|---|---|---|---|
+| `search_meetings` | `v1_meeting` | `committee_uid` | Parent (preferred) | `committee:<uid>` |
+| `search_meetings` | `v1_meeting` | `project_uid` | Parent (fallback) | `project:<uid>` |
+| `search_meeting_registrants` | `v1_meeting_registrant` | `meeting_id` | Parent (preferred) | `meeting:<id>` |
+| `search_meeting_registrants` | `v1_meeting_registrant` | `committee_uid` | Parent (fallback) | `committee:<uid>` |
+| `search_past_meetings` | `v1_past_meeting` | `project_uid` | Parent | `project:<uid>` |
+| `search_past_meetings` | `v1_past_meeting` | `committee_uid` | Tag | `committee_uid:<uid>` |
+| `search_past_meetings` | `v1_past_meeting` | `meeting_id` | Tag | `meeting_id:<id>` |
+| `search_past_meeting_participants` | `v1_past_meeting_participant` | `meeting_id` | Tag | `meeting_id:<id>` |
+| `search_past_meeting_summaries` | `v1_past_meeting_summary` | `meeting_id` | Tag | `meeting_id:<id>` |
+
+Re-read the handler code to verify this table is current before proceeding.
+
+## Step 3 — Fetch indexer contracts
+
+Fetch the indexer-contract documentation for each resource type and extract
+the **Tags** table and **Parent References** table.
+
+Known contract URLs:
+
+- `v1_meeting`, `v1_meeting_registrant`, `v1_past_meeting_participant`,
+  `v1_past_meeting_transcript`, `v1_past_meeting_summary`:
+  https://github.com/linuxfoundation/lfx-v2-meeting-service/blob/main/docs/indexer-contract.md
+
+Fetch each URL and record which tag keys and parent_ref prefixes the contract
+defines for each resource type.
+
+## Step 4 — Sample the live index
+
+For each resource type, run the following queries via the NATS box. Replace
+`$NATS_POD`, `$OPENSEARCH_URL`, and `$INDEX` with the values from Step 1.
+
+**Sample tags and parent_refs from 3 documents:**
+
+```bash
+aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
+  exec -n lfx "$NATS_POD" -- \
+  curl -s -X GET "$OPENSEARCH_URL/$INDEX/_search" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "size": 3,
+    "_source": ["tags", "parent_refs", "object_type"],
+    "query": {
+      "term": { "object_type": "<RESOURCE_TYPE>" }
+    }
+  }'
+```
+
+**Check whether a specific tag key has any non-empty values:**
+
+```bash
+aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
+  exec -n lfx "$NATS_POD" -- \
+  curl -s -X GET "$OPENSEARCH_URL/$INDEX/_search" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "size": 1,
+    "_source": ["tags"],
+    "query": {
+      "bool": {
+        "must": [
+          { "term": { "object_type": "<RESOURCE_TYPE>" } },
+          { "prefix": { "tags": "<TAG_KEY>:" } }
+        ],
+        "must_not": [
+          { "term": { "tags": "<TAG_KEY>:" } }
+        ]
+      }
+    }
+  }'
+```
+
+**Check whether a specific parent_ref prefix exists:**
+
+```bash
+aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
+  exec -n lfx "$NATS_POD" -- \
+  curl -s -X GET "$OPENSEARCH_URL/$INDEX/_search" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "size": 1,
+    "_source": ["parent_refs"],
+    "query": {
+      "bool": {
+        "must": [
+          { "term": { "object_type": "<RESOURCE_TYPE>" } },
+          { "prefix": { "parent_refs": "<PREFIX>:" } }
+        ]
+      }
+    }
+  }'
+```
+
+Record the `total.value` from each response. A non-zero value confirms the
+key/prefix is present in the index.
+
+## Step 5 — Build the truth table
+
+Cross-reference: tool parameter → mechanism → index evidence. Assign a
+verdict to each filter parameter:
+
+- ✅ **Works** — the tag key or parent_ref prefix exists in the index with
+  non-empty values, matching what the tool sends.
+- ⚠️ **Broken** — the tool sends the wrong mechanism (e.g. tag when it should
+  be parent_ref), or uses a key/prefix that does not appear in the index.
+- ❌ **Not indexed** — the data is not present in the index at all for this
+  resource type; the parameter should be removed from the tool.
+
+## Step 6 — Report findings
+
+Emit a structured markdown report grouped by tool:
+
+```markdown
+## <tool_name> (resource type: <type>)
+
+| Parameter | Mechanism | Sent as | Index evidence | Verdict |
+|---|---|---|---|---|
+| committee_uid | Parent | committee:<uid> | parent_refs prefix "committee:" — N hits | ✅ Works |
+| project_uid | Parent | project:<uid> | parent_refs prefix "project:" — 0 hits | ⚠️ Broken |
+```
+
+After the table, state explicitly:
+- Which filters are confirmed working.
+- Which are broken and why (wrong mechanism, wrong key name, etc.).
+- Which should be removed because the data is not indexed.
+
+## Step 7 — Apply fixes (optional)
+
+Only proceed if explicitly instructed to fix. Apply the correct pattern for
+each broken filter:
+
+- **Tag → parent_ref**: change `payload.Tags` to
+  `payload.Parent = "<type>:<uid>"`.
+- **Wrong tag key**: use the key that actually appears in the index.
+- **Not indexed**: remove the parameter from the args struct and handler.
+- **Shared handler impact**: if the fix is in `handleSearchPastMeetingResource`,
+  verify that the change is correct for all resource types that use it
+  (`v1_past_meeting_participant`, `v1_past_meeting_summary`, and any others).
+
+After applying fixes, run `make build` to confirm compilation succeeds.
+
+## Step 8 — Verify fixes
+
+Re-run the targeted `curl` queries from Step 4 against the corrected
+mechanism to confirm non-zero results. Report before/after hit counts for
+each fixed filter.

--- a/.agents/skills/validate-search-filters/SKILL.md
+++ b/.agents/skills/validate-search-filters/SKILL.md
@@ -2,7 +2,7 @@
 name: validate-search-filters
 description: Validate MCP search tool filter parameters against the live OpenSearch resources index and upstream indexer-contract documentation. Use after any filter bug report or indexer contract change to identify broken, missing, or incorrectly implemented filter parameters.
 license: MIT
-compatibility: Requires kubectl configured against the LFX v2 Kubernetes cluster (dev or prod) with aws-vault access. The OpenSearch cluster is an AWS-managed OpenSearch Service domain reachable only from within the cluster network — queries are tunnelled through the NATS box pod using kubectl exec.
+compatibility: Requires kubectl configured against the LFX v2 Kubernetes cluster (dev or prod). The OpenSearch cluster is an AWS-managed OpenSearch Service domain reachable only from within the cluster network — queries are tunnelled through the NATS box pod using kubectl exec.
 ---
 
 Validate every filter parameter across all tools that use the query service SDK
@@ -29,10 +29,11 @@ and optionally apply fixes.
   that the mechanism works.
 - `payload.Parent` in the query service is a single string. A tool that
   accepts both `project_uid` and `committee_uid` can only send one at a time.
-- `handleSearchPastMeetingResource` is a shared handler used by
-  `v1_past_meeting_participant`, `v1_past_meeting_summary`, and
-  (if added) `v1_past_meeting_transcript`. Changes to its filter logic affect
-  all three resource types simultaneously.
+- `handleSearchPastMeetingResource` is a shared handler used only by
+  `v1_past_meeting_summary` (and `v1_past_meeting_transcript` if added).
+  `v1_past_meeting_participant` has its own dedicated handler
+  `handleSearchPastMeetingParticipants`. Changes to the shared handler affect
+  all resource types that use it simultaneously.
 - When sampling documents, use `"size": 3` to keep output small. Use
   `_source` filtering to request only `tags` and `parent_refs` fields.
 
@@ -40,33 +41,29 @@ and optionally apply fixes.
 
 ```bash
 # Resolve the NATS box pod name.
-NATS_POD=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
-  get pod -n lfx \
+NATS_POD=$(kubectl get pod -n lfx \
   -l 'app.kubernetes.io/component=nats-box,app.kubernetes.io/instance=lfx-platform' \
   -o jsonpath='{.items[0].metadata.name}')
 
 # Resolve OpenSearch URL and index from the indexer deployment env vars.
-OPENSEARCH_URL=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
-  get deploy -n lfx lfx-v2-indexer-service \
+OPENSEARCH_URL=$(kubectl get deploy -n lfx lfx-v2-indexer-service \
   -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPENSEARCH_URL")].value}')
-OPENSEARCH_INDEX=$(aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
-  get deploy -n lfx lfx-v2-indexer-service \
+OPENSEARCH_INDEX=$(kubectl get deploy -n lfx lfx-v2-indexer-service \
   -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPENSEARCH_INDEX")].value}')
 
 # Build the base URL used in all search queries below.
 OPENSEARCH_BASEURL="$OPENSEARCH_URL/$OPENSEARCH_INDEX"
 
 # Verify connectivity — halt if this returns an error or empty body.
-aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
-  exec -n lfx "$NATS_POD" -- \
-  curl -s "$OPENSEARCH_URL/"
+# Use --max-time 15 to prevent the curl from hanging and triggering OOMKill (exit 137).
+kubectl exec -n lfx "$NATS_POD" -- \
+  curl -s --max-time 15 "$OPENSEARCH_URL/"
 ```
 
 If the connectivity check fails, stop and report: **OpenSearch unreachable —
-check cluster access and aws-vault session.**
+check cluster access.**
 
-Substitute `lfx-prod` / `prod-lfx-v2` with `lfx-dev` / `dev-lfx-v2` if you
-need to target the dev cluster instead.
+Substitute the kubectl context as needed to target dev vs. prod.
 
 ## Step 2 — Enumerate search tools and their filter mappings
 
@@ -100,56 +97,68 @@ Current tools using the query service SDK and their structured filter parameters
 | `search_past_meetings` | `v1_past_meeting` | `project_uid` | Parent | `project:<uid>` |
 | `search_past_meetings` | `v1_past_meeting` | `committee_uid` | Tag | `committee_uid:<uid>` |
 | `search_past_meetings` | `v1_past_meeting` | `meeting_id` | Tag | `meeting_id:<id>` |
-| `search_past_meeting_participants` | `v1_past_meeting_participant` | `meeting_id` | Tag | `meeting_id:<id>` |
-| `search_past_meeting_summaries` | `v1_past_meeting_summary` | `meeting_id` | Tag | `meeting_id:<id>` |
+| `search_past_meeting_participants` | `v1_past_meeting_participant` | `past_meeting_id` | Parent (preferred) | `past_meeting:<meeting_and_occurrence_id>` |
+| `search_past_meeting_participants` | `v1_past_meeting_participant` | `project_uid` | Parent (fallback) | `project:<uid>` |
+| `search_past_meeting_summaries` | `v1_past_meeting_summary` | `past_meeting_id` | Parent (preferred) | `past_meeting:<meeting_and_occurrence_id>` |
+| `search_past_meeting_summaries` | `v1_past_meeting_summary` | `project_uid` | Parent (fallback) | `project:<uid>` |
 
 Re-read the handler code to verify this table is current before proceeding.
 
 ## Step 3 — Fetch indexer contracts
 
-Fetch the indexer-contract documentation for each resource type and extract
-the **Tags** table and **Parent References** table.
+Fetch the indexer-contract documentation for each resource type. The contracts
+define the canonical set of tag keys and parent_ref prefixes each service
+publishes. This information is **required** for the Step 6 report — every
+filter parameter must be cross-referenced against the contract.
 
 Known contract URLs:
 
-- `v1_meeting`, `v1_meeting_registrant`, `v1_past_meeting_participant`,
-  `v1_past_meeting_transcript`, `v1_past_meeting_summary`:
+- `v1_meeting`, `v1_meeting_registrant`, `v1_past_meeting`,
+  `v1_past_meeting_participant`, `v1_past_meeting_transcript`,
+  `v1_past_meeting_summary`:
   https://github.com/linuxfoundation/lfx-v2-meeting-service/blob/main/docs/indexer-contract.md
-- `project`, `committee`, `committee_member`, `groupsio_mailing_list`,
-  `groupsio_member`: search for `indexer-contract.md` in the relevant service
-  repos (e.g. `lfx-v2-project-service`, `lfx-v2-committee-service`,
-  `lfx-v2-mailing-list-service`) and add the URLs here when found.
+- `project`:
+  https://github.com/linuxfoundation/lfx-v2-project-service/blob/main/docs/indexer-contract.md
+- `committee`, `committee_member`:
+  https://github.com/linuxfoundation/lfx-v2-committee-service/blob/main/docs/indexer-contract.md
+- `groupsio_mailing_list`, `groupsio_member`:
+  https://github.com/linuxfoundation/lfx-v2-mailing-list-service/blob/main/docs/indexer-contract.md
 
-Fetch each URL and record which tag keys and parent_ref prefixes the contract
-defines for each resource type.
+Fetch each URL and extract the **Tags** table and **Parent References** table
+for each resource type. Record which tag keys and parent_ref prefixes the
+contract defines. If a URL 404s or has no contract doc, note it and continue —
+treat those filters as "no contract definition" in the report.
 
 ## Step 4 — Sample the live index
 
 For each resource type, run the following queries via the NATS box. Use the
 `$NATS_POD` and `$OPENSEARCH_BASEURL` variables set in Step 1.
 
-**Sample tags and parent_refs from 3 documents:**
+**Sample tags and parent_refs from 3 recently indexed documents (last 45 days):**
 
 ```bash
-aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
-  exec -n lfx "$NATS_POD" -- \
-  curl -s -X GET "$OPENSEARCH_BASEURL/_search" \
+kubectl exec -n lfx "$NATS_POD" -- \
+  curl -s --max-time 15 -X GET "$OPENSEARCH_BASEURL/_search" \
   -H 'Content-Type: application/json' \
   -d '{
     "size": 3,
     "_source": ["tags", "parent_refs", "object_type"],
     "query": {
-      "term": { "object_type": "<RESOURCE_TYPE>" }
+      "bool": {
+        "must": [
+          { "term": { "object_type": "<RESOURCE_TYPE>" } },
+          { "range": { "updated_at": { "gte": "now-45d" } } }
+        ]
+      }
     }
   }'
 ```
 
-**Check whether a specific tag key has any non-empty values:**
+**Check whether a specific tag key has any non-empty values (last 45 days):**
 
 ```bash
-aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
-  exec -n lfx "$NATS_POD" -- \
-  curl -s -X GET "$OPENSEARCH_BASEURL/_search" \
+kubectl exec -n lfx "$NATS_POD" -- \
+  curl -s --max-time 15 -X GET "$OPENSEARCH_BASEURL/_search" \
   -H 'Content-Type: application/json' \
   -d '{
     "size": 1,
@@ -158,7 +167,8 @@ aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
       "bool": {
         "must": [
           { "term": { "object_type": "<RESOURCE_TYPE>" } },
-          { "prefix": { "tags": "<TAG_KEY>:" } }
+          { "prefix": { "tags": "<TAG_KEY>:" } },
+          { "range": { "updated_at": { "gte": "now-45d" } } }
         ],
         "must_not": [
           { "term": { "tags": "<TAG_KEY>:" } }
@@ -168,12 +178,11 @@ aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
   }'
 ```
 
-**Check whether a specific parent_ref prefix exists:**
+**Check whether a specific parent_ref prefix exists (last 45 days):**
 
 ```bash
-aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
-  exec -n lfx "$NATS_POD" -- \
-  curl -s -X GET "$OPENSEARCH_BASEURL/_search" \
+kubectl exec -n lfx "$NATS_POD" -- \
+  curl -s --max-time 15 -X GET "$OPENSEARCH_BASEURL/_search" \
   -H 'Content-Type: application/json' \
   -d '{
     "size": 1,
@@ -182,7 +191,8 @@ aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
       "bool": {
         "must": [
           { "term": { "object_type": "<RESOURCE_TYPE>" } },
-          { "prefix": { "parent_refs": "<PREFIX>:" } }
+          { "prefix": { "parent_refs": "<PREFIX>:" } },
+          { "range": { "updated_at": { "gte": "now-45d" } } }
         ]
       }
     }
@@ -190,37 +200,50 @@ aws-vault exec lfx-prod -s -- kubectl --context=prod-lfx-v2 \
 ```
 
 Record the `total.value` from each response. A non-zero value confirms the
-key/prefix is present in the index.
+key/prefix is present in recently indexed data. If the count is zero but the
+resource type has older data, note it as "not seen in last 45 days" rather
+than immediately marking it broken — check the sample query to understand
+overall coverage before rendering a verdict.
 
 ## Step 5 — Build the truth table
 
-Cross-reference: tool parameter → mechanism → index evidence. Assign a
-verdict to each filter parameter:
+Cross-reference: tool parameter → mechanism → contract definition → index
+evidence. Assign a verdict to each filter parameter:
 
 - ✅ **Works** — the tag key or parent_ref prefix exists in the index with
-  non-empty values, matching what the tool sends.
+  non-empty values, matching what the tool sends, and the contract defines it.
 - ⚠️ **Broken** — the tool sends the wrong mechanism (e.g. tag when it should
   be parent_ref), or uses a key/prefix that does not appear in the index.
 - ❌ **Not indexed** — the data is not present in the index at all for this
   resource type; the parameter should be removed from the tool.
+- ⚠️ **No contract definition** — the filter works in the live index but is
+  not listed in the indexer-contract doc; flag for follow-up.
 
 ## Step 6 — Report findings
 
-Emit a structured markdown report grouped by tool:
+Emit a structured markdown report grouped by tool. Each row must include a
+"Contract" column that cross-references the indexer-contract documentation
+fetched in Step 3 — state whether the contract defines the tag key or
+parent_ref prefix used by the tool, and if so, whether the tool's mechanism
+matches what the contract specifies.
 
 ```markdown
 ## <tool_name> (resource type: <type>)
 
-| Parameter | Mechanism | Sent as | Index evidence | Verdict |
-|---|---|---|---|---|
-| committee_uid | Parent | committee:<uid> | parent_refs prefix "committee:" — N hits | ✅ Works |
-| project_uid | Parent | project:<uid> | parent_refs prefix "project:" — 0 hits | ⚠️ Broken |
+| Parameter | Mechanism | Sent as | Contract | Index evidence | Verdict |
+|---|---|---|---|---|---|
+| committee_uid | Parent | committee:<uid> | ✅ parent_ref `committee:` | parent_refs prefix "committee:" — N hits | ✅ Works |
+| project_uid | Parent | project:<uid> | ✅ parent_ref `project:` | parent_refs prefix "project:" — 0 hits | ⚠️ Broken |
+| meeting_id | Tag | meeting_id:<id> | ⚠️ not in contract | tag key "meeting_id:" — N hits | ⚠️ Review |
 ```
 
 After the table, state explicitly:
-- Which filters are confirmed working.
+- Which filters are confirmed working and match the contract.
 - Which are broken and why (wrong mechanism, wrong key name, etc.).
 - Which should be removed because the data is not indexed.
+- Which have no contract definition (tag/parent_ref not listed in the
+  indexer-contract doc) — flag these for follow-up even if they appear to work
+  in the live index, since undocumented fields may be removed without notice.
 
 ## Step 7 — Apply fixes (optional)
 

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -147,7 +147,7 @@ func RegisterGetPastMeetingParticipant(server *mcp.Server) {
 func RegisterSearchPastMeetingSummaries(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_past_meeting_summaries",
-		Description: "Search for LFX past meeting summaries using the query service. Supports filtering by past meeting ID, project UID, and name.",
+		Description: "Search for LFX past meeting summaries using the query service. Supports filtering by past meeting ID (the meeting_and_occurrence_id value, e.g. 91461158520-1771596000000), project UID, and name.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meeting Summaries",
 			ReadOnlyHint: true,

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -123,7 +123,7 @@ func RegisterGetMeetingRegistrant(server *mcp.Server) {
 func RegisterSearchPastMeetingParticipants(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_past_meeting_participants",
-		Description: "Search for LFX past meeting participants using the query service. Supports filtering by meeting ID and name.",
+		Description: "Search for LFX past meeting participants using the query service. Supports filtering by past meeting ID (meeting_and_occurrence_id), project UID, and name.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meeting Participants",
 			ReadOnlyHint: true,
@@ -147,7 +147,7 @@ func RegisterGetPastMeetingParticipant(server *mcp.Server) {
 func RegisterSearchPastMeetingSummaries(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_past_meeting_summaries",
-		Description: "Search for LFX past meeting summaries using the query service. Supports filtering by meeting ID and name.",
+		Description: "Search for LFX past meeting summaries using the query service. Supports filtering by past meeting ID, project UID, and name.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meeting Summaries",
 			ReadOnlyHint: true,
@@ -267,12 +267,13 @@ type GetMeetingRegistrantArgs struct {
 
 // SearchPastMeetingParticipantsArgs defines the input parameters for the search_past_meeting_participants tool.
 type SearchPastMeetingParticipantsArgs struct {
-	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter participants by meeting ID"`
-	Name      string   `json:"name,omitempty" jsonschema:"Name or partial name of the participant to search for"`
-	Filters   []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
-	PageSize  int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
-	PageToken string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+	PastMeetingID string   `json:"past_meeting_id,omitempty" jsonschema:"Filter participants by past meeting ID (the meeting_and_occurrence_id value, e.g. 91461158520-1771596000000)"`
+	ProjectUID    string   `json:"project_uid,omitempty" jsonschema:"Filter participants by project UID (ignored when past_meeting_id is set)"`
+	Name          string   `json:"name,omitempty" jsonschema:"Name or partial name of the participant to search for"`
+	Filters       []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort          string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
+	PageSize      int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken     string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // GetPastMeetingParticipantArgs defines the input parameters for the get_past_meeting_participant tool.
@@ -282,12 +283,13 @@ type GetPastMeetingParticipantArgs struct {
 
 // SearchPastMeetingSummariesArgs defines the input parameters for the search_past_meeting_summaries tool.
 type SearchPastMeetingSummariesArgs struct {
-	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter summaries by meeting ID"`
-	Name      string   `json:"name,omitempty" jsonschema:"Name or partial name of the summary to search for"`
-	Filters   []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
-	PageSize  int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
-	PageToken string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+	PastMeetingID string   `json:"past_meeting_id,omitempty" jsonschema:"Filter summaries by past meeting ID (the meeting_and_occurrence_id value, e.g. 91461158520-1771596000000)"`
+	ProjectUID    string   `json:"project_uid,omitempty" jsonschema:"Filter summaries by project UID (ignored when past_meeting_id is set)"`
+	Name          string   `json:"name,omitempty" jsonschema:"Name or partial name of the summary to search for"`
+	Filters       []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
+	Sort          string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
+	PageSize      int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken     string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // GetPastMeetingSummaryArgs defines the input parameters for the get_past_meeting_summary tool.
@@ -346,7 +348,7 @@ func handleSearchMeetings(ctx context.Context, req *mcp.CallToolRequest, args Se
 	}
 
 	// committee_uid takes precedence over project_uid when both are provided
-	// because committee resolves to a more specific parent reference.
+	// because committee resolves to a more specific filter.
 	if args.CommitteeUID != "" {
 		parentRef := "committee:" + args.CommitteeUID
 		payload.Parent = &parentRef
@@ -560,8 +562,8 @@ func handleSearchMeetingRegistrants(ctx context.Context, req *mcp.CallToolReques
 		Sort:     sort,
 	}
 
-	// meeting_id takes precedence over committee_uid because Parent can only be
-	// set once; prefer the more specific filter.
+	// meeting_id takes precedence over committee_uid because only one filter
+	// of this type can be set; prefer the more specific filter.
 	if args.MeetingID != "" {
 		parentRef := "meeting:" + args.MeetingID
 		payload.Parent = &parentRef
@@ -721,7 +723,123 @@ func handleGetMeetingRegistrant(ctx context.Context, req *mcp.CallToolRequest, a
 
 // handleSearchPastMeetingParticipants implements the search_past_meeting_participants tool logic.
 func handleSearchPastMeetingParticipants(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingParticipantsArgs) (*mcp.CallToolResult, any, error) {
-	return handleSearchPastMeetingResource(ctx, req, pastMeetingParticipantResourceType, "past meeting participants", args.MeetingID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
+	logger := newToolLogger(ctx, req)
+
+	if meetingConfig == nil {
+		logger.ErrorContext(ctx, "meeting tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: meeting tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = meetingConfig.Clients.WithMCPToken(ctx, mcpToken)
+	clients := meetingConfig.Clients
+
+	pageSize := args.PageSize
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	sort := args.Sort
+	if sort == "" {
+		sort = "name_asc"
+	}
+
+	resourceType := pastMeetingParticipantResourceType
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
+		PageSize: pageSize,
+		Sort:     sort,
+	}
+
+	// past_meeting_id takes precedence over project_uid; only one filter of this type can be set.
+	if args.PastMeetingID != "" {
+		parentRef := "past_meeting:" + args.PastMeetingID
+		payload.Parent = &parentRef
+	} else if args.ProjectUID != "" {
+		parentRef := "project:" + args.ProjectUID
+		payload.Parent = &parentRef
+	}
+
+	if args.Name != "" {
+		payload.Name = &args.Name
+	}
+
+	if len(args.Filters) > 0 {
+		payload.Filters = args.Filters
+	}
+
+	if args.PageToken != "" {
+		payload.PageToken = &args.PageToken
+	}
+
+	logger.InfoContext(ctx, "searching past meeting participants",
+		"past_meeting_id", args.PastMeetingID,
+		"project_uid", args.ProjectUID,
+		"name", args.Name,
+		"page_size", pageSize,
+	)
+
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
+	if err != nil {
+		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: friendlyAPIError("failed to search past meeting participants", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	type searchResult struct {
+		Resources []*querysvc.Resource `json:"resources"`
+		PageToken *string              `json:"page_token,omitempty"`
+	}
+
+	out := searchResult{
+		Resources: result.Resources,
+		PageToken: result.PageToken,
+	}
+
+	var pageWarning string
+	if result.PageToken != nil && len(result.Resources) < pageSize {
+		pageWarning = "WARNING: some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters"
+	}
+
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to marshal search result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.InfoContext(ctx, "search past meeting participants succeeded", "count", len(result.Resources))
+
+	content := []mcp.Content{}
+	if pageWarning != "" {
+		content = append(content, &mcp.TextContent{Text: pageWarning})
+	}
+	content = append(content, &mcp.TextContent{Text: string(prettyJSON)})
+	return &mcp.CallToolResult{Content: content}, nil, nil
 }
 
 // handleGetPastMeetingParticipant implements the get_past_meeting_participant tool logic.
@@ -731,7 +849,123 @@ func handleGetPastMeetingParticipant(ctx context.Context, req *mcp.CallToolReque
 
 // handleSearchPastMeetingSummaries implements the search_past_meeting_summaries tool logic.
 func handleSearchPastMeetingSummaries(ctx context.Context, req *mcp.CallToolRequest, args SearchPastMeetingSummariesArgs) (*mcp.CallToolResult, any, error) {
-	return handleSearchPastMeetingResource(ctx, req, pastMeetingSummaryResourceType, "past meeting summaries", args.MeetingID, args.Name, args.Filters, args.Sort, args.PageSize, args.PageToken)
+	logger := newToolLogger(ctx, req)
+
+	if meetingConfig == nil {
+		logger.ErrorContext(ctx, "meeting tools not configured")
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "Error: meeting tools not configured"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to extract MCP token", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	ctx = meetingConfig.Clients.WithMCPToken(ctx, mcpToken)
+	clients := meetingConfig.Clients
+
+	pageSize := args.PageSize
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	sort := args.Sort
+	if sort == "" {
+		sort = "name_asc"
+	}
+
+	resourceType := pastMeetingSummaryResourceType
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
+		PageSize: pageSize,
+		Sort:     sort,
+	}
+
+	// past_meeting_id takes precedence over project_uid; only one filter of this type can be set.
+	if args.PastMeetingID != "" {
+		parentRef := "past_meeting:" + args.PastMeetingID
+		payload.Parent = &parentRef
+	} else if args.ProjectUID != "" {
+		parentRef := "project:" + args.ProjectUID
+		payload.Parent = &parentRef
+	}
+
+	if args.Name != "" {
+		payload.Name = &args.Name
+	}
+
+	if len(args.Filters) > 0 {
+		payload.Filters = args.Filters
+	}
+
+	if args.PageToken != "" {
+		payload.PageToken = &args.PageToken
+	}
+
+	logger.InfoContext(ctx, "searching past meeting summaries",
+		"past_meeting_id", args.PastMeetingID,
+		"project_uid", args.ProjectUID,
+		"name", args.Name,
+		"page_size", pageSize,
+	)
+
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
+	if err != nil {
+		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: friendlyAPIError("failed to search past meeting summaries", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	type searchResult struct {
+		Resources []*querysvc.Resource `json:"resources"`
+		PageToken *string              `json:"page_token,omitempty"`
+	}
+
+	out := searchResult{
+		Resources: result.Resources,
+		PageToken: result.PageToken,
+	}
+
+	var pageWarning string
+	if result.PageToken != nil && len(result.Resources) < pageSize {
+		pageWarning = "WARNING: some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters"
+	}
+
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to marshal search result", "error", err)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	logger.InfoContext(ctx, "search past meeting summaries succeeded", "past_meeting_id", args.PastMeetingID, "project_uid", args.ProjectUID, "count", len(result.Resources))
+
+	content := []mcp.Content{}
+	if pageWarning != "" {
+		content = append(content, &mcp.TextContent{Text: pageWarning})
+	}
+	content = append(content, &mcp.TextContent{Text: string(prettyJSON)})
+	return &mcp.CallToolResult{Content: content}, nil, nil
 }
 
 // handleGetPastMeetingSummary implements the get_past_meeting_summary tool logic.

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -213,7 +213,6 @@ type SearchMeetingsArgs struct {
 	DateField    string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set)"`
 	DateFrom     string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
 	DateTo       string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
-	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. visibility:public or status:active)"`
 	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -227,7 +226,6 @@ type SearchMeetingsGroupArgs struct {
 	DateField  string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set)"`
 	DateFrom   string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
 	DateTo     string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
-	Filters    []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. visibility:public or status:active)"`
 	Sort       string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
 	PageSize   int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken  string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -243,7 +241,6 @@ type SearchMeetingRegistrantsArgs struct {
 	MeetingID    string   `json:"meeting_id,omitempty" jsonschema:"Filter registrants by meeting ID"`
 	CommitteeUID string   `json:"committee_uid,omitempty" jsonschema:"Filter registrants by committee UID (ignored when meeting_id is set)"`
 	Name         string   `json:"name,omitempty" jsonschema:"Name or partial name of the registrant to search for"`
-	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. host:true or type:committee)"`
 	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -254,7 +251,6 @@ type SearchMeetingRegistrantsGroupArgs struct {
 	MeetingID string   `json:"meeting_id,omitempty" jsonschema:"Filter registrants by meeting ID"`
 	GroupUID  string   `json:"group_uid,omitempty" jsonschema:"Filter registrants by group UID (also known as committee UID; ignored when meeting_id is set)"`
 	Name      string   `json:"name,omitempty" jsonschema:"Name or partial name of the registrant to search for"`
-	Filters   []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters (e.g. host:true or type:committee)"`
 	Sort      string   `json:"sort,omitempty" jsonschema:"Sort order for results (default name_asc),enum=name_asc,enum=name_desc,enum=updated_asc,enum=updated_desc"`
 	PageSize  int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -270,7 +266,6 @@ type SearchPastMeetingParticipantsArgs struct {
 	PastMeetingID string   `json:"past_meeting_id,omitempty" jsonschema:"Filter participants by past meeting ID (the meeting_and_occurrence_id value, e.g. 91461158520-1771596000000)"`
 	ProjectUID    string   `json:"project_uid,omitempty" jsonschema:"Filter participants by project UID (ignored when past_meeting_id is set)"`
 	Name          string   `json:"name,omitempty" jsonschema:"Name or partial name of the participant to search for"`
-	Filters       []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
 	Sort          string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize      int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken     string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -286,7 +281,6 @@ type SearchPastMeetingSummariesArgs struct {
 	PastMeetingID string   `json:"past_meeting_id,omitempty" jsonschema:"Filter summaries by past meeting ID (the meeting_and_occurrence_id value, e.g. 91461158520-1771596000000)"`
 	ProjectUID    string   `json:"project_uid,omitempty" jsonschema:"Filter summaries by project UID (ignored when past_meeting_id is set)"`
 	Name          string   `json:"name,omitempty" jsonschema:"Name or partial name of the summary to search for"`
-	Filters       []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
 	Sort          string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize      int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken     string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
@@ -369,10 +363,6 @@ func handleSearchMeetings(ctx context.Context, req *mcp.CallToolRequest, args Se
 		if args.DateTo != "" {
 			payload.DateTo = &args.DateTo
 		}
-	}
-
-	if len(args.Filters) > 0 {
-		payload.Filters = args.Filters
 	}
 
 	if args.PageToken != "" {
@@ -576,10 +566,6 @@ func handleSearchMeetingRegistrants(ctx context.Context, req *mcp.CallToolReques
 		payload.Name = &args.Name
 	}
 
-	if len(args.Filters) > 0 {
-		payload.Filters = args.Filters
-	}
-
 	if args.PageToken != "" {
 		payload.PageToken = &args.PageToken
 	}
@@ -780,10 +766,6 @@ func handleSearchPastMeetingParticipants(ctx context.Context, req *mcp.CallToolR
 		payload.Name = &args.Name
 	}
 
-	if len(args.Filters) > 0 {
-		payload.Filters = args.Filters
-	}
-
 	if args.PageToken != "" {
 		payload.PageToken = &args.PageToken
 	}
@@ -906,10 +888,6 @@ func handleSearchPastMeetingSummaries(ctx context.Context, req *mcp.CallToolRequ
 		payload.Name = &args.Name
 	}
 
-	if len(args.Filters) > 0 {
-		payload.Filters = args.Filters
-	}
-
 	if args.PageToken != "" {
 		payload.PageToken = &args.PageToken
 	}
@@ -971,118 +949,6 @@ func handleSearchPastMeetingSummaries(ctx context.Context, req *mcp.CallToolRequ
 // handleGetPastMeetingSummary implements the get_past_meeting_summary tool logic.
 func handleGetPastMeetingSummary(ctx context.Context, req *mcp.CallToolRequest, args GetPastMeetingSummaryArgs) (*mcp.CallToolResult, any, error) {
 	return handleGetPastMeetingResource(ctx, req, pastMeetingSummaryResourceType, "past meeting summary", args.UID)
-}
-
-// handleSearchPastMeetingResource is a shared implementation for searching past meeting resource types.
-func handleSearchPastMeetingResource(ctx context.Context, req *mcp.CallToolRequest, resourceType, resourceLabel, meetingID, name string, filters []string, sort string, pageSize int, pageToken string) (*mcp.CallToolResult, any, error) {
-	logger := newToolLogger(ctx, req)
-
-	if meetingConfig == nil {
-		logger.ErrorContext(ctx, "meeting tools not configured")
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: meeting tools not configured"},
-			},
-			IsError: true,
-		}, nil, nil
-	}
-
-	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to extract MCP token", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
-			},
-			IsError: true,
-		}, nil, nil
-	}
-
-	ctx = meetingConfig.Clients.WithMCPToken(ctx, mcpToken)
-	clients := meetingConfig.Clients
-
-	if pageSize <= 0 {
-		pageSize = 10
-	}
-
-	if sort == "" {
-		sort = "name_asc"
-	}
-
-	payload := &querysvc.QueryResourcesPayload{
-		Version:  "1",
-		Type:     &resourceType,
-		PageSize: pageSize,
-		Sort:     sort,
-	}
-
-	var tags []string
-	if meetingID != "" {
-		tags = append(tags, fmt.Sprintf("meeting_id:%s", meetingID))
-	}
-	if len(tags) > 0 {
-		payload.Tags = tags
-	}
-
-	if name != "" {
-		payload.Name = &name
-	}
-
-	if len(filters) > 0 {
-		payload.Filters = filters
-	}
-
-	if pageToken != "" {
-		payload.PageToken = &pageToken
-	}
-
-	logger.InfoContext(ctx, "searching "+resourceLabel, "meeting_id", meetingID, "name", name, "page_size", pageSize)
-
-	result, err := clients.QuerySvc.QueryResources(ctx, payload)
-	if err != nil {
-		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: friendlyAPIError("failed to search "+resourceLabel, err)},
-			},
-			IsError: true,
-		}, nil, nil
-	}
-
-	type searchResult struct {
-		Resources []*querysvc.Resource `json:"resources"`
-		PageToken *string              `json:"page_token,omitempty"`
-	}
-
-	out := searchResult{
-		Resources: result.Resources,
-		PageToken: result.PageToken,
-	}
-
-	var pageWarning string
-	if result.PageToken != nil && len(result.Resources) < pageSize {
-		pageWarning = "WARNING: some results on this page were excluded because you do not have access to them; consider continuing with the next page token, increasing the page size, or narrowing your filters"
-	}
-
-	prettyJSON, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to marshal search result", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
-			},
-			IsError: true,
-		}, nil, nil
-	}
-
-	logger.InfoContext(ctx, "search "+resourceLabel+" succeeded", "count", len(result.Resources))
-
-	content := []mcp.Content{}
-	if pageWarning != "" {
-		content = append(content, &mcp.TextContent{Text: pageWarning})
-	}
-	content = append(content, &mcp.TextContent{Text: string(prettyJSON)})
-	return &mcp.CallToolResult{Content: content}, nil, nil
 }
 
 // handleGetPastMeetingResource is a shared implementation for getting a past meeting resource by UID.
@@ -1181,30 +1047,28 @@ type SearchPastMeetingsArgs struct {
 	DateField    string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set); also accepts end_time"`
 	DateFrom     string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
 	DateTo       string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
-	Filters      []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
 	Sort         string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
 	PageSize     int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
 	PageToken    string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
-// SearchPastMeetingsGroupArgs is the groups-mode variant of SearchPastMeetingsArgs.
-type SearchPastMeetingsGroupArgs struct {
-	Name       string   `json:"name,omitempty" jsonschema:"Name or partial name of the past meeting to search for"`
-	ProjectUID string   `json:"project_uid,omitempty" jsonschema:"Filter past meetings by project UID"`
-	GroupUID   string   `json:"group_uid,omitempty" jsonschema:"Filter past meetings by group UID (also known as committee UID)"`
-	MeetingID  string   `json:"meeting_id,omitempty" jsonschema:"Filter past meetings by meeting ID"`
-	DateField  string   `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set); also accepts end_time"`
-	DateFrom   string   `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
-	DateTo     string   `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
-	Filters    []string `json:"filters,omitempty" jsonschema:"Direct field:value term filters"`
-	Sort       string   `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
-	PageSize   int      `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
-	PageToken  string   `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
-}
-
 // GetPastMeetingArgs defines the input parameters for the get_past_meeting tool.
 type GetPastMeetingArgs struct {
 	UID string `json:"uid" jsonschema:"The UID of the past meeting to retrieve"`
+}
+
+// SearchPastMeetingsGroupArgs is the groups-mode variant of SearchPastMeetingsArgs.
+type SearchPastMeetingsGroupArgs struct {
+	Name       string `json:"name,omitempty" jsonschema:"Name or partial name of the past meeting to search for"`
+	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Filter past meetings by project UID"`
+	GroupUID   string `json:"group_uid,omitempty" jsonschema:"Filter past meetings by group UID (also known as committee UID)"`
+	MeetingID  string `json:"meeting_id,omitempty" jsonschema:"Filter past meetings by meeting ID"`
+	DateField  string `json:"date_field,omitempty" jsonschema:"Date field to filter on (default start_time when date_from or date_to is set); also accepts end_time"`
+	DateFrom   string `json:"date_from,omitempty" jsonschema:"Start date inclusive in ISO 8601 format (e.g. 2025-01-01)"`
+	DateTo     string `json:"date_to,omitempty" jsonschema:"End date inclusive in ISO 8601 format (e.g. 2025-12-31)"`
+	Sort       string `json:"sort,omitempty" jsonschema:"Sort order: name_asc (default), name_desc, updated_asc, updated_desc"`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
+	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
 }
 
 // handleSearchMeetingsGroupMode adapts group-mode args to the meetings handler.
@@ -1216,7 +1080,6 @@ func handleSearchMeetingsGroupMode(ctx context.Context, req *mcp.CallToolRequest
 		DateField:    args.DateField,
 		DateFrom:     args.DateFrom,
 		DateTo:       args.DateTo,
-		Filters:      args.Filters,
 		Sort:         args.Sort,
 		PageSize:     args.PageSize,
 		PageToken:    args.PageToken,
@@ -1229,7 +1092,6 @@ func handleSearchMeetingRegistrantsGroupMode(ctx context.Context, req *mcp.CallT
 		MeetingID:    args.MeetingID,
 		CommitteeUID: args.GroupUID,
 		Name:         args.Name,
-		Filters:      args.Filters,
 		Sort:         args.Sort,
 		PageSize:     args.PageSize,
 		PageToken:    args.PageToken,
@@ -1246,7 +1108,6 @@ func handleSearchPastMeetingsGroupMode(ctx context.Context, req *mcp.CallToolReq
 		DateField:    args.DateField,
 		DateFrom:     args.DateFrom,
 		DateTo:       args.DateTo,
-		Filters:      args.Filters,
 		Sort:         args.Sort,
 		PageSize:     args.PageSize,
 		PageToken:    args.PageToken,
@@ -1332,10 +1193,6 @@ func handleSearchPastMeetings(ctx context.Context, req *mcp.CallToolRequest, arg
 		if args.DateTo != "" {
 			payload.DateTo = &args.DateTo
 		}
-	}
-
-	if len(args.Filters) > 0 {
-		payload.Filters = args.Filters
 	}
 
 	if args.PageToken != "" {


### PR DESCRIPTION
## Summary

### Remove generic `filters` param (`internal/tools/meeting.go`)

- Removes the `filters` parameter (direct `field:value` term filter pass-through) from all eight meeting search args structs (`SearchMeetingsArgs`, `SearchMeetingsGroupArgs`, `SearchMeetingRegistrantsArgs`, `SearchMeetingRegistrantsGroupArgs`, `SearchPastMeetingParticipantsArgs`, `SearchPastMeetingSummariesArgs`, `SearchPastMeetingsArgs`, `SearchPastMeetingsGroupArgs`) to reduce API surface area
- Removes all corresponding handler usages and the now-unused `handleSearchPastMeetingResource` shared helper (-157 lines net)

### Filter fixes (`internal/tools/meeting.go`)

- **`search_past_meeting_participants`**: replaced broken `meeting_id:` tag filter with the contract-defined `past_meeting:` parent_ref (using `past_meeting_id` = `meeting_and_occurrence_id`); added `project_uid` as a Parent fallback; gave the tool its own dedicated handler (`handleSearchPastMeetingParticipants`) so its filter logic is independent of summaries
- **`search_past_meeting_summaries`**: same fix — replaced `meeting_id:` tag with `past_meeting:` parent_ref; added `project_uid` as a Parent fallback; dedicated handler (`handleSearchPastMeetingSummaries`)
- Both tools now use `past_meeting_id` (not `meeting_id`) as the primary filter parameter, accepting the `meeting_and_occurrence_id` value (e.g. `91461158520-1771596000000`)
- Minor wording cleanup on existing `ignored when` / comment conventions in `meeting.go`

### Skill (`validate-search-filters`)

- Adds `.agents/skills/validate-search-filters/SKILL.md`, a repo-local agent skill encoding the process for validating MCP search tool filter parameters against the live OpenSearch `resources` index
- Skill tunnels `curl` queries through the NATS box pod via `kubectl exec` (no port-forward required)
- Dynamically discovers OpenSearch URL, index name, and pod name — no hardcoded values
- All index queries scoped to last 45 days to catch regressions in recently indexed data
- Produces a per-filter verdict table with Contract column (✅ works / ⚠️ broken / ❌ not indexed / ⚠️ no contract definition) and optionally applies fixes
- Includes all four indexer-contract URLs (meeting, project, committee, mailing-list services)

Motivated by the filter bugs documented in ARCH-393. Closes ARCH-394.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)