### PR TITLE
fix: adapt member tools to lfx-v2-member-service v0.8.0 rearchitecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Hitting **Connect** will open a browser window for LFID login.
 | Tool                              | Description                                                                     |
 |-----------------------------------|---------------------------------------------------------------------------------|
 | `search_members`                  | Search and filter members (memberships) by project, tier, status, or B2B organization        |
-| `get_member_membership`           | Get a single member's membership details by member and membership ID                         |
+| `get_member_membership`           | Get a single membership by membership UID                                                    |
 | `get_membership_key_contacts`     | Get key contacts (primary contacts, board members) for a membership             |
 | `get_membership_key_contact`      | Get a single key contact by project, membership, and contact UID                |
 | `create_membership_key_contact`   | Add a key contact to a membership                                               |
@@ -290,7 +290,7 @@ Hitting **Connect** will open a browser window for LFID login.
 
 | Tool                       | Description                                                   |
 |----------------------------|---------------------------------------------------------------|
-| `search_b2b_orgs`          | Search and list B2B organizations by name                     |
+| `search_b2b_orgs`          | Search B2B organizations by name or domain                    |
 
 ### Utility
 

--- a/README.md
+++ b/README.md
@@ -235,10 +235,8 @@ Hitting **Connect** will open a browser window for LFID login.
 
 | Tool                              | Description                                                                     |
 |-----------------------------------|---------------------------------------------------------------------------------|
-| `search_members`                  | Search and filter members (memberships) by status, tier, organization, and more |
-| `get_member_membership`           | Get a single member's membership details by member and membership ID            |
-| `list_project_tiers`              | List all membership tiers (e.g. Gold, Silver, Bronze) defined for a project     |
-| `get_project_tier`                | Get a single membership tier by project and tier UID                            |
+| `search_members`                  | Search and filter members (memberships) by project, tier, status, or B2B organization        |
+| `get_member_membership`           | Get a single member's membership details by member and membership ID                         |
 | `get_membership_key_contacts`     | Get key contacts (primary contacts, board members) for a membership             |
 | `get_membership_key_contact`      | Get a single key contact by project, membership, and contact UID                |
 | `create_membership_key_contact`   | Add a key contact to a membership                                               |
@@ -292,8 +290,7 @@ Hitting **Connect** will open a browser window for LFID login.
 
 | Tool                       | Description                                                   |
 |----------------------------|---------------------------------------------------------------|
-| `search_b2b_orgs`          | Search and list B2B organizations                             |
-| `list_b2b_org_memberships` | List all project memberships for a B2B organization           |
+| `search_b2b_orgs`          | Search and list B2B organizations by name                     |
 
 ### Utility
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Hitting **Connect** will open a browser window for LFID login.
 | `search_members`                  | Search and filter members (memberships) by project, tier, status, or B2B organization        |
 | `get_member_membership`           | Get a single membership by membership UID                                                    |
 | `get_membership_key_contacts`     | Get key contacts (primary contacts, board members) for a membership             |
-| `get_membership_key_contact`      | Get a single key contact by project, membership, and contact UID                |
+| `get_membership_key_contact`      | Get a single key contact by membership UID and contact UID                      |
 | `create_membership_key_contact`   | Add a key contact to a membership                                               |
 | `update_membership_key_contact`   | Update an existing key contact on a membership                                  |
 | `delete_membership_key_contact`   | Remove a key contact from a membership                                          |

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -134,8 +134,6 @@ var defaultTools = []string{
 	"get_mailing_list_member",
 	"search_mailing_lists",
 	"search_mailing_list_members",
-	"list_project_tiers",
-	"get_project_tier",
 	"search_members",
 	"get_member_membership",
 	"get_membership_key_contacts",
@@ -164,7 +162,6 @@ var defaultTools = []string{
 	"query_lfx_lens",
 	"query_lfx_semantic_layer",
 	"search_b2b_orgs",
-	"list_b2b_org_memberships",
 }
 
 var logger *slog.Logger
@@ -678,12 +675,6 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 	if enabledTools["search_mailing_list_members"] && canRead {
 		tools.RegisterSearchMailingListMembers(server)
 	}
-	if enabledTools["list_project_tiers"] && canRead {
-		tools.RegisterListProjectTiers(server)
-	}
-	if enabledTools["get_project_tier"] && canRead {
-		tools.RegisterGetProjectTier(server)
-	}
 	if enabledTools["search_members"] && canRead {
 		tools.RegisterSearchMembers(server)
 	}
@@ -737,9 +728,6 @@ func newServer(cfg Config, serviceName string, callerToken *auth.TokenInfo) *mcp
 	}
 	if enabledTools["search_b2b_orgs"] && canRead {
 		tools.RegisterSearchB2bOrgs(server)
-	}
-	if enabledTools["list_b2b_org_memberships"] && canRead {
-		tools.RegisterListB2bOrgMemberships(server)
 	}
 
 	// Service API tools.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/linuxfoundation/lfx-v2-committee-service v0.2.35
 	github.com/linuxfoundation/lfx-v2-mailing-list-service v0.4.13
-	github.com/linuxfoundation/lfx-v2-member-service v0.5.3
+	github.com/linuxfoundation/lfx-v2-member-service v0.8.0
 	github.com/linuxfoundation/lfx-v2-project-service v0.6.11
 	github.com/linuxfoundation/lfx-v2-query-service v0.4.21
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/linuxfoundation/lfx-v2-mailing-list-service v0.4.13 h1:5nNZI5mr1NquOt
 github.com/linuxfoundation/lfx-v2-mailing-list-service v0.4.13/go.mod h1:gz5bGYepAar5l7y61j5QV07z8n/jxhZKQBINF3oRFTQ=
 github.com/linuxfoundation/lfx-v2-member-service v0.5.3 h1:xotDUAs2oVpioTo6gosEdngGpgCSzncjWul0lFj7a6E=
 github.com/linuxfoundation/lfx-v2-member-service v0.5.3/go.mod h1:qMzCkX1KayvzmxZQhVL2+dX1jXHqU3CcRGZ/t41vbgs=
+github.com/linuxfoundation/lfx-v2-member-service v0.8.0 h1:b7JSXeRcgC7v5sjZ+n098arG5652tfufLqxcvodEhos=
+github.com/linuxfoundation/lfx-v2-member-service v0.8.0/go.mod h1:CTnF8JHXN/1+bFEbxcBMcFOdZj+CXxnKT/kJXbEX94E=
 github.com/linuxfoundation/lfx-v2-project-service v0.6.11 h1:ACr/XI/Io3PEWX4vJaHHTvEOhN+na4jp1kx3p4PYLsA=
 github.com/linuxfoundation/lfx-v2-project-service v0.6.11/go.mod h1:3ULEcvKwHWcBcMxSW3yeMPGqk5+tnu2X+FjcaAw9Fy4=
 github.com/linuxfoundation/lfx-v2-query-service v0.4.21 h1:FDoqt8oeC0Egbl3Z7BeqZ2XKcfm4BujFQ4mBSQd3KEs=

--- a/internal/lfxv2/client.go
+++ b/internal/lfxv2/client.go
@@ -273,7 +273,10 @@ func NewClients(_ context.Context, cfg ClientConfig) (*Clients, error) {
 	)
 
 	// Initialize member service client.
-	memberURL, err := url.Parse(cfg.APIDomain + "/members")
+	// The member service exposes root-level paths (/b2b_orgs/, /project_memberships/,
+	// /key_contacts/) with no path prefix, so use cfg.APIDomain directly — identical
+	// to how the project and committee clients are wired.
+	memberURL, err := url.Parse(cfg.APIDomain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse member service URL: %w", err)
 	}
