### PR TITLE
feat(tools): add outputSchema and structuredContent via typed handler Out parameters

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -183,7 +183,7 @@ sequenceDiagram
     MCP->>Auth0: token exchange (RFC 8693)<br />M2M client assertion + {mcp_jwt}
     Auth0-->>MCP: CTE token (carries user identity, cached)
 
-    MCP->>LFX: GET /committees?projectID={uuid}<br />Authorization: Bearer {cte_token}
+    MCP->>LFX: GET /committees/{uuid}<br />Authorization: Bearer {cte_token}
     LFX->>LFX: verify token + OpenFGA authz<br />(natively, no MCP involvement)
     LFX-->>MCP: committee data
     MCP-->>Client: tool result
@@ -216,7 +216,7 @@ sequenceDiagram
     Note over MCP: query_lfx_lens registered only when<br />read scope (read:all or manage:all) AND lf_staff=true
     MCP-->>Client: tools/list (includes query_lfx_lens)
 
-    User->>Client: invoke query_lfx_lens (slug="tlf")
+    User->>Client: invoke query_lfx_lens (project_slug="tlf")
     Client->>MCP: tools/call {query_lfx_lens}<br />Authorization: Bearer {mcp_jwt}
 
     Note over MCP: lf_staff=true already verified at registration
@@ -256,7 +256,7 @@ sequenceDiagram
     MCP->>MCP: verify signature, expiry, audience<br />extract scopes
     MCP-->>Client: tools/list (filtered to caller's scopes)
 
-    User->>Client: invoke send_email (slug="tlf", ...)
+    User->>Client: invoke send_email (project_slug="tlf", ...)
     Client->>MCP: tools/call {send_email}<br />Authorization: Bearer {mcp_jwt}
 
     MCP->>Auth0: token exchange (RFC 8693)<br />M2M client assertion + {mcp_jwt}

--- a/internal/tools/b2b_org.go
+++ b/internal/tools/b2b_org.go
@@ -101,6 +101,18 @@ func toB2bOrgMembershipView(m *memberservice.ProjectMembershipResponse) b2bOrgMe
 	}
 }
 
+// b2bOrgSearchResult is the output type for the search_b2b_orgs tool.
+type b2bOrgSearchResult struct {
+	Orgs     []b2bOrgView                `json:"orgs"`
+	Metadata *memberservice.ListMetadata `json:"metadata,omitempty"`
+}
+
+// b2bOrgMembershipListResult is the output type for the list_b2b_org_memberships tool.
+type b2bOrgMembershipListResult struct {
+	Memberships []b2bOrgMembershipView      `json:"memberships"`
+	Metadata    *memberservice.ListMetadata `json:"metadata,omitempty"`
+}
+
 // toB2bOrgView converts a B2bOrgResponse to the MCP view.
 func toB2bOrgView(o *memberservice.B2bOrgResponse) b2bOrgView {
 	return b2bOrgView{
@@ -140,7 +152,7 @@ func RegisterListB2bOrgMemberships(server *mcp.Server) {
 }
 
 // handleSearchB2bOrgs implements the search_b2b_orgs tool logic.
-func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args SearchB2bOrgsArgs) (*mcp.CallToolResult, any, error) {
+func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args SearchB2bOrgsArgs) (*mcp.CallToolResult, b2bOrgSearchResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -150,7 +162,7 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: "Error: member tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgSearchResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -161,7 +173,7 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgSearchResult{}, nil
 	}
 
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -198,7 +210,7 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: friendlyAPIError("failed to search B2B orgs", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgSearchResult{}, nil
 	}
 
 	views := make([]b2bOrgView, 0, len(result.Orgs))
@@ -206,11 +218,7 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		views = append(views, toB2bOrgView(o))
 	}
 
-	type searchResult struct {
-		Orgs     []b2bOrgView                `json:"orgs"`
-		Metadata *memberservice.ListMetadata `json:"metadata,omitempty"`
-	}
-	output := searchResult{
+	output := b2bOrgSearchResult{
 		Orgs:     views,
 		Metadata: result.Metadata,
 	}
@@ -223,7 +231,7 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgSearchResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "search_b2b_orgs succeeded", "count", len(result.Orgs))
@@ -232,11 +240,11 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, output, nil
 }
 
 // handleListB2bOrgMemberships implements the list_b2b_org_memberships tool logic.
