### PR TITLE
feat(tools): route social listening questions to query_lfx_lens

### DIFF
--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -46,6 +46,10 @@ Always use this tool for:
   IMPORTANT: activities data (contributors, PRs, code contributions etc) not involving maintainers should use query_lfx_semantic_layer.
 - Maintainer time series and trends (the maintainer model lacks good time granularity)
 - Event sponsorships (the semantic layer should be used for events and event registration data not related to sponsorships)
+- Social listening: mentions of a project on social media and the web (Twitter/X, Bluesky, Reddit, Hacker News, DEV,
+  Podcasts, YouTube, LinkedIn, TikTok), sentiment, share of voice by platform, and author reach/followers
+  (e.g. "how is Kubernetes trending on social media?", "sentiment split of our mentions last month").
+  The semantic layer has no social listening data.
 
 Also use this tool for:
 - Open-ended or exploratory analysis (e.g. "which projects need attention?", "contribution overview")
@@ -70,7 +74,7 @@ Tips:
 // QueryLFXLensArgs defines the input for query_lfx_lens.
 type QueryLFXLensArgs struct {
 	ProjectSlug string `json:"project_slug" jsonschema:"Project slug from search_projects (e.g. 'cncf') (required)"`
-	Input       string `json:"input" jsonschema:"Natural language question. Use for maintainer names/trends, open-ended analysis, subproject questions, cross-domain joins, and exploratory questions. Contributor, activity and membership questions belong to the semantic layer. Takes 15-30s. (required)"`
+	Input       string `json:"input" jsonschema:"Natural language question. Use for maintainer names/trends, social listening (mentions/sentiment/reach), open-ended analysis, subproject questions, cross-domain joins, and exploratory questions. Contributor, activity and membership questions belong to the semantic layer. Takes 15-30s. (required)"`
 }
 
 type lensWorkflowAdditional struct {


### PR DESCRIPTION
## Summary

The Lens MCP agent is gaining a social listening semantic model (linuxfoundation/lfx-lens#29, backed by linuxfoundation/lf-dbt#2713) covering Octolens mentions: volume, sentiment, platform share of voice, and author follower reach.

The semantic layer has no social listening data, so this adds social listening to the `query_lfx_lens` tool description's "always use this tool" list and to the `input` field guidance, so client LLMs route those questions to Lens instead of the semantic layer.

## Rollout order

Merge after linuxfoundation/lf-dbt#2713 and linuxfoundation/lfx-lens#29 land and the semantic model sync runs — until then the Lens agent will answer social listening questions with "not in my catalog".

## Test plan

- [x] `make build` passes
- [x] `go test ./internal/tools/...` passes
- [ ] After the lfx-lens rollout: end-to-end via local MCP server (`query_lfx_lens` with "how is Kubernetes trending on social media?")

🤖 Generated with [Claude Code](https://claude.com/claude-code)