@@ -288,17 +291,20 @@ func NewClients(_ context.Context, cfg ClientConfig) (*Clients, error) {
 	)
 
 	clients.Member = memberservice.NewClient(
-		memberHTTPClient.ListProjectTiers(),
-		memberHTTPClient.GetProjectTier(),
-		memberHTTPClient.ListProjectMemberships(),
+		memberHTTPClient.GetB2bOrg(),
+		memberHTTPClient.CreateB2bOrg(),
+		memberHTTPClient.UpdateB2bOrg(),
+		memberHTTPClient.GetB2bOrgSettings(),
+		memberHTTPClient.UpdateB2bOrgSettings(),
+		memberHTTPClient.AddB2bOrgSettingsUser(),
+		memberHTTPClient.UpdateB2bOrgSettingsUserRole(),
+		memberHTTPClient.DeleteB2bOrgSettingsUser(),
 		memberHTTPClient.GetProjectMembership(),
-		memberHTTPClient.ListMembershipKeyContacts(),
-		memberHTTPClient.CreateMembershipKeyContact(),
-		memberHTTPClient.UpdateMembershipKeyContact(),
-		memberHTTPClient.DeleteMembershipKeyContact(),
-		memberHTTPClient.GetMembershipKeyContact(),
-		memberHTTPClient.ListB2bOrgs(),
-		memberHTTPClient.ListB2bOrgMemberships(),
+		memberHTTPClient.GetKeyContact(),
+		memberHTTPClient.CreateKeyContact(),
+		memberHTTPClient.UpdateKeyContact(),
+		memberHTTPClient.DeleteKeyContact(),
+		memberHTTPClient.AdminReindex(),
 		memberHTTPClient.Readyz(),
 		memberHTTPClient.Livez(),
 		memberHTTPClient.DebugVars(),

--- a/internal/tools/b2b_org.go
+++ b/internal/tools/b2b_org.go
@@ -10,128 +10,28 @@ import (
 	"fmt"
 
 	"github.com/linuxfoundation/lfx-mcp/internal/lfxv2"
-	memberservice "github.com/linuxfoundation/lfx-v2-member-service/gen/membership_service"
+	querysvc "github.com/linuxfoundation/lfx-v2-query-service/gen/query_svc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // SearchB2bOrgsArgs defines the input parameters for the search_b2b_orgs tool.
 type SearchB2bOrgsArgs struct {
-	SearchName string `json:"search_name,omitempty" jsonschema:"Search B2B organizations by name (case-insensitive substring match)."`
-	Sort       string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
-	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 1000)"`
-	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
-}
-
-// ListB2bOrgMembershipsArgs defines the input parameters for the list_b2b_org_memberships tool.
-type ListB2bOrgMembershipsArgs struct {
-	B2bOrgUID string `json:"b2b_org_uid" jsonschema:"B2B organization UID (required)"`
-	Sort      string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
-	PageSize  int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 1000)"`
-	PageToken string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous list response"`
-}
-
-// b2bOrgView is a filtered view of B2bOrgResponse for MCP responses.
-type b2bOrgView struct {
-	UID           *string  `json:"uid,omitempty"`
-	Name          *string  `json:"name,omitempty"`
-	Website       *string  `json:"website,omitempty"`
-	PrimaryDomain *string  `json:"primary_domain,omitempty"`
-	DomainAliases []string `json:"domain_aliases,omitempty"`
-	LogoURL       *string  `json:"logo_url,omitempty"`
-	CreatedAt     *string  `json:"created_at,omitempty"`
-	UpdatedAt     *string  `json:"updated_at,omitempty"`
-}
-
-// b2bOrgMembershipView is a filtered view of ProjectMembershipResponse for
-// MCP responses from the list_b2b_org_memberships tool (org drill-down).
-// Omitted fields: b2b_org_uid (redundant input), company_name/logo/domain
-// (always the same org for every result), tier_family (always "Membership"),
-// tier_product_type (always null), and membership_type (raw Salesforce record
-// type ID). project_uid and project_slug are included because this is a
-// cross-project view and callers need to identify which project each
-// membership belongs to.
-type b2bOrgMembershipView struct {
-	UID              *string  `json:"uid,omitempty"`
-	TierUID          *string  `json:"tier_uid,omitempty"`
-	ProjectUID       *string  `json:"project_uid,omitempty"`
-	ProjectSlug      *string  `json:"project_slug,omitempty"`
-	Status           *string  `json:"status,omitempty"`
-	Year             *string  `json:"year,omitempty"`
-	Tier             *string  `json:"tier,omitempty"`
-	AutoRenew        *bool    `json:"auto_renew,omitempty"`
-	RenewalType      *string  `json:"renewal_type,omitempty"`
-	Price            *float64 `json:"price,omitempty"`
-	AnnualFullPrice  *float64 `json:"annual_full_price,omitempty"`
-	PaymentFrequency *string  `json:"payment_frequency,omitempty"`
-	PaymentTerms     *string  `json:"payment_terms,omitempty"`
-	AgreementDate    *string  `json:"agreement_date,omitempty"`
-	PurchaseDate     *string  `json:"purchase_date,omitempty"`
-	StartDate        *string  `json:"start_date,omitempty"`
-	EndDate          *string  `json:"end_date,omitempty"`
-	TierName         *string  `json:"tier_name,omitempty"`
-	CreatedAt        *string  `json:"created_at,omitempty"`
-	UpdatedAt        *string  `json:"updated_at,omitempty"`
-}
-
-// toB2bOrgMembershipView converts a ProjectMembershipResponse to the filtered
-// MCP view for list_b2b_org_memberships, dropping b2b_org_uid (redundant
-// input) and company fields (same org for every row in an org-scoped query).
-func toB2bOrgMembershipView(m *memberservice.ProjectMembershipResponse) b2bOrgMembershipView {
-	return b2bOrgMembershipView{
-		UID:              m.UID,
-		TierUID:          m.TierUID,
-		ProjectUID:       m.ProjectUID,
-		ProjectSlug:      m.ProjectSlug,
-		Status:           m.Status,
-		Year:             m.Year,
-		Tier:             m.Tier,
-		AutoRenew:        m.AutoRenew,
-		RenewalType:      m.RenewalType,
-		Price:            m.Price,
-		AnnualFullPrice:  m.AnnualFullPrice,
-		PaymentFrequency: m.PaymentFrequency,
-		PaymentTerms:     m.PaymentTerms,
-		AgreementDate:    m.AgreementDate,
-		PurchaseDate:     m.PurchaseDate,
-		StartDate:        m.StartDate,
-		EndDate:          m.EndDate,
-		TierName:         m.TierName,
-		CreatedAt:        m.CreatedAt,
-		UpdatedAt:        m.UpdatedAt,
-	}
+	SearchName string `json:"search_name,omitempty" jsonschema:"Search B2B organizations by name or domain (typeahead)."`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)."`
+	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response."`
 }
 
 // b2bOrgSearchResult is the output type for the search_b2b_orgs tool.
 type b2bOrgSearchResult struct {
-	Orgs     []b2bOrgView                `json:"orgs"`
-	Metadata *memberservice.ListMetadata `json:"metadata,omitempty"`
-}
-
-// b2bOrgMembershipListResult is the output type for the list_b2b_org_memberships tool.
-type b2bOrgMembershipListResult struct {
-	Memberships []b2bOrgMembershipView      `json:"memberships"`
-	Metadata    *memberservice.ListMetadata `json:"metadata,omitempty"`
-}
-
-// toB2bOrgView converts a B2bOrgResponse to the MCP view.
-func toB2bOrgView(o *memberservice.B2bOrgResponse) b2bOrgView {
-	return b2bOrgView{
-		UID:           o.UID,
-		Name:          o.Name,
-		Website:       o.Website,
-		PrimaryDomain: o.PrimaryDomain,
-		DomainAliases: o.DomainAliases,
-		LogoURL:       o.LogoURL,
-		CreatedAt:     o.CreatedAt,
-		UpdatedAt:     o.UpdatedAt,
-	}
+	Resources []*querysvc.Resource `json:"resources"`
+	PageToken *string              `json:"page_token,omitempty"`
 }
 
 // RegisterSearchB2bOrgs registers the search_b2b_orgs tool with the MCP server.
 func RegisterSearchB2bOrgs(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_b2b_orgs",
-		Description: "Search and list B2B organizations. Use this tool when users ask about B2B orgs, member companies, or organizations across LFX. Supports search_name for case-insensitive name substring search and sort order (newest, name, last_modified). Uses cursor-based pagination via page_token.",
+		Description: "Search and list B2B organizations. Use this tool when users ask about B2B orgs, member companies, or organizations across LFX. Supports search_name for name and domain typeahead. Uses cursor-based pagination via page_token.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search B2B Orgs",
 			ReadOnlyHint: true,
@@ -139,19 +39,7 @@ func RegisterSearchB2bOrgs(server *mcp.Server) {
 	}, handleSearchB2bOrgs)
 }
 
-// RegisterListB2bOrgMemberships registers the list_b2b_org_memberships tool with the MCP server.
-func RegisterListB2bOrgMemberships(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "list_b2b_org_memberships",
-		Description: "List all project memberships for a given B2B organization across all projects. Use this tool when users ask which projects or foundations a B2B org is a member of, or want to see all memberships for a company. Requires b2b_org_uid. Uses cursor-based pagination via page_token.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:        "List B2B Org Memberships",
-			ReadOnlyHint: true,
-		},
-	}, handleListB2bOrgMemberships)
-}
-
-// handleSearchB2bOrgs implements the search_b2b_orgs tool logic.
+// handleSearchB2bOrgs implements the search_b2b_orgs tool logic using the Query Service.
 func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args SearchB2bOrgsArgs) (*mcp.CallToolResult, b2bOrgSearchResult, error) {
 	logger := newToolLogger(ctx, req)
 
@@ -184,27 +72,26 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		pageSize = 10
 	}
 
-	payload := &memberservice.ListB2bOrgsPayload{
+	resourceType := b2bOrgResourceType
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
 		PageSize: pageSize,
-		Sort:     args.Sort,
+	}
+
+	if args.SearchName != "" {
+		payload.Name = &args.SearchName
 	}
 
 	if args.PageToken != "" {
 		payload.PageToken = &args.PageToken
 	}
 