-func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, args ListB2bOrgMembershipsArgs) (*mcp.CallToolResult, any, error) {
+func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, args ListB2bOrgMembershipsArgs) (*mcp.CallToolResult, b2bOrgMembershipListResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -246,7 +254,7 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 				&mcp.TextContent{Text: "Error: member tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgMembershipListResult{}, nil
 	}
 
 	if args.B2bOrgUID == "" {
@@ -255,7 +263,7 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 				&mcp.TextContent{Text: "Error: b2b_org_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgMembershipListResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -266,7 +274,7 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgMembershipListResult{}, nil
 	}
 
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -299,7 +307,7 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 				&mcp.TextContent{Text: friendlyAPIError("failed to list B2B org memberships", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgMembershipListResult{}, nil
 	}
 
 	views := make([]b2bOrgMembershipView, 0, len(result.Memberships))
@@ -319,11 +327,7 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 		}
 	}
 
-	type listResult struct {
-		Memberships []b2bOrgMembershipView      `json:"memberships"`
-		Metadata    *memberservice.ListMetadata `json:"metadata,omitempty"`
-	}
-	output := listResult{
+	output := b2bOrgMembershipListResult{
 		Memberships: views,
 		Metadata:    result.Metadata,
 	}
@@ -336,7 +340,7 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, b2bOrgMembershipListResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "list_b2b_org_memberships succeeded", "b2b_org_uid", args.B2bOrgUID, "count", len(result.Memberships))
@@ -346,5 +350,5 @@ func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, 
 		content = append(content, &mcp.TextContent{Text: onboardingWarning})
 	}
 	content = append(content, &mcp.TextContent{Text: string(prettyJSON)})
-	return &mcp.CallToolResult{Content: content}, nil, nil
+	return &mcp.CallToolResult{Content: content}, output, nil
 }