-	if args.SearchName != "" {
-		payload.SearchName = &args.SearchName
-	}
-
-	version := "1"
-	payload.Version = &version
-
 	logger.InfoContext(ctx, "searching B2B orgs", "search_name", args.SearchName, "page_size", pageSize, "page_token", args.PageToken)
 
-	result, err := clients.Member.ListB2bOrgs(ctx, payload)
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {
-		logger.ErrorContext(ctx, "ListB2bOrgs failed", "error", err)
+		logger.ErrorContext(ctx, "QueryResources (b2b_org) failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: friendlyAPIError("failed to search B2B orgs", err)},
@@ -213,17 +100,12 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		}, b2bOrgSearchResult{}, nil
 	}
 
-	views := make([]b2bOrgView, 0, len(result.Orgs))
-	for _, o := range result.Orgs {
-		views = append(views, toB2bOrgView(o))
+	out := b2bOrgSearchResult{
+		Resources: result.Resources,
+		PageToken: result.PageToken,
 	}
 
-	output := b2bOrgSearchResult{
-		Orgs:     views,
-		Metadata: result.Metadata,
-	}
-
-	prettyJSON, err := json.MarshalIndent(output, "", "  ")
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal search result", "error", err)
 		return &mcp.CallToolResult{
@@ -234,121 +116,11 @@ func handleSearchB2bOrgs(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		}, b2bOrgSearchResult{}, nil
 	}
 
-	logger.InfoContext(ctx, "search_b2b_orgs succeeded", "count", len(result.Orgs))
+	logger.InfoContext(ctx, "search_b2b_orgs succeeded", "count", len(result.Resources))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, output, nil
-}
-
-// handleListB2bOrgMemberships implements the list_b2b_org_memberships tool logic.
-func handleListB2bOrgMemberships(ctx context.Context, req *mcp.CallToolRequest, args ListB2bOrgMembershipsArgs) (*mcp.CallToolResult, b2bOrgMembershipListResult, error) {
-	logger := newToolLogger(ctx, req)
-
-	if memberConfig == nil {
-		logger.ErrorContext(ctx, "member tools not configured")
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: member tools not configured"},
-			},
-			IsError: true,
-		}, b2bOrgMembershipListResult{}, nil
-	}
-
-	if args.B2bOrgUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: b2b_org_uid is required"},
-			},
-			IsError: true,
-		}, b2bOrgMembershipListResult{}, nil
-	}
-
-	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to extract MCP token", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
-			},
-			IsError: true,
-		}, b2bOrgMembershipListResult{}, nil
-	}
-
-	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
-	clients := memberConfig.Clients
-
-	pageSize := args.PageSize
-	if pageSize <= 0 {
-		pageSize = 10
-	}
-
-	version := "1"
-	payload := &memberservice.ListB2bOrgMembershipsPayload{
-		Version:   &version,
-		B2bOrgUID: args.B2bOrgUID,
-		PageSize:  pageSize,
-		Sort:      args.Sort,
-	}
-
-	if args.PageToken != "" {
-		payload.PageToken = &args.PageToken
-	}
-
-	logger.InfoContext(ctx, "listing B2B org memberships", "b2b_org_uid", args.B2bOrgUID, "page_size", pageSize, "page_token", args.PageToken)
-
-	result, err := clients.Member.ListB2bOrgMemberships(ctx, payload)
-	if err != nil {
-		logger.ErrorContext(ctx, "ListB2bOrgMemberships failed", "error", err, "b2b_org_uid", args.B2bOrgUID)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: friendlyAPIError("failed to list B2B org memberships", err)},
-			},
-			IsError: true,
-		}, b2bOrgMembershipListResult{}, nil
-	}
-
-	views := make([]b2bOrgMembershipView, 0, len(result.Memberships))
-	for _, m := range result.Memberships {
-		views = append(views, toB2bOrgMembershipView(m))
-	}
-
-	// Warn if any membership has a project_slug but no project_uid, which
-	// indicates the project is not yet onboarded into LFX Self Service.
-	var onboardingWarning string
-	if len(result.Memberships) > 0 {
-		for _, m := range result.Memberships {
-			if m.ProjectSlug != nil && *m.ProjectSlug != "" && (m.ProjectUID == nil || *m.ProjectUID == "") {
-				onboardingWarning = "WARNING: projects missing a `project_uid` are not yet onboarded into *LFX Self Service*"
-				break
-			}
-		}
-	}
-
-	output := b2bOrgMembershipListResult{
-		Memberships: views,
-		Metadata:    result.Metadata,
-	}
-
-	prettyJSON, err := json.MarshalIndent(output, "", "  ")
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to marshal memberships result", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
-			},
-			IsError: true,
-		}, b2bOrgMembershipListResult{}, nil
-	}
-
-	logger.InfoContext(ctx, "list_b2b_org_memberships succeeded", "b2b_org_uid", args.B2bOrgUID, "count", len(result.Memberships))
-
-	content := []mcp.Content{}
-	if onboardingWarning != "" {
-		content = append(content, &mcp.TextContent{Text: onboardingWarning})
-	}
-	content = append(content, &mcp.TextContent{Text: string(prettyJSON)})
-	return &mcp.CallToolResult{Content: content}, output, nil
+	}, out, nil
 }

--- a/internal/tools/b2b_org.go
+++ b/internal/tools/b2b_org.go
@@ -14,6 +14,9 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// b2bOrgResourceType is the resource type filter for B2B org queries.
+const b2bOrgResourceType = "b2b_org"
+
 // SearchB2bOrgsArgs defines the input parameters for the search_b2b_orgs tool.
 type SearchB2bOrgsArgs struct {
 	SearchName string `json:"search_name,omitempty" jsonschema:"Search B2B organizations by name or domain (typeahead)."`

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -41,10 +41,11 @@ func SetMemberConfig(cfg *MemberConfig) {
 // SearchMembersArgs defines the input parameters for the search_members tool.
 type SearchMembersArgs struct {
 	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Filter by project UUID. At least one of project_uid or b2b_org_uid is strongly recommended."`
-	B2bOrgUID  string `json:"b2b_org_uid,omitempty" jsonschema:"Filter by B2B organization UID. At least one of project_uid or b2b_org_uid is strongly recommended. Also replaces the removed list_b2b_org_memberships tool."`
+	B2bOrgUID  string `json:"b2b_org_uid,omitempty" jsonschema:"Filter by B2B organization UID. At least one of project_uid or b2b_org_uid is strongly recommended."`
 	SearchName string `json:"search_name,omitempty" jsonschema:"Search memberships by member company name (typeahead)."`
-	TierUID    string `json:"tier_uid,omitempty" jsonschema:"Filter by membership tier UID."`
-	TierName   string `json:"tier_name,omitempty" jsonschema:"Filter by tier label, e.g. 'Gold'."`
+	TierUID    string `json:"tier_uid,omitempty" jsonschema:"Filter by exact tier+range UID (each employee-count range has a distinct UID)."`
+	TierName   string `json:"tier_name,omitempty" jsonschema:"Filter by exact tier product name, e.g. 'Silver ISV Member'. Must match the full name as stored."`
+	ActiveOnly *bool  `json:"active_only,omitempty" jsonschema:"When true (default), only return memberships with status Active. Set to false to include all statuses."`
 	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)."`
 	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response."`
 }
@@ -69,8 +70,52 @@ type GetMembershipKeyContactArgs struct {
 
 // memberSearchResult is the output type for the search_members tool.
 type memberSearchResult struct {
-	Resources []*querysvc.Resource `json:"resources"`
-	PageToken *string              `json:"page_token,omitempty"`
+	Resources []membershipView `json:"resources"`
+	PageToken *string          `json:"page_token,omitempty"`
+}
+
+// membershipView is a shaped view of a project_membership resource returned by
+// the query service. It renames the upstream "tier" field (an employee-count
+// range string used for variable-priced tiers) to "tier_range" within the data
+// map to avoid confusion with the human-readable "tier_name" field. The field
+// is omitted entirely when absent or null in the upstream payload.
+type membershipView struct {
+	Type *string        `json:"type,omitempty"`
+	ID   *string        `json:"id,omitempty"`
+	Data map[string]any `json:"data,omitempty"`
+}
+
+// toMembershipView converts a querysvc.Resource into a membershipView,
+// renaming "tier" to "tier_range" inside the data map and removing fields
+// that should not be surfaced in MCP output.
+func toMembershipView(r *querysvc.Resource) membershipView {
+	v := membershipView{
+		Type: r.Type,
+		ID:   r.ID,
+	}
+	if r.Data != nil {
+		if m, ok := r.Data.(map[string]any); ok {
+			// Copy the map so we don't mutate the original.
+			data := make(map[string]any, len(m))
+			for k, val := range m {
+				data[k] = val
+			}
+			// Rename "tier" to "tier_range" within data; omit when null or absent.
+			if tierVal, exists := data["tier"]; exists {
+				delete(data, "tier")
+				if tierVal != nil {
+					data["tier_range"] = tierVal
+				}
+			}
+			// Hide internal Salesforce project SFID from MCP output.
+			delete(data, "project_sfid")
+			v.Data = data
+		} else {
+			// Unexpected type — preserve the raw value so no data is silently lost.
+			v.Data = map[string]any{"_raw": r.Data}
+		}
+	}
+	return v
 }
 
 // keyContactListResult is the output type for get_membership_key_contacts.
@@ -123,7 +168,7 @@ func toKeyContactView(c *memberservice.ProjectKeyContactResponse) keyContactView
 func RegisterSearchMembers(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_members",
-		Description: "List and search project memberships. At least one of project_uid or b2b_org_uid is strongly recommended — an unfiltered search across all memberships is unlikely to be useful. Supports search_name for company name typeahead, tier_uid or tier_name filter, and cursor-based pagination via page_token. Also accepts b2b_org_uid to list all memberships for a given org across all projects (replaces the removed list_b2b_org_memberships tool).",
+		Description: "List and search project memberships. At least one of project_uid or b2b_org_uid is strongly recommended — an unfiltered search across all memberships is unlikely to be useful. Defaults to active memberships only (active_only=true); set active_only=false to include all statuses. Supports search_name for company name typeahead, tier_name for exact tier product name filtering, tier_uid for exact tier+range filtering, and cursor-based pagination via page_token. Also accepts b2b_org_uid to list all memberships for a given org across all projects.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Members",
 			ReadOnlyHint: true,
@@ -223,8 +268,11 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		filtersAll = append(filtersAll, "tier_uid:"+args.TierUID)
 	}
 	if args.TierName != "" {
-		// The indexed field is "tier" (the short label such as "Gold"), not "tier_name".
-		filtersAll = append(filtersAll, "tier:"+args.TierName)
+		filtersAll = append(filtersAll, "tier_name:"+args.TierName)
+	}
+	// Default to active-only unless the caller explicitly sets active_only=false.
+	if args.ActiveOnly == nil || *args.ActiveOnly {
+		filtersAll = append(filtersAll, "status:Active")
 	}
 	if len(filtersAll) > 0 {
 		payload.FiltersAll = filtersAll
@@ -253,8 +301,12 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		}, memberSearchResult{}, nil
 	}
 
+	views := make([]membershipView, len(result.Resources))
+	for i, r := range result.Resources {
+		views[i] = toMembershipView(r)
+	}
 	out := memberSearchResult{
-		Resources: result.Resources,
+		Resources: views,
 		PageToken: result.PageToken,
 	}
 

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -21,9 +21,6 @@ const memberResourceType = "project_membership"
 // keyContactResourceType is the resource type filter for key contact queries.
 const keyContactResourceType = "key_contact"
 
-// b2bOrgResourceType is the resource type filter for B2B org queries.
-const b2bOrgResourceType = "b2b_org"
-
 // MemberConfig holds configuration shared by member tools.
 type MemberConfig struct {
 	// Clients is the shared LFX v2 API client instance. It must be created once

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -8,12 +8,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/linuxfoundation/lfx-mcp/internal/lfxv2"
 	memberservice "github.com/linuxfoundation/lfx-v2-member-service/gen/membership_service"
+	querysvc "github.com/linuxfoundation/lfx-v2-query-service/gen/query_svc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// memberResourceType is the resource type filter for project membership queries.
+const memberResourceType = "project_membership"
+
+// keyContactResourceType is the resource type filter for key contact queries.
+const keyContactResourceType = "key_contact"
+
+// b2bOrgResourceType is the resource type filter for B2B org queries.
+const b2bOrgResourceType = "b2b_org"
 
 // MemberConfig holds configuration shared by member tools.
 type MemberConfig struct {
@@ -31,91 +40,47 @@ func SetMemberConfig(cfg *MemberConfig) {
 
 // SearchMembersArgs defines the input parameters for the search_members tool.
 type SearchMembersArgs struct {
-	ProjectUID string `json:"project_uid" jsonschema:"Project UUID (required)"`
-	SearchName string `json:"search_name,omitempty" jsonschema:"Search memberships by member company name (case-insensitive substring match)."`
-	TierUID    string `json:"tier_uid,omitempty" jsonschema:"Filter by membership tier UID (UUID from list_project_tiers)"`
-	Sort       string `json:"sort,omitempty" jsonschema:"Sort order: newest (default), name, last_modified"`
-	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)"`
-	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response"`
+	ProjectUID string `json:"project_uid,omitempty" jsonschema:"Filter by project UUID. At least one of project_uid or b2b_org_uid is strongly recommended."`
+	B2bOrgUID  string `json:"b2b_org_uid,omitempty" jsonschema:"Filter by B2B organization UID. At least one of project_uid or b2b_org_uid is strongly recommended. Also replaces the removed list_b2b_org_memberships tool."`
+	SearchName string `json:"search_name,omitempty" jsonschema:"Search memberships by member company name (typeahead)."`
+	TierUID    string `json:"tier_uid,omitempty" jsonschema:"Filter by membership tier UID."`
+	TierName   string `json:"tier_name,omitempty" jsonschema:"Filter by tier label, e.g. 'Gold'."`
+	PageSize   int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)."`
+	PageToken  string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous search response."`
 }
 
 // GetMemberMembershipArgs defines the input parameters for the get_member_membership tool.
 type GetMemberMembershipArgs struct {
-	ProjectUID    string `json:"project_uid" jsonschema:"Project UUID"`
 	MembershipUID string `json:"membership_uid" jsonschema:"The membership UID"`
 }
 
 // GetMembershipKeyContactsArgs defines the input parameters for the get_membership_key_contacts tool.
 type GetMembershipKeyContactsArgs struct {
-	ProjectUID    string `json:"project_uid" jsonschema:"Project UUID"`
 	MembershipUID string `json:"membership_uid" jsonschema:"The membership UID"`
-}
-
-// ListProjectTiersArgs defines the input parameters for the list_project_tiers tool.
-type ListProjectTiersArgs struct {
-	ProjectUID string `json:"project_uid" jsonschema:"Project UUID (required)"`
-}
-
-// GetProjectTierArgs defines the input parameters for the get_project_tier tool.
-type GetProjectTierArgs struct {
-	ProjectUID string `json:"project_uid" jsonschema:"Project UUID (required)"`
-	TierUID    string `json:"tier_uid" jsonschema:"Membership tier UID"`
+	PageSize      int    `json:"page_size,omitempty" jsonschema:"Number of results per page (default 10, max 100)."`
+	PageToken     string `json:"page_token,omitempty" jsonschema:"Opaque pagination token from a previous response."`
 }
 
 // GetMembershipKeyContactArgs defines the input parameters for the get_membership_key_contact tool.
 type GetMembershipKeyContactArgs struct {
-	ProjectUID    string `json:"project_uid" jsonschema:"Project UUID"`
 	MembershipUID string `json:"membership_uid" jsonschema:"The membership UID"`
 	ContactUID    string `json:"contact_uid" jsonschema:"Key contact UID"`
 }
 
-// membershipTierView is a filtered view of MembershipTierResponse for MCP
-// responses. Redundant fields that are either required inputs or always
-// constant are omitted: project_uid (required input), family (always
-// "Membership"), and product_type (always null).
-type membershipTierView struct {
-	UID       *string `json:"uid,omitempty"`
-	Name      *string `json:"name,omitempty"`
-	CreatedAt *string `json:"created_at,omitempty"`
-	UpdatedAt *string `json:"updated_at,omitempty"`
+// memberSearchResult is the output type for the search_members tool.
+type memberSearchResult struct {
+	Resources []*querysvc.Resource `json:"resources"`
+	PageToken *string              `json:"page_token,omitempty"`
 }
 
-// membershipView is a filtered view of ProjectMembershipResponse for MCP
-// responses from the search_members tool (project drill-down). Omitted fields:
-// project_uid and project_slug (redundant — same for every result in a
-// project-scoped query), tier_family (always "Membership"), tier_product_type
-// (always null), and membership_type (a raw Salesforce record type ID, not
-// useful to callers). Company fields are renamed with a b2b_org_ prefix to
-// align with b2b tool naming conventions.
-type membershipView struct {
-	UID              *string  `json:"uid,omitempty"`
-	TierUID          *string  `json:"tier_uid,omitempty"`
-	B2bOrgUID        *string  `json:"b2b_org_uid,omitempty"`
-	Status           *string  `json:"status,omitempty"`
-	Year             *string  `json:"year,omitempty"`
-	Tier             *string  `json:"tier,omitempty"`
-	AutoRenew        *bool    `json:"auto_renew,omitempty"`
-	RenewalType      *string  `json:"renewal_type,omitempty"`
-	Price            *float64 `json:"price,omitempty"`
-	AnnualFullPrice  *float64 `json:"annual_full_price,omitempty"`
-	PaymentFrequency *string  `json:"payment_frequency,omitempty"`
-	PaymentTerms     *string  `json:"payment_terms,omitempty"`
-	AgreementDate    *string  `json:"agreement_date,omitempty"`
-	PurchaseDate     *string  `json:"purchase_date,omitempty"`
-	StartDate        *string  `json:"start_date,omitempty"`
-	EndDate          *string  `json:"end_date,omitempty"`
-	B2bOrgName       *string  `json:"b2b_org_name,omitempty"`
-	B2bOrgLogoURL    *string  `json:"b2b_org_logo_url,omitempty"`
-	B2bOrgDomain     *string  `json:"b2b_org_domain,omitempty"`
-	TierName         *string  `json:"tier_name,omitempty"`
-	CreatedAt        *string  `json:"created_at,omitempty"`
-	UpdatedAt        *string  `json:"updated_at,omitempty"`
+// keyContactListResult is the output type for get_membership_key_contacts.
+type keyContactListResult struct {
+	Resources []*querysvc.Resource `json:"resources"`
+	PageToken *string              `json:"page_token,omitempty"`
 }
 
 // keyContactView is a filtered view of ProjectKeyContactResponse for MCP
-// responses. Redundant fields omitted: tier_uid (a degree removed from the
-// contact and not directly useful), project_uid (required input), and
-// membership_uid (the id required input).
+// responses from the member service single-resource endpoint.
 type keyContactView struct {
 	UID            *string `json:"uid,omitempty"`
 	Role           *string `json:"role,omitempty"`
@@ -131,65 +96,6 @@ type keyContactView struct {
 	CompanyDomain  *string `json:"company_domain,omitempty"`
 	CreatedAt      *string `json:"created_at,omitempty"`
 	UpdatedAt      *string `json:"updated_at,omitempty"`
-}
-
-// memberSearchResult is the output type for the search_members tool.
-type memberSearchResult struct {
-	Memberships []membershipView            `json:"memberships"`
-	Metadata    *memberservice.ListMetadata `json:"metadata,omitempty"`
-}
-
-// membershipTierListResult wraps a slice of tiers as an object root so the
-// MCP outputSchema and structuredContent are always JSON objects.
-type membershipTierListResult struct {
-	Tiers []membershipTierView `json:"tiers"`
-}
-
-// keyContactListResult wraps a slice of key contacts as an object root so the
-// MCP outputSchema and structuredContent are always JSON objects.
-type keyContactListResult struct {
-	Contacts []keyContactView `json:"contacts"`
-}
-
-// toMembershipTierView converts a MembershipTierResponse to the filtered MCP
-// view, dropping redundant fields.
-func toMembershipTierView(t *memberservice.MembershipTierResponse) membershipTierView {
-	return membershipTierView{
-		UID:       t.UID,
-		Name:      t.Name,
-		CreatedAt: t.CreatedAt,
-		UpdatedAt: t.UpdatedAt,
-	}
-}
-
-// toMembershipView converts a ProjectMembershipResponse to the filtered MCP
-// view for search_members, dropping project_uid/slug (redundant in a
-// project-scoped query) and renaming company fields to b2b_org_ prefix.
-func toMembershipView(m *memberservice.ProjectMembershipResponse) membershipView {
-	return membershipView{
-		UID:              m.UID,
-		TierUID:          m.TierUID,
-		B2bOrgUID:        m.B2bOrgUID,
-		Status:           m.Status,
-		Year:             m.Year,
-		Tier:             m.Tier,
-		AutoRenew:        m.AutoRenew,
-		RenewalType:      m.RenewalType,
-		Price:            m.Price,
-		AnnualFullPrice:  m.AnnualFullPrice,
-		PaymentFrequency: m.PaymentFrequency,
-		PaymentTerms:     m.PaymentTerms,
-		AgreementDate:    m.AgreementDate,
-		PurchaseDate:     m.PurchaseDate,
-		StartDate:        m.StartDate,
-		EndDate:          m.EndDate,
-		B2bOrgName:       m.CompanyName,
-		B2bOrgLogoURL:    m.CompanyLogoURL,
-		B2bOrgDomain:     m.CompanyDomain,
-		TierName:         m.TierName,
-		CreatedAt:        m.CreatedAt,
-		UpdatedAt:        m.UpdatedAt,
-	}
 }
 
 // toKeyContactView converts a ProjectKeyContactResponse to the filtered MCP
@@ -217,7 +123,7 @@ func toKeyContactView(c *memberservice.ProjectKeyContactResponse) keyContactView
 func RegisterSearchMembers(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_members",
-		Description: "List and search memberships for a project. Use this tool when users ask about members, memberships, or member organizations for a specific project. Requires project_uid. Supports search_name for case-insensitive company name substring search, tier_uid filter, and sort order (newest, name, last_modified). Uses cursor-based pagination via page_token.",
+		Description: "List and search project memberships. At least one of project_uid or b2b_org_uid is strongly recommended — an unfiltered search across all memberships is unlikely to be useful. Supports search_name for company name typeahead, tier_uid or tier_name filter, and cursor-based pagination via page_token. Also accepts b2b_org_uid to list all memberships for a given org across all projects (replaces the removed list_b2b_org_memberships tool).",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Members",
 			ReadOnlyHint: true,
@@ -229,7 +135,7 @@ func RegisterSearchMembers(server *mcp.Server) {
 func RegisterGetMemberMembership(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_member_membership",
-		Description: "Get a single membership by project UID and membership ID. Use this when users ask for details about a specific membership.",
+		Description: "Get a single membership by membership UID. Use this when users ask for details about a specific membership.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Member Membership",
 			ReadOnlyHint: true,
@@ -237,35 +143,11 @@ func RegisterGetMemberMembership(server *mcp.Server) {
 	}, handleGetMemberMembership)
 }
 
-// RegisterListProjectTiers registers the list_project_tiers tool with the MCP server.
-func RegisterListProjectTiers(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "list_project_tiers",
-		Description: "List all membership tiers (e.g. Gold, Silver, Bronze) defined for a project. Use this to discover available tier UIDs before filtering search_members by tier_uid.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:        "List Project Tiers",
-			ReadOnlyHint: true,
-		},
-	}, handleListProjectTiers)
-}
-
-// RegisterGetProjectTier registers the get_project_tier tool with the MCP server.
-func RegisterGetProjectTier(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_project_tier",
-		Description: "Get a single membership tier by project UID and tier UID.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:        "Get Project Tier",
-			ReadOnlyHint: true,
-		},
-	}, handleGetProjectTier)
-}
-
 // RegisterGetMembershipKeyContacts registers the get_membership_key_contacts tool with the MCP server.
 func RegisterGetMembershipKeyContacts(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_membership_key_contacts",
-		Description: "Get key contacts for a membership by project UID and membership ID. Returns the people associated with a membership such as primary contacts and board members.",
+		Description: "List key contacts for a membership by membership UID. Returns the people associated with a membership such as primary contacts and board members.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Membership Key Contacts",
 			ReadOnlyHint: true,
@@ -277,7 +159,7 @@ func RegisterGetMembershipKeyContacts(server *mcp.Server) {
 func RegisterGetMembershipKeyContact(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_membership_key_contact",
-		Description: "Get a single key contact for a membership by project UID, membership UID, and key contact UID.",
+		Description: "Get a single key contact for a membership by membership UID and key contact UID.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Membership Key Contact",
 			ReadOnlyHint: true,
@@ -285,7 +167,7 @@ func RegisterGetMembershipKeyContact(server *mcp.Server) {
 	}, handleGetMembershipKeyContact)
 }
 
-// handleSearchMembers implements the search_members tool logic.
+// handleSearchMembers implements the search_members tool logic using the Query Service.
 func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args SearchMembersArgs) (*mcp.CallToolResult, memberSearchResult, error) {
 	logger := newToolLogger(ctx, req)
 
@@ -313,52 +195,56 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
 	clients := memberConfig.Clients
 
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: project_uid is required"},
-			},
-			IsError: true,
-		}, memberSearchResult{}, nil
-	}
-
 	pageSize := args.PageSize
 	if pageSize <= 0 {
 		pageSize = 10
 	}
 