--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -30,6 +30,24 @@ type CommitteeConfig struct {
 
 var committeeConfig *CommitteeConfig
 
+// committeeSearchResult is the output type for search_committees / search_groups.
+type committeeSearchResult struct {
+	Resources []*querysvc.Resource `json:"resources"`
+	PageToken *string              `json:"page_token,omitempty"`
+}
+
+// committeeGetResult is the output type for get_committee / get_group.
+type committeeGetResult struct {
+	Base     *committeeservice.CommitteeBaseWithReadonlyAttributes     `json:"base"`
+	Settings *committeeservice.CommitteeSettingsWithReadonlyAttributes `json:"settings,omitempty"`
+}
+
+// committeeMemberSearchResult is the output type for search_committee_members / search_group_members.
+type committeeMemberSearchResult struct {
+	Resources []*querysvc.Resource `json:"resources"`
+	PageToken *string              `json:"page_token,omitempty"`
+}
+
 // SetCommitteeConfig sets the configuration for committee tools.
 func SetCommitteeConfig(cfg *CommitteeConfig) {
 	committeeConfig = cfg
@@ -192,17 +210,17 @@ type SearchGroupMembersArgs struct {
 }
 
 // handleSearchCommitteesGroupMode adapts group-mode args to the committee handler.
-func handleSearchCommitteesGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchGroupsArgs) (*mcp.CallToolResult, any, error) {
+func handleSearchCommitteesGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchGroupsArgs) (*mcp.CallToolResult, committeeSearchResult, error) {
 	return handleSearchCommittees(ctx, req, SearchCommitteesArgs(args))
 }
 
 // handleGetCommitteeGroupMode adapts group-mode args to the committee handler.
-func handleGetCommitteeGroupMode(ctx context.Context, req *mcp.CallToolRequest, args GetGroupArgs) (*mcp.CallToolResult, any, error) {
+func handleGetCommitteeGroupMode(ctx context.Context, req *mcp.CallToolRequest, args GetGroupArgs) (*mcp.CallToolResult, committeeGetResult, error) {
 	return handleGetCommittee(ctx, req, GetCommitteeArgs(args))
 }
 
 // handleGetCommitteeMemberGroupMode adapts group-mode args to the committee member handler.
-func handleGetCommitteeMemberGroupMode(ctx context.Context, req *mcp.CallToolRequest, args GetGroupMemberArgs) (*mcp.CallToolResult, any, error) {
+func handleGetCommitteeMemberGroupMode(ctx context.Context, req *mcp.CallToolRequest, args GetGroupMemberArgs) (*mcp.CallToolResult, *committeeservice.CommitteeMemberFullWithReadonlyAttributes, error) {
 	return handleGetCommitteeMember(ctx, req, GetCommitteeMemberArgs{
 		CommitteeUID: args.GroupUID,
 		MemberUID:    args.MemberUID,
@@ -210,7 +228,7 @@ func handleGetCommitteeMemberGroupMode(ctx context.Context, req *mcp.CallToolReq
 }
 
 // handleSearchCommitteeMembersGroupMode adapts group-mode args to the committee members handler.
-func handleSearchCommitteeMembersGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchGroupMembersArgs) (*mcp.CallToolResult, any, error) {
+func handleSearchCommitteeMembersGroupMode(ctx context.Context, req *mcp.CallToolRequest, args SearchGroupMembersArgs) (*mcp.CallToolResult, committeeMemberSearchResult, error) {
 	return handleSearchCommitteeMembers(ctx, req, SearchCommitteeMembersArgs{
 		CommitteeUID: args.GroupUID,
 		ProjectUID:   args.ProjectUID,
@@ -221,7 +239,7 @@ func handleSearchCommitteeMembersGroupMode(ctx context.Context, req *mcp.CallToo
 }
 
 // handleSearchCommittees implements the search_committees tool logic.
-func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args SearchCommitteesArgs) (*mcp.CallToolResult, any, error) {
+func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args SearchCommitteesArgs) (*mcp.CallToolResult, committeeSearchResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if committeeConfig == nil {
@@ -231,7 +249,7 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: "Error: committee tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeSearchResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -242,7 +260,7 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeSearchResult{}, nil
 	}
 
 	ctx = committeeConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -285,12 +303,7 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: friendlyAPIError("failed to search committees", err)},
 			},
 			IsError: true,
-		}, nil, nil
-	}
-
-	type searchResult struct {
-		Resources []*querysvc.Resource `json:"resources"`
-		PageToken *string              `json:"page_token,omitempty"`
+		}, committeeSearchResult{}, nil
 	}
 
 	// Strip the unreliable total_members field from indexed committee data. The
@@ -303,7 +316,7 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 		}
 	}
 
-	out := searchResult{
+	out := committeeSearchResult{
 		Resources: result.Resources,
 		PageToken: result.PageToken,
 	}
@@ -323,7 +336,7 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeSearchResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "search_committees succeeded", "count", len(result.Resources))
@@ -333,12 +346,12 @@ func handleSearchCommittees(ctx context.Context, req *mcp.CallToolRequest, args 
 		content = append(content, &mcp.TextContent{Text: pageWarning})
 	}
 	content = append(content, &mcp.TextContent{Text: string(prettyJSON)})
-	return &mcp.CallToolResult{Content: content}, nil, nil
+	return &mcp.CallToolResult{Content: content}, out, nil
 }
 
 // handleGetCommittee implements the get_committee tool logic, fetching both base
 // info and settings for the given committee UID.
-func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetCommitteeArgs) (*mcp.CallToolResult, any, error) {
+func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetCommitteeArgs) (*mcp.CallToolResult, committeeGetResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if committeeConfig == nil {
@@ -348,7 +361,7 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 				&mcp.TextContent{Text: "Error: committee tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeGetResult{}, nil
 	}
 
 	if args.UID == "" {
@@ -357,7 +370,7 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 				&mcp.TextContent{Text: "Error: uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeGetResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -368,7 +381,7 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeGetResult{}, nil
 	}
 
 	ctx = committeeConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -386,7 +399,7 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 				&mcp.TextContent{Text: friendlyAPIError("failed to get committee", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeGetResult{}, nil
 	}
 
 	// Settings may be unavailable due to insufficient permissions; treat that
@@ -412,12 +425,7 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 		baseResult.CommitteeBase.TotalMembers = nil
 	}
 
-	type committeeResult struct {
-		Base     *committeeservice.CommitteeBaseWithReadonlyAttributes     `json:"base"`
-		Settings *committeeservice.CommitteeSettingsWithReadonlyAttributes `json:"settings,omitempty"`
-	}
-
-	out := committeeResult{
+	out := committeeGetResult{
 		Base:     baseResult.CommitteeBase,
 		Settings: committeeSettings,
 	}
@@ -430,7 +438,7 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeGetResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "get_committee succeeded", "uid", args.UID)
@@ -443,11 +451,11 @@ func handleGetCommittee(ctx context.Context, req *mcp.CallToolRequest, args GetC
 
 	return &mcp.CallToolResult{
 		Content: content,
-	}, nil, nil
+	}, out, nil
 }
 
 // handleGetCommitteeMember implements the get_committee_member tool logic.
-func handleGetCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, args GetCommitteeMemberArgs) (*mcp.CallToolResult, any, error) {
+func handleGetCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, args GetCommitteeMemberArgs) (*mcp.CallToolResult, *committeeservice.CommitteeMemberFullWithReadonlyAttributes, error) {
 	logger := newToolLogger(ctx, req)
 
 	if committeeConfig == nil {
@@ -526,11 +534,11 @@ func handleGetCommitteeMember(ctx context.Context, req *mcp.CallToolRequest, arg
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, result.Member, nil
 }
 
 // handleSearchCommitteeMembers implements the search_committee_members tool logic.
-func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchCommitteeMembersArgs) (*mcp.CallToolResult, any, error) {
+func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchCommitteeMembersArgs) (*mcp.CallToolResult, committeeMemberSearchResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if committeeConfig == nil {
@@ -540,7 +548,7 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 				&mcp.TextContent{Text: "Error: committee tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeMemberSearchResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -551,7 +559,7 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeMemberSearchResult{}, nil
 	}
 
 	ctx = committeeConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -600,15 +608,10 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 				&mcp.TextContent{Text: friendlyAPIError("failed to search committee members", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeMemberSearchResult{}, nil
 	}
 
-	type searchResult struct {
-		Resources []*querysvc.Resource `json:"resources"`
-		PageToken *string              `json:"page_token,omitempty"`
-	}
-
-	out := searchResult{
+	out := committeeMemberSearchResult{
 		Resources: result.Resources,
 		PageToken: result.PageToken,
 	}
@@ -628,7 +631,7 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, committeeMemberSearchResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "search_committee_members succeeded", "committee_uid", args.CommitteeUID, "project_uid", args.ProjectUID, "count", len(result.Resources))
@@ -638,5 +641,5 @@ func handleSearchCommitteeMembers(ctx context.Context, req *mcp.CallToolRequest,
 		content = append(content, &mcp.TextContent{Text: pageWarning})
 	}
 	content = append(content, &mcp.TextContent{Text: string(prettyJSON)})
-	return &mcp.CallToolResult{Content: content}, nil, nil
+	return &mcp.CallToolResult{Content: content}, out, nil
 }

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -480,7 +480,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: "Error: member tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, []membershipTierView{}, nil
 	}
 
 	if args.ProjectUID == "" {
@@ -489,7 +489,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: "Error: project_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, []membershipTierView{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -500,7 +500,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, []membershipTierView{}, nil
 	}
 
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -520,7 +520,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: friendlyAPIError("failed to list project tiers", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, []membershipTierView{}, nil
 	}
 
 	tierViews := make([]membershipTierView, 0, len(result.Tiers))
@@ -536,7 +536,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, []membershipTierView{}, nil
 	}
 
 	logger.InfoContext(ctx, "list_project_tiers succeeded", "project_uid", args.ProjectUID, "count", len(result.Tiers))

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -133,6 +133,12 @@ type keyContactView struct {
 	UpdatedAt      *string `json:"updated_at,omitempty"`
 }
 
+// memberSearchResult is the output type for the search_members tool.
+type memberSearchResult struct {
+	Memberships []membershipView            `json:"memberships"`
+	Metadata    *memberservice.ListMetadata `json:"metadata,omitempty"`
+}
+
 // toMembershipTierView converts a MembershipTierResponse to the filtered MCP
 // view, dropping redundant fields.
 func toMembershipTierView(t *memberservice.MembershipTierResponse) membershipTierView {
@@ -268,7 +274,7 @@ func RegisterGetMembershipKeyContact(server *mcp.Server) {
 }
 
 // handleSearchMembers implements the search_members tool logic.
-func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchMembersArgs) (*mcp.CallToolResult, any, error) {
+func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchMembersArgs) (*mcp.CallToolResult, memberSearchResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -278,7 +284,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: "Error: member tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, memberSearchResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -289,7 +295,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, memberSearchResult{}, nil
 	}
 
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -301,7 +307,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: "Error: project_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, memberSearchResult{}, nil
 	}
 
 	pageSize := args.PageSize
@@ -346,7 +352,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: friendlyAPIError("failed to search members", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, memberSearchResult{}, nil
 	}
 
 	views := make([]membershipView, 0, len(result.Memberships))
@@ -354,11 +360,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		views = append(views, toMembershipView(m))
 	}
 