-	// Build filter string from non-empty filter args.
-	var filters []string
-	if args.TierUID != "" {
-		filters = append(filters, "tier_uid="+args.TierUID)
+	resourceType := memberResourceType
+	payload := &querysvc.QueryResourcesPayload{
+		Version:  "1",
+		Type:     &resourceType,
+		PageSize: pageSize,
 	}
 
-	version := "1"
-	payload := &memberservice.ListProjectMembershipsPayload{
-		Version:    &version,
-		ProjectUID: &args.ProjectUID,
-		PageSize:   pageSize,
-		Sort:       args.Sort,
+	if args.SearchName != "" {
+		payload.Name = &args.SearchName
+	}
+
+	// Build FiltersAll for data-field equality filters.
+	var filtersAll []string
+	if args.ProjectUID != "" {
+		filtersAll = append(filtersAll, "project_uid:"+args.ProjectUID)
+	}
+	if args.B2bOrgUID != "" {
+		filtersAll = append(filtersAll, "b2b_org_uid:"+args.B2bOrgUID)
+	}
+	if args.TierUID != "" {
+		filtersAll = append(filtersAll, "tier_uid:"+args.TierUID)
+	}
+	if args.TierName != "" {
+		// The indexed field is "tier" (the short label such as "Gold"), not "tier_name".
+		filtersAll = append(filtersAll, "tier:"+args.TierName)
+	}
+	if len(filtersAll) > 0 {
+		payload.FiltersAll = filtersAll
 	}
 
 	if args.PageToken != "" {
 		payload.PageToken = &args.PageToken
 	}
 
-	if len(filters) > 0 {
-		filterStr := strings.Join(filters, ";")
-		payload.Filter = &filterStr
-	}
+	logger.InfoContext(ctx, "searching members",
+		"project_uid", args.ProjectUID,
+		"b2b_org_uid", args.B2bOrgUID,
+		"search_name", args.SearchName,
+		"filter_count", len(filtersAll),
+		"page_size", pageSize,
+	)
 
-	if args.SearchName != "" {
-		payload.SearchName = &args.SearchName
-	}
-
-	logger.InfoContext(ctx, "searching members", "project_uid", args.ProjectUID, "filter_count", len(filters), "page_size", pageSize, "page_token", args.PageToken, "search_name", args.SearchName)
-
-	result, err := clients.Member.ListProjectMemberships(ctx, payload)
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {
-		logger.ErrorContext(ctx, "ListProjectMemberships failed", "error", err)
+		logger.ErrorContext(ctx, "QueryResources failed", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: friendlyAPIError("failed to search members", err)},
@@ -367,17 +253,12 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		}, memberSearchResult{}, nil
 	}
 
-	views := make([]membershipView, 0, len(result.Memberships))
-	for _, m := range result.Memberships {
-		views = append(views, toMembershipView(m))
+	out := memberSearchResult{
+		Resources: result.Resources,
+		PageToken: result.PageToken,
 	}
 
-	filtered := memberSearchResult{
-		Memberships: views,
-		Metadata:    result.Metadata,
-	}
-
-	prettyJSON, err := json.MarshalIndent(filtered, "", "  ")
+	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal search result", "error", err)
 		return &mcp.CallToolResult{
@@ -388,13 +269,13 @@ func handleSearchMembers(ctx context.Context, req *mcp.CallToolRequest, args Sea
 		}, memberSearchResult{}, nil
 	}
 
-	logger.InfoContext(ctx, "search_members succeeded", "count", len(result.Memberships))
+	logger.InfoContext(ctx, "search_members succeeded", "count", len(result.Resources))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, filtered, nil
+	}, out, nil
 }
 
 // handleGetMemberMembership implements the get_member_membership tool logic.
@@ -411,15 +292,6 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 		}, nil, nil
 	}
 
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: project_uid is required"},
-			},
-			IsError: true,
-		}, nil, nil
-	}
-
 	if args.MembershipUID == "" {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -443,16 +315,15 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
 	clients := memberConfig.Clients
 
-	logger.InfoContext(ctx, "fetching member membership", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
+	logger.InfoContext(ctx, "fetching member membership", "membership_uid", args.MembershipUID)
 
 	version := "1"
 	result, err := clients.Member.GetProjectMembership(ctx, &memberservice.GetProjectMembershipPayload{
-		Version:       &version,
-		ProjectUID:    &args.ProjectUID,
-		MembershipUID: &args.MembershipUID,
+		Version: &version,
+		UID:     args.MembershipUID,
 	})
 	if err != nil {
-		logger.ErrorContext(ctx, "GetProjectMembership failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
+		logger.ErrorContext(ctx, "GetProjectMembership failed", "error", err, "membership_uid", args.MembershipUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: friendlyAPIError("failed to get member membership", err)},
@@ -461,7 +332,7 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 		}, nil, nil
 	}
 
-	prettyJSON, err := json.MarshalIndent(result.Membership, "", "  ")
+	prettyJSON, err := json.MarshalIndent(result.ProjectMembership, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal membership result", "error", err)
 		return &mcp.CallToolResult{
@@ -472,183 +343,17 @@ func handleGetMemberMembership(ctx context.Context, req *mcp.CallToolRequest, ar
 		}, nil, nil
 	}
 
-	logger.InfoContext(ctx, "get_member_membership succeeded", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
+	logger.InfoContext(ctx, "get_member_membership succeeded", "membership_uid", args.MembershipUID)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(prettyJSON)},
 		},
-	}, result.Membership, nil
+	}, result.ProjectMembership, nil
 }
 
-// handleListProjectTiers implements the list_project_tiers tool logic.
-func handleListProjectTiers(ctx context.Context, req *mcp.CallToolRequest, args ListProjectTiersArgs) (*mcp.CallToolResult, membershipTierListResult, error) {
-	logger := newToolLogger(ctx, req)
-
-	if memberConfig == nil {
-		logger.ErrorContext(ctx, "member tools not configured")
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: member tools not configured"},
-			},
-			IsError: true,
-		}, membershipTierListResult{}, nil
-	}
-
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: project_uid is required"},
-			},
-			IsError: true,
-		}, membershipTierListResult{}, nil
-	}
-
-	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to extract MCP token", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
-			},
-			IsError: true,
-		}, membershipTierListResult{}, nil
-	}
-
-	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
-	clients := memberConfig.Clients
-
-	logger.InfoContext(ctx, "listing project tiers", "project_uid", args.ProjectUID)
-
-	version := "1"
-	result, err := clients.Member.ListProjectTiers(ctx, &memberservice.ListProjectTiersPayload{
-		Version:    &version,
-		ProjectUID: &args.ProjectUID,
-	})
-	if err != nil {
-		logger.ErrorContext(ctx, "ListProjectTiers failed", "error", err, "project_uid", args.ProjectUID)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: friendlyAPIError("failed to list project tiers", err)},
-			},
-			IsError: true,
-		}, membershipTierListResult{}, nil
-	}
-
-	out := membershipTierListResult{
-		Tiers: make([]membershipTierView, 0, len(result.Tiers)),
-	}
-	for _, t := range result.Tiers {
-		out.Tiers = append(out.Tiers, toMembershipTierView(t))
-	}
-
-	prettyJSON, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to marshal tiers result", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
-			},
-			IsError: true,
-		}, membershipTierListResult{}, nil
-	}
-
-	logger.InfoContext(ctx, "list_project_tiers succeeded", "project_uid", args.ProjectUID, "count", len(result.Tiers))
-
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: string(prettyJSON)},
-		},
-	}, out, nil
-}
-
-// handleGetProjectTier implements the get_project_tier tool logic.
-func handleGetProjectTier(ctx context.Context, req *mcp.CallToolRequest, args GetProjectTierArgs) (*mcp.CallToolResult, membershipTierView, error) {
-	logger := newToolLogger(ctx, req)
-
-	if memberConfig == nil {
-		logger.ErrorContext(ctx, "member tools not configured")
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: member tools not configured"},
-			},
-			IsError: true,
-		}, membershipTierView{}, nil
-	}
-
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: project_uid is required"},
-			},
-			IsError: true,
-		}, membershipTierView{}, nil
-	}
-
-	if args.TierUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: tier_uid is required"},
-			},
-			IsError: true,
-		}, membershipTierView{}, nil
-	}
-
-	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to extract MCP token", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to extract MCP token: %v", err)},
-			},
-			IsError: true,
-		}, membershipTierView{}, nil
-	}
-
-	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
-	clients := memberConfig.Clients
-
-	logger.InfoContext(ctx, "fetching project tier", "project_uid", args.ProjectUID, "tier_uid", args.TierUID)
-
-	version := "1"
-	result, err := clients.Member.GetProjectTier(ctx, &memberservice.GetProjectTierPayload{
-		Version:    &version,
-		ProjectUID: &args.ProjectUID,
-		TierUID:    &args.TierUID,
-	})
-	if err != nil {
-		logger.ErrorContext(ctx, "GetProjectTier failed", "error", err, "project_uid", args.ProjectUID, "tier_uid", args.TierUID)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: friendlyAPIError("failed to get project tier", err)},
-			},
-			IsError: true,
-		}, membershipTierView{}, nil
-	}
-
-	tierView := toMembershipTierView(result.Tier)
-
-	prettyJSON, err := json.MarshalIndent(tierView, "", "  ")
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to marshal tier result", "error", err)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
-			},
-			IsError: true,
-		}, membershipTierView{}, nil
-	}
-
-	logger.InfoContext(ctx, "get_project_tier succeeded", "project_uid", args.ProjectUID, "tier_uid", args.TierUID)
-
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: string(prettyJSON)},
-		},
-	}, tierView, nil
-}
-
-// handleGetMembershipKeyContacts implements the get_membership_key_contacts tool logic.
+// handleGetMembershipKeyContacts implements the get_membership_key_contacts tool
+// logic using the Query Service with a membership_uid filter.
 func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolRequest, args GetMembershipKeyContactsArgs) (*mcp.CallToolResult, keyContactListResult, error) {
 	logger := newToolLogger(ctx, req)
 
@@ -662,15 +367,6 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 		}, keyContactListResult{}, nil
 	}
 
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: project_uid is required"},
-			},
-			IsError: true,
-		}, keyContactListResult{}, nil
-	}
-
 	if args.MembershipUID == "" {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -694,16 +390,28 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
 	clients := memberConfig.Clients
 
-	logger.InfoContext(ctx, "fetching membership key contacts", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
+	pageSize := args.PageSize
+	if pageSize <= 0 {
+		pageSize = 10
+	}
 
-	version := "1"
-	result, err := clients.Member.ListMembershipKeyContacts(ctx, &memberservice.ListMembershipKeyContactsPayload{
-		Version:       &version,
-		ProjectUID:    &args.ProjectUID,
-		MembershipUID: &args.MembershipUID,
-	})
+	resourceType := keyContactResourceType
+	payload := &querysvc.QueryResourcesPayload{
+		Version:    "1",
+		Type:       &resourceType,
+		FiltersAll: []string{"membership_uid:" + args.MembershipUID},
+		PageSize:   pageSize,
+	}
+
+	if args.PageToken != "" {
+		payload.PageToken = &args.PageToken
+	}
+
+	logger.InfoContext(ctx, "fetching membership key contacts", "membership_uid", args.MembershipUID)
+
+	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {
-		logger.ErrorContext(ctx, "ListMembershipKeyContacts failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
+		logger.ErrorContext(ctx, "QueryResources (key_contact) failed", "error", err, "membership_uid", args.MembershipUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: friendlyAPIError("failed to get membership key contacts", err)},
@@ -713,15 +421,13 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 	}
 
 	out := keyContactListResult{
-		Contacts: make([]keyContactView, 0, len(result.Contacts)),
-	}
-	for _, c := range result.Contacts {
-		out.Contacts = append(out.Contacts, toKeyContactView(c))
+		Resources: result.Resources,
+		PageToken: result.PageToken,
 	}
 
 	prettyJSON, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to marshal membership key contacts result", "error", err)
+		logger.ErrorContext(ctx, "failed to marshal key contacts result", "error", err)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: fmt.Sprintf("Error: failed to format result: %v", err)},
@@ -730,7 +436,7 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 		}, keyContactListResult{}, nil
 	}
 