-	type searchResult struct {
-		Memberships []membershipView            `json:"memberships"`
-		Metadata    *memberservice.ListMetadata `json:"metadata,omitempty"`
-	}
-	filtered := searchResult{
+	filtered := memberSearchResult{
 		Memberships: views,
 		Metadata:    result.Metadata,
 	}
@@ -371,7 +373,7 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, memberSearchResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "search_members succeeded", "count", len(result.Memberships))
@@ -380,11 +382,11 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, filtered, nil
 }
 
 // handleGetMemberMembership implements the get_member_membership tool logic.
-func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, args GetMemberMembershipArgs) (*mcp.CallToolResult, any, error) {
+func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, args GetMemberMembershipArgs) (*mcp.CallToolResult, *memberservice.ProjectMembershipResponse, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -464,11 +466,11 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, result.Membership, nil
 }
 
 // handleListProjectTiers implements the list_project_tiers tool logic.
-func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args ListProjectTiersArgs) (*mcp.CallToolResult, any, error) {
+func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args ListProjectTiersArgs) (*mcp.CallToolResult, []membershipTierView, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -543,11 +545,11 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, tierViews, nil
 }
 
 // handleGetProjectTier implements the get_project_tier tool logic.
-func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args GetProjectTierArgs) (*mcp.CallToolResult, any, error) {
+func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args GetProjectTierArgs) (*mcp.CallToolResult, membershipTierView, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -557,7 +559,7 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 				&mcp.TextContent{Text: "Error: member tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, membershipTierView{}, nil
 	}
 
 	if args.ProjectUID == "" {
@@ -566,7 +568,7 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 				&mcp.TextContent{Text: "Error: project_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, membershipTierView{}, nil
 	}
 
 	if args.TierUID == "" {
@@ -575,7 +577,7 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 				&mcp.TextContent{Text: "Error: tier_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, membershipTierView{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -586,7 +588,7 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, membershipTierView{}, nil
 	}
 
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -607,10 +609,12 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 				&mcp.TextContent{Text: friendlyAPIError("failed to get project tier", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, membershipTierView{}, nil
 	}
 
-	prettyJSON, err := json.MarshalIndent(result.Tier, "", "  ")
+	tierView := toMembershipTierView(result.Tier)
+
+	prettyJSON, err := json.MarshalIndent(tierView, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal tier result", "error", err)
 		return &mcp.CallToolResult{
@@ -618,7 +622,7 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, membershipTierView{}, nil
 	}
 
 	logger.InfoContext(ctx, "get_project_tier succeeded", "project_uid", args.ProjectUID, "tier_uid", args.TierUID)
@@ -627,11 +631,11 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, tierView, nil
 }
 
 // handleGetMembershipKeyContacts implements the get_membership_key_contacts tool logic.
-func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactsArgs) (*mcp.CallToolResult, any, error) {
+func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactsArgs) (*mcp.CallToolResult, []keyContactView, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -716,11 +720,11 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, contactViews, nil
 }
 
 // handleGetMembershipKeyContact implements the get_membership_key_contact tool logic.
-func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactArgs) (*mcp.CallToolResult, any, error) {
+func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactArgs) (*mcp.CallToolResult, keyContactView, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -730,7 +734,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 				&mcp.TextContent{Text: "Error: member tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactView{}, nil
 	}
 
 	if args.ProjectUID == "" {
@@ -739,7 +743,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 				&mcp.TextContent{Text: "Error: project_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactView{}, nil
 	}
 
 	if args.MembershipUID == "" {
@@ -748,7 +752,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 				&mcp.TextContent{Text: "Error: membership_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactView{}, nil
 	}
 
 	if args.ContactUID == "" {
@@ -757,7 +761,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 				&mcp.TextContent{Text: "Error: contact_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactView{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -768,7 +772,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactView{}, nil
 	}
 
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -790,10 +794,12 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 				&mcp.TextContent{Text: friendlyAPIError("failed to get membership key contact", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactView{}, nil
 	}
 
-	prettyJSON, err := json.MarshalIndent(toKeyContactView(result.Contact), "", "  ")
+	contactView := toKeyContactView(result.Contact)
+
+	prettyJSON, err := json.MarshalIndent(contactView, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal key contact result", "error", err)
 		return &mcp.CallToolResult{
@@ -801,7 +807,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactView{}, nil
 	}
 
 	logger.InfoContext(ctx, "get_membership_key_contact succeeded", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
@@ -810,5 +816,5 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, contactView, nil
 }

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -139,6 +139,18 @@ type memberSearchResult struct {
 	Metadata    *memberservice.ListMetadata `json:"metadata,omitempty"`
 }
 
+// membershipTierListResult wraps a slice of tiers as an object root so the
+// MCP outputSchema and structuredContent are always JSON objects.
+type membershipTierListResult struct {
+	Tiers []membershipTierView `json:"tiers"`
+}
+
+// keyContactListResult wraps a slice of key contacts as an object root so the
+// MCP outputSchema and structuredContent are always JSON objects.
+type keyContactListResult struct {
+	Contacts []keyContactView `json:"contacts"`
+}
+
 // toMembershipTierView converts a MembershipTierResponse to the filtered MCP
 // view, dropping redundant fields.
 func toMembershipTierView(t *memberservice.MembershipTierResponse) membershipTierView {
@@ -470,7 +482,7 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 }
 
 // handleListProjectTiers implements the list_project_tiers tool logic.
-func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args ListProjectTiersArgs) (*mcp.CallToolResult, []membershipTierView, error) {
+func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args ListProjectTiersArgs) (*mcp.CallToolResult, membershipTierListResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -480,7 +492,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: "Error: member tools not configured"},
 			},
 			IsError: true,
-		}, []membershipTierView{}, nil
+		}, membershipTierListResult{}, nil
 	}
 
 	if args.ProjectUID == "" {
@@ -489,7 +501,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: "Error: project_uid is required"},
 			},
 			IsError: true,
-		}, []membershipTierView{}, nil
+		}, membershipTierListResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -500,7 +512,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, []membershipTierView{}, nil
+		}, membershipTierListResult{}, nil
 	}
 
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -520,15 +532,17 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: friendlyAPIError("failed to list project tiers", err)},
 			},
 			IsError: true,