-	logger.InfoContext(ctx, "get_membership_key_contacts succeeded", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
+	logger.InfoContext(ctx, "get_membership_key_contacts succeeded", "membership_uid", args.MembershipUID, "count", len(result.Resources))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -748,15 +454,6 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: "Error: member tools not configured"},
-			},
-			IsError: true,
-		}, keyContactView{}, nil
-	}
-
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: project_uid is required"},
 			},
 			IsError: true,
 		}, keyContactView{}, nil
@@ -794,17 +491,16 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 	ctx = memberConfig.Clients.WithMCPToken(ctx, mcpToken)
 	clients := memberConfig.Clients
 
-	logger.InfoContext(ctx, "fetching membership key contact", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
+	logger.InfoContext(ctx, "fetching membership key contact", "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 
 	version := "1"
-	result, err := clients.Member.GetMembershipKeyContact(ctx, &memberservice.GetMembershipKeyContactPayload{
+	result, err := clients.Member.GetKeyContact(ctx, &memberservice.GetKeyContactPayload{
 		Version:       &version,
-		ProjectUID:    &args.ProjectUID,
-		MembershipUID: &args.MembershipUID,
-		ContactUID:    &args.ContactUID,
+		MembershipUID: args.MembershipUID,
+		UID:           args.ContactUID,
 	})
 	if err != nil {
-		logger.ErrorContext(ctx, "GetMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
+		logger.ErrorContext(ctx, "GetKeyContact failed", "error", err, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: friendlyAPIError("failed to get membership key contact", err)},
@@ -813,7 +509,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 		}, keyContactView{}, nil
 	}
 
-	contactView := toKeyContactView(result.Contact)
+	contactView := toKeyContactView(result.KeyContact)
 
 	prettyJSON, err := json.MarshalIndent(contactView, "", "  ")
 	if err != nil {
@@ -826,7 +522,7 @@ func handleGetMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequest
 		}, keyContactView{}, nil
 	}
 
-	logger.InfoContext(ctx, "get_membership_key_contact succeeded", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
+	logger.InfoContext(ctx, "get_membership_key_contact succeeded", "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -115,10 +115,36 @@ func toMembershipView(r *querysvc.Resource) membershipView {
 	return v
 }
 
+// toKeyContactResourceView converts a raw query-service key_contact resource
+// into a membershipView, removing internal fields that should not be surfaced
+// in MCP output (e.g. project_sfid).
+func toKeyContactResourceView(r *querysvc.Resource) membershipView {
+	v := membershipView{
+		Type: r.Type,
+		ID:   r.ID,
+	}
+	if r.Data != nil {
+		if m, ok := r.Data.(map[string]any); ok {
+			// Copy the map so we don't mutate the original.
+			data := make(map[string]any, len(m))
+			for k, val := range m {
+				data[k] = val
+			}
+			// Hide internal Salesforce project SFID from MCP output.
+			delete(data, "project_sfid")
+			v.Data = data
+		} else {
+			// Unexpected type — preserve the raw value so no data is silently lost.
+			v.Data = map[string]any{"_raw": r.Data}
+		}
+	}
+	return v
+}
+
 // keyContactListResult is the output type for get_membership_key_contacts.
 type keyContactListResult struct {
-	Resources []*querysvc.Resource `json:"resources"`
-	PageToken *string              `json:"page_token,omitempty"`
+	Resources []membershipView `json:"resources"`
+	PageToken *string          `json:"page_token,omitempty"`
 }
 
 // keyContactView is a filtered view of ProjectKeyContactResponse for MCP
@@ -473,8 +499,13 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 		}, keyContactListResult{}, nil
 	}
 
+	views := make([]membershipView, len(result.Resources))
+	for i, r := range result.Resources {
+		views[i] = toKeyContactResourceView(r)
+	}
+
 	out := keyContactListResult{
-		Resources: result.Resources,
+		Resources: views,
 		PageToken: result.PageToken,
 	}
 

--- a/internal/tools/member.go
+++ b/internal/tools/member.go
@@ -407,7 +407,11 @@ func handleGetMembershipKeyContacts(ctx context.Context, req *mcp.CallToolReques
 		payload.PageToken = &args.PageToken
 	}
 
-	logger.InfoContext(ctx, "fetching membership key contacts", "membership_uid", args.MembershipUID)
+	logger.With(
+		"membership_uid", args.MembershipUID,
+		"page_size", pageSize,
+		"page_token", args.PageToken,
+	).InfoContext(ctx, "fetching membership key contacts")
 
 	result, err := clients.QuerySvc.QueryResources(ctx, payload)
 	if err != nil {

--- a/internal/tools/member_write.go
+++ b/internal/tools/member_write.go
@@ -19,13 +19,12 @@ import (
 // CreateMembershipKeyContactArgs defines the input parameters for the
 // create_membership_key_contact tool.
 type CreateMembershipKeyContactArgs struct {
-	ProjectUID     string  `json:"project_uid" jsonschema:"Project UUID"`
 	MembershipUID  string  `json:"membership_uid" jsonschema:"Membership UID"`
 	Email          string  `json:"email" jsonschema:"Contact email address; used to resolve or create the Salesforce Contact record"`
 	FirstName      string  `json:"first_name" jsonschema:"Contact first name; used when creating a new Contact on miss"`
 	LastName       string  `json:"last_name" jsonschema:"Contact last name; used when creating a new Contact on miss"`
 	Title          *string `json:"title,omitempty" jsonschema:"Contact job title; used when creating a new Contact on miss"`
-	Role           *string `json:"role,omitempty" jsonschema:"Contact role designation, e.g. 'Voting Representative'"`
+	Role           string  `json:"role" jsonschema:"Contact role designation, e.g. 'Voting Representative' (required)"`
 	Status         *string `json:"status,omitempty" jsonschema:"Role record status, e.g. 'Active'"`
 	BoardMember    *bool   `json:"board_member,omitempty" jsonschema:"Whether this contact holds a board member role"`
 	PrimaryContact *bool   `json:"primary_contact,omitempty" jsonschema:"Whether this is the primary contact for the membership"`
@@ -35,7 +34,6 @@ type CreateMembershipKeyContactArgs struct {
 // update_membership_key_contact tool. Only provided (non-nil) fields are
 // updated; omitted fields retain their current values.
 type UpdateMembershipKeyContactArgs struct {
-	ProjectUID     string  `json:"project_uid" jsonschema:"Project UUID"`
 	MembershipUID  string  `json:"membership_uid" jsonschema:"Membership UID"`
 	ContactUID     string  `json:"contact_uid" jsonschema:"Key contact UID"`
 	Role           *string `json:"role,omitempty" jsonschema:"Contact role designation, e.g. 'Voting Representative'"`
@@ -47,7 +45,6 @@ type UpdateMembershipKeyContactArgs struct {
 // DeleteMembershipKeyContactArgs defines the input parameters for the
 // delete_membership_key_contact tool.
 type DeleteMembershipKeyContactArgs struct {
-	ProjectUID    string `json:"project_uid" jsonschema:"Project UUID"`
 	MembershipUID string `json:"membership_uid" jsonschema:"Membership UID"`
 	ContactUID    string `json:"contact_uid" jsonschema:"Key contact UID to remove"`
 }
@@ -88,7 +85,7 @@ func RegisterUpdateMembershipKeyContact(server *mcp.Server) {
 func RegisterDeleteMembershipKeyContact(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "delete_membership_key_contact",
-		Description: "Remove a key contact from a membership. This also invalidates the key-contacts cache for the membership. Requires writer permission on the project.",
+		Description: "Remove a key contact from a membership. Requires writer permission on the project.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:           "Delete Membership Key Contact",
 			ReadOnlyHint:    false,
@@ -110,12 +107,6 @@ func handleCreateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 		}, nil, nil
 	}
 
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: "Error: project_uid is required"}},
-			IsError: true,
-		}, nil, nil
-	}
 	if args.MembershipUID == "" {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Error: membership_uid is required"}},
@@ -140,6 +131,12 @@ func handleCreateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 			IsError: true,
 		}, nil, nil
 	}
+	if args.Role == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "Error: role is required"}},
+			IsError: true,
+		}, nil, nil
+	}
 
 	mcpToken, err := lfxv2.ExtractMCPToken(req.Extra.TokenInfo)
 	if err != nil {
@@ -154,10 +151,9 @@ func handleCreateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 	clients := memberConfig.Clients
 
 	version := "1"
-	payload := &memberservice.CreateMembershipKeyContactPayload{
+	payload := &memberservice.CreateKeyContactPayload{
 		Version:        &version,
-		ProjectUID:     &args.ProjectUID,
-		MembershipUID:  &args.MembershipUID,
+		MembershipUID:  args.MembershipUID,
 		Email:          args.Email,
 		FirstName:      args.FirstName,
 		LastName:       args.LastName,
@@ -168,18 +164,18 @@ func handleCreateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 		PrimaryContact: args.PrimaryContact,
 	}
 
-	logger.InfoContext(ctx, "creating membership key contact", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "email", args.Email)
+	logger.InfoContext(ctx, "creating membership key contact", "membership_uid", args.MembershipUID, "email", args.Email)
 
-	result, err := clients.Member.CreateMembershipKeyContact(ctx, payload)
+	result, err := clients.Member.CreateKeyContact(ctx, payload)
 	if err != nil {
-		logger.ErrorContext(ctx, "CreateMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID)
+		logger.ErrorContext(ctx, "CreateKeyContact failed", "error", err, "membership_uid", args.MembershipUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: friendlyAPIError("failed to create key contact", err)}},
 			IsError: true,
 		}, nil, nil
 	}
 
-	prettyJSON, err := json.MarshalIndent(result.Contact, "", "  ")
+	prettyJSON, err := json.MarshalIndent(result.KeyContact, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal create result", "error", err)
 		return &mcp.CallToolResult{
@@ -188,7 +184,7 @@ func handleCreateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 		}, nil, nil
 	}
 
-	logger.InfoContext(ctx, "create_membership_key_contact succeeded", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", ptrStr(result.Contact.UID))
+	logger.InfoContext(ctx, "create_membership_key_contact succeeded", "membership_uid", args.MembershipUID, "contact_uid", ptrStr(result.KeyContact.UID))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: string(prettyJSON)}},
@@ -206,12 +202,6 @@ func handleUpdateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 		}, nil, nil
 	}
 
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: "Error: project_uid is required"}},
-			IsError: true,
-		}, nil, nil
-	}
 	if args.MembershipUID == "" {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Error: membership_uid is required"}},
@@ -238,25 +228,24 @@ func handleUpdateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 	clients := memberConfig.Clients
 
 	version := "1"
-	result, err := clients.Member.UpdateMembershipKeyContact(ctx, &memberservice.UpdateMembershipKeyContactPayload{
+	result, err := clients.Member.UpdateKeyContact(ctx, &memberservice.UpdateKeyContactPayload{
 		Version:        &version,
-		ProjectUID:     &args.ProjectUID,
-		MembershipUID:  &args.MembershipUID,
-		ContactUID:     &args.ContactUID,
+		MembershipUID:  args.MembershipUID,
+		UID:            args.ContactUID,
 		Role:           args.Role,
 		Status:         args.Status,
 		BoardMember:    args.BoardMember,
 		PrimaryContact: args.PrimaryContact,
 	})
 	if err != nil {
-		logger.ErrorContext(ctx, "UpdateMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
+		logger.ErrorContext(ctx, "UpdateKeyContact failed", "error", err, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: friendlyAPIError("failed to update key contact", err)}},
 			IsError: true,
 		}, nil, nil
 	}
 
-	prettyJSON, err := json.MarshalIndent(result.Contact, "", "  ")
+	prettyJSON, err := json.MarshalIndent(result.KeyContact, "", "  ")
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to marshal update result", "error", err)
 		return &mcp.CallToolResult{
@@ -265,7 +254,7 @@ func handleUpdateMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 		}, nil, nil
 	}
 
-	logger.InfoContext(ctx, "update_membership_key_contact succeeded", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
+	logger.InfoContext(ctx, "update_membership_key_contact succeeded", "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: string(prettyJSON)}},
@@ -283,12 +272,6 @@ func handleDeleteMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 		}, nil, nil
 	}
 
-	if args.ProjectUID == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: "Error: project_uid is required"}},
-			IsError: true,
-		}, nil, nil
-	}
 	if args.MembershipUID == "" {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "Error: membership_uid is required"}},
@@ -315,21 +298,20 @@ func handleDeleteMembershipKeyContact(ctx context.Context, req *mcp.CallToolRequ
 	clients := memberConfig.Clients
 
 	version := "1"
-	err = clients.Member.DeleteMembershipKeyContact(ctx, &memberservice.DeleteMembershipKeyContactPayload{
+	err = clients.Member.DeleteKeyContact(ctx, &memberservice.DeleteKeyContactPayload{
 		Version:       &version,
-		ProjectUID:    &args.ProjectUID,
-		MembershipUID: &args.MembershipUID,
-		ContactUID:    &args.ContactUID,
+		MembershipUID: args.MembershipUID,
+		UID:           args.ContactUID,
 	})
 	if err != nil {
-		logger.ErrorContext(ctx, "DeleteMembershipKeyContact failed", "error", err, "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
+		logger.ErrorContext(ctx, "DeleteKeyContact failed", "error", err, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: friendlyAPIError("failed to delete key contact", err)}},
 			IsError: true,
 		}, nil, nil
 	}
 
-	logger.InfoContext(ctx, "delete_membership_key_contact succeeded", "project_uid", args.ProjectUID, "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
+	logger.InfoContext(ctx, "delete_membership_key_contact succeeded", "membership_uid", args.MembershipUID, "contact_uid", args.ContactUID)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Key contact %s successfully removed from membership %s.", args.ContactUID, args.MembershipUID)}},


### PR DESCRIPTION
## Summary

Fixes three lfx-mcp tools broken by the lfx-v2-member-service rearchitecture (v0.5.3 → v0.8.0).

Fixes: #96
Jira: [LFXV2-2151](https://linuxfoundation.atlassian.net/browse/LFXV2-2151)

## Changes

### Removed tools
- `list_project_tiers` and `get_project_tier` — tier type not yet in the Query Service indexer contract; no viable target
- `list_b2b_org_memberships` — folded into `search_members` via new `b2b_org_uid` filter

### Fixed / rewritten tools
- **`search_b2b_orgs`** — rewritten to use `QuerySvc.QueryResources` (type `b2b_org`) instead of the removed `ListB2bOrgs` member service endpoint
- **`search_members`** — rewritten to use `QuerySvc.QueryResources` (type `project_membership`); adds `b2b_org_uid` filter (replaces removed tool), `tier_name` filter, and `active_only` flag (default `true`)
- **Key contact write tools** — updated for renamed methods and changed payload fields in v0.8.0 (`CreateKeyContact`, `UpdateKeyContact`, `DeleteKeyContact`, `GetKeyContact`)
- **`get_membership_key_contacts`** — `ListMembershipKeyContacts` removed in v0.8.0; rewritten to use Query Service (type `key_contact`)

### Bug fixes discovered during validation
- `tier_name` filter was wired to `data.tier` (an employee-count range like `"1 - 300"`); fixed to use `data.tier_name` (human-readable label like `"Silver ISV Member"`)
- `data.tier` renamed to `data.tier_range` in MCP output to avoid confusion
- `data.project_sfid` hidden from MCP output (internal Salesforce ID)

### Infrastructure
- Fixes member service client base URL in `internal/lfxv2/client.go` (the `/members` suffix was silently discarded by Goa anyway)
- Bumps `lfx-v2-member-service` to v0.8.0

## Testing
- `make check` passes
- `./scripts/test_server.sh` passes

---
🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[LFXV2-2151]: https://linuxfoundation.atlassian.net/browse/LFXV2-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