-		}, []membershipTierView{}, nil
+		}, membershipTierListResult{}, nil
 	}
 
-	tierViews := make([]membershipTierView, 0, len(result.Tiers))
+	out := membershipTierListResult{
+		Tiers: make([]membershipTierView, 0, len(result.Tiers)),
+	}
 	for _, t := range result.Tiers {
-		tierViews = append(tierViews, toMembershipTierView(t))
+		out.Tiers = append(out.Tiers, toMembershipTierView(t))
 	}
 
-	prettyJSON, err := json.MarshalIndent(tierViews, "", "  ")
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal tiers result", "error", err)
 		return &mcp.CallToolResult{
@@ -536,7 +550,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, []membershipTierView{}, nil
+		}, membershipTierListResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "list_project_tiers succeeded", "project_uid", args.ProjectUID, "count", len(result.Tiers))
@@ -545,7 +559,7 @@ func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args 
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, tierViews, nil
+	}, out, nil
 }
 
 // handleGetProjectTier implements the get_project_tier tool logic.
@@ -635,7 +649,7 @@ func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args Ge
 }
 
 // handleGetMembershipKeyContacts implements the get_membership_key_contacts tool logic.
-func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactsArgs) (*mcp.CallToolResult, []keyContactView, error) {
+func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactsArgs) (*mcp.CallToolResult, keyContactListResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if memberConfig == nil {
@@ -645,7 +659,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 				&mcp.TextContent{Text: "Error: member tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactListResult{}, nil
 	}
 
 	if args.ProjectUID == "" {
@@ -654,7 +668,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 				&mcp.TextContent{Text: "Error: project_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactListResult{}, nil
 	}
 
 	if args.MembershipUID == "" {
@@ -663,7 +677,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 				&mcp.TextContent{Text: "Error: membership_uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactListResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -674,7 +688,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactListResult{}, nil
 	}
 
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -695,15 +709,17 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 				&mcp.TextContent{Text: friendlyAPIError("failed to get membership key contacts", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactListResult{}, nil
 	}
 
-	contactViews := make([]keyContactView, 0, len(result.Contacts))
+	out := keyContactListResult{
+		Contacts: make([]keyContactView, 0, len(result.Contacts)),
+	}
 	for _, c := range result.Contacts {
-		contactViews = append(contactViews, toKeyContactView(c))
+		out.Contacts = append(out.Contacts, toKeyContactView(c))
 	}
 
-	prettyJSON, err := json.MarshalIndent(contactViews, "", "  ")
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal membership key contacts result", "error", err)
 		return &mcp.CallToolResult{
@@ -711,7 +727,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, keyContactListResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "get_membership_key_contacts succeeded", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
@@ -720,7 +736,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, contactViews, nil
+	}, out, nil
 }
 
 // handleGetMembershipKeyContact implements the get_membership_key_contact tool logic.

--- a/internal/tools/project.go
+++ b/internal/tools/project.go
@@ -32,6 +32,18 @@ func SetProjectConfig(cfg *ProjectConfig) {
 	projectConfig = cfg
 }
 
+// projectSearchResult is the output type for the search_projects tool.
+type projectSearchResult struct {
+	Resources []*querysvc.Resource `json:"resources"`
+	PageToken *string              `json:"page_token,omitempty"`
+}
+
+// projectGetResult is the output type for the get_project tool.
+type projectGetResult struct {
+	Base     *projectservice.ProjectBase     `json:"base"`
+	Settings *projectservice.ProjectSettings `json:"settings,omitempty"`
+}
+
 // RegisterSearchProjects registers the search_projects tool with the MCP server.
 func RegisterSearchProjects(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
@@ -70,7 +82,7 @@ type GetProjectArgs struct {
 }
 
 // handleSearchProjects implements the search_projects tool logic.
-func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args SearchProjectsArgs) (*mcp.CallToolResult, any, error) {
+func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args SearchProjectsArgs) (*mcp.CallToolResult, projectSearchResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if projectConfig == nil {
@@ -80,7 +92,7 @@ func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args Se
 				&mcp.TextContent{Text: "Error: project tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectSearchResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -91,7 +103,7 @@ func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args Se
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectSearchResult{}, nil
 	}
 
 	ctx = projectConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -134,15 +146,10 @@ func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args Se
 				&mcp.TextContent{Text: friendlyAPIError("failed to search projects", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectSearchResult{}, nil
 	}
 
-	type searchResult struct {
-		Resources []*querysvc.Resource `json:"resources"`
-		PageToken *string              `json:"page_token,omitempty"`
-	}
-
-	out := searchResult{
+	out := projectSearchResult{
 		Resources: result.Resources,
 		PageToken: result.PageToken,
 	}
@@ -155,7 +162,7 @@ func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args Se
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectSearchResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "search_projects succeeded", "count", len(result.Resources))
@@ -164,12 +171,12 @@ func handleSearchProjects(ctx context.Context, req *mcp.CallToolRequest, args Se
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, nil, nil
+	}, out, nil
 }
 
 // handleGetProject implements the get_project tool logic, fetching both base
 // info and settings for the given project UID.
-func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetProjectArgs) (*mcp.CallToolResult, any, error) {
+func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetProjectArgs) (*mcp.CallToolResult, projectGetResult, error) {
 	logger := newToolLogger(ctx, req)
 
 	if projectConfig == nil {
@@ -179,7 +186,7 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 				&mcp.TextContent{Text: "Error: project tools not configured"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectGetResult{}, nil
 	}
 
 	if args.UID == "" {
@@ -188,7 +195,7 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 				&mcp.TextContent{Text: "Error: uid is required"},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectGetResult{}, nil
 	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
@@ -199,7 +206,7 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectGetResult{}, nil
 	}
 
 	ctx = projectConfig.Clients.WithMCPToken(ctx, mcpToken)
@@ -217,7 +224,7 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 				&mcp.TextContent{Text: friendlyAPIError("failed to get project", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectGetResult{}, nil
 	}
 
 	// Settings may be unavailable (e.g. insufficient permissions, or a response
@@ -235,12 +242,7 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 		projectSettings = settingsResult.ProjectSettings
 	}
 
-	type projectResult struct {
-		Base     *projectservice.ProjectBase     `json:"base"`
-		Settings *projectservice.ProjectSettings `json:"settings,omitempty"`
-	}
-
-	out := projectResult{
+	out := projectGetResult{
 		Base:     baseResult.Project,
 		Settings: projectSettings,
 	}
@@ -253,7 +255,7 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
 			},
 			IsError: true,
-		}, nil, nil
+		}, projectGetResult{}, nil
 	}
 
 	logger.InfoContext(ctx, "get_project succeeded", "uid", args.UID)
@@ -266,5 +268,5 @@ func handleGetProject(ctx context.Context, req *mcp.CallToolRequest, args GetPro
 
 	return &mcp.CallToolResult{
 		Content: content,
-	}, nil, nil
+	}, out, nil
 }


### PR DESCRIPTION
## Summary

Promotes tool handler signatures from untyped `ToolHandlerFor[In, any]` to concrete output types so the MCP Go SDK automatically generates `Tool.OutputSchema` and populates `StructuredContent` on every successful response.

The existing `TextContent` fallback (pretty-printed JSON) is retained in the `Content` array so backward-compatible clients continue to receive a text response unchanged.

## Tools Updated

| Tool | Output Type |
|------|------------|
| `search_b2b_orgs` | `b2bOrgSearchResult` |
| `list_b2b_org_memberships` | `b2bOrgMembershipListResult` |
| `search_members` | `memberSearchResult` |
| `get_member_membership` | `*ProjectMembershipResponse` |
| `list_project_tiers` | `membershipTierListResult` |
| `get_project_tier` | `membershipTierView` |
| `get_membership_key_contacts` | `keyContactListResult` |
| `get_membership_key_contact` | `keyContactView` |
| `search_projects` | `projectSearchResult` |
| `get_project` | `projectGetResult` |
| `search_committees` / `search_groups` | `committeeSearchResult` |
| `get_committee` / `get_group` | `committeeGetResult` |
| `get_committee_member` / `get_group_member` | `*CommitteeMemberFullWithReadonlyAttributes` |
| `search_committee_members` / `search_group_members` | `committeeMemberSearchResult` |

## Skipped Tools

- `hello_world`, `user_info` — no stable structured schema
- `query_lfx_lens`, `query_lfx_semantic_layer` — freeform text output
- Write tools, email, discord — no structured output schema

## Behavioral Notes

- `get_project_tier` and `get_membership_key_contact` now marshal the filtered view type instead of the raw service response, aligning with the rest of the member tools and stripping internal fields.
- Inline anonymous structs lifted to named package-level types to satisfy the type parameter constraint.
- `list_project_tiers` and `get_membership_key_contacts` wrap their slice results in an object type to conform to the 2025-11-25 spec requirement that `outputSchema` have `type: "object"` at the root.

## Known Client Caveats

- **Claude Code**: Silently drops all tools from a server when any tool includes `outputSchema` in `tools/list`. Validate separately.
- **Claude Desktop** (Windows): May fail on complex `outputSchema` containing `$defs`/`$ref`. Our schemas are flat structs so this likely does not apply, but should be confirmed in Dev.
- **Claude.ai web + Claude Desktop**: Reported "Error occurred during tool execution" on every call when `outputSchema` is present. Validate that tool *calls* succeed, not just that tools appear in the list.
- **Cursor**: Validates `structuredContent` against `outputSchema`; returns `-32602` on mismatch.
- **MCP Inspector / Gemini CLI**: Full support.

## Testing

- `make check` passes
- Integration tests pass (`./scripts/test_server.sh`)
- Dev validation pending: confirm tools appear **and** tool calls succeed in both Claude Desktop and Claude Code

Jira: LFXV2-1996

---

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)