### PR TITLE
ci: standardize MegaLinter and Go toolchain policy

### DIFF
--- a/.github/workflows/ko-build-main.yaml
+++ b/.github/workflows/ko-build-main.yaml
@@ -20,8 +20,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
@@ -30,10 +32,11 @@ jobs:
       - name: Build and publish lfx-mcp-server image
         env:
           VERSION: development-${{ github.sha }}
+          SHA: ${{ github.sha }}
         run: |
           ko build github.com/linuxfoundation/lfx-mcp/cmd/lfx-mcp-server \
             -B \
             --platform linux/amd64,linux/arm64 \
-            -t ${{ github.sha }} \
+            -t "${SHA}" \
             -t development \
             --sbom spdx

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -31,15 +31,17 @@ jobs:
       image_name: ${{ steps.build.outputs.image_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Prepare versions
         id: prepare
         run: |
           set -euo pipefail
-          APP_VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          APP_VERSION="${GITHUB_REF_NAME#v}"
           CHART_NAME="$(yq '.name' charts/*/Chart.yaml)"
-          CHART_VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          CHART_VERSION="${GITHUB_REF_NAME#v}"
           {
             echo "app_version=$APP_VERSION"
             echo "chart_name=$CHART_NAME"
@@ -47,9 +49,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Setup Ko
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
@@ -60,13 +63,14 @@ jobs:
         id: build
         env:
           VERSION: ${{ github.ref_name }}
+          APP_VERSION: ${{ steps.prepare.outputs.app_version }}
         run: |
           set -euo pipefail
           ko build github.com/linuxfoundation/lfx-mcp/cmd/lfx-mcp-server \
             -B \
             --platform linux/amd64,linux/arm64 \
-            -t ${{ github.ref_name }} \
-            -t ${{ steps.prepare.outputs.app_version }} \
+            -t "${VERSION}" \
+            -t "${APP_VERSION}" \
             -t latest \
             --sbom spdx \
             --image-refs /tmp/image-refs.txt
@@ -92,9 +96,11 @@ jobs:
       - name: Sign the container image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: ${{ steps.build.outputs.image_name }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
-          cosign sign --yes '${{ steps.build.outputs.image_name }}@${{ steps.build.outputs.digest }}'
+          cosign sign --yes "${IMAGE_NAME}@${DIGEST}"
 
   release-helm-chart:
     needs:
@@ -109,12 +115,14 @@ jobs:
       image_name: ${{ steps.publish-ghcr.outputs.image_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Publish Chart to GHCR
         id: publish-ghcr
         # yamllint disable-line rule:line-length
-        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@17e4144d7ba68f7c3e8c16eece5aed15fd7c2dc8 # main
+        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@a93335d2abc2a2e2bb1b7a4cdefbbf15351681ce # v0.1.0
         with:
           name: ${{ needs.publish.outputs.chart_name }}
           repository: ${{ github.repository }}/chart
@@ -140,9 +148,11 @@ jobs:
       - name: Sign the Helm chart in GHCR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: ${{ steps.publish-ghcr.outputs.image_name }}
+          DIGEST: ${{ steps.publish-ghcr.outputs.digest }}
         run: |
           set -euo pipefail
-          cosign sign --yes '${{ steps.publish-ghcr.outputs.image_name }}@${{ steps.publish-ghcr.outputs.digest }}'
+          cosign sign --yes "${IMAGE_NAME}@${DIGEST}"
 
   create-ghcr-helm-provenance:
     needs:
@@ -151,7 +161,7 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ${{ needs.release-helm-chart.outputs.image_name }}
       digest: ${{ needs.release-helm-chart.outputs.digest }}
@@ -166,7 +176,7 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       image: ${{ needs.publish.outputs.image_name }}
       digest: ${{ needs.publish.outputs.digest }}

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -12,4 +12,4 @@ permissions:
 jobs:
   license-header-check:
     name: License Header Check
-    uses: linuxfoundation/lfx-public-workflows/.github/workflows/license-header-check.yml@main
+    uses: linuxfoundation/lfx-public-workflows/.github/workflows/license-header-check.yml@a93335d2abc2a2e2bb1b7a4cdefbbf15351681ce # v0.1.0

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -37,6 +37,10 @@ jobs:
         # `megalinter` target in the Makefile.
         uses: oxsecurity/megalinter/flavors/go@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc  # v9.6.0
         env:
+          # Only Actions-specific values (secrets, runner behavior) belong
+          # here. Generic MegaLinter/repo config belongs in .mega-linter.yml
+          # so local runs (e.g. mega-linter-runner) get the same behavior.
+          #
           # All available variables are described in documentation
           # https://megalinter.io/latest/configuration/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -25,18 +25,23 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # MegaLinter
       - name: MegaLinter
         id: ml
-        # Use the Go flavor.
-        uses: oxsecurity/megalinter/flavors/go@62c799d895af9bcbca5eacfebca29d527f125a57  # 9.1.0
+        # Use the Go flavor. Keep this version in sync with the
+        # `megalinter` target in the Makefile.
+        uses: oxsecurity/megalinter/flavors/go@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc  # v9.6.0
         env:
           # All available variables are described in documentation
-          # https://megalinter.io/configuration/
+          # https://megalinter.io/latest/configuration/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Allow GITHUB_TOKEN for working around rate limits (aquasecurity/trivy#7668).
           REPOSITORY_TRIVY_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN
+          # zizmor's "artipacked" audit needs the GitHub API (to verify
+          # SHA-pinned action tags), which requires GITHUB_TOKEN.
+          ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,6 +534,45 @@ The SDK handles most protocol-level errors automatically. Tool implementation sh
 6. **Documentation**: Update README.md for user-facing changes
 7. **Code Quality**: Run `make check` before commits
 8. **Package Comments**: Every new `*.go` file must include a `// Package <name> ...` doc comment immediately above the `package` declaration (required by Megalinter's revive `package-comments` rule)
+9. **Go toolchain version**: Freely bump `go.mod`'s `go` directive to the
+   latest available *patch* release (e.g. `1.X.Y` → `1.X.{Y+1}`) to pick up
+   security fixes. Do **not** bump the *minor* version (e.g. `1.X.x` →
+   `1.{X+1}.x`) unless the user explicitly asks for it, **and** you've
+   validated it against the Go version MegaLinter itself bundles --
+   MegaLinter runs several linters (e.g. `golangci-lint`) against its own
+   bundled Go version, and a `go.mod` directive newer than that bundled
+   version breaks those checks.
+
+   To find MegaLinter's bundled Go version:
+
+   ```bash
+   # 1. Find the MegaLinter flavor and pinned version tag used in CI.
+   grep -A1 'oxsecurity/megalinter' .github/workflows/*.yml
+   # e.g. "uses: oxsecurity/megalinter/flavors/<flavor>@<sha>  # <tag>"
+
+   # 2. Fetch that flavor's Dockerfile and read its GO_ALPINE_VERSION (or
+   #    GO_IMAGE_VERSION) build arg.
+   curl -s "https://raw.githubusercontent.com/oxsecurity/megalinter/<tag>/flavors/<flavor>/Dockerfile" \
+     | grep -i 'GO_ALPINE_VERSION\|GO_IMAGE_VERSION'
+   ```
+
+   `go.mod`'s `go` directive must never exceed that bundled version. Staying
+   one minor version behind it (rather than matching its minor *and* patch
+   exactly) leaves room to always take the latest patch release for security
+   fixes without ever being blocked by MegaLinter's own bundled patch version
+   lagging behind a newly disclosed vulnerability.
+
+   There's no built-in `go` subcommand to look up the latest patch release
+   for a given minor version -- query the official `go.dev/dl` JSON feed
+   instead:
+
+   ```bash
+   # Find the latest patch release for the minor version pinned in go.mod.
+   MINOR=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)
+   curl -s "https://go.dev/dl/?mode=json&include=all" \
+     | jq -r --arg m "go${MINOR}." '.[].version | select(startswith($m))' \
+     | sort -V | tail -1
+   ```
 
 ## Release Process
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,45 +534,56 @@ The SDK handles most protocol-level errors automatically. Tool implementation sh
 6. **Documentation**: Update README.md for user-facing changes
 7. **Code Quality**: Run `make check` before commits
 8. **Package Comments**: Every new `*.go` file must include a `// Package <name> ...` doc comment immediately above the `package` declaration (required by Megalinter's revive `package-comments` rule)
-9. **Go toolchain version**: Freely bump `go.mod`'s `go` directive to the
-   latest available *patch* release (e.g. `1.X.Y` → `1.X.{Y+1}`) to pick up
-   security fixes. Do **not** bump the *minor* version (e.g. `1.X.x` →
-   `1.{X+1}.x`) unless the user explicitly asks for it, **and** you've
-   validated it against the Go version MegaLinter itself bundles --
-   MegaLinter runs several linters (e.g. `golangci-lint`) against its own
-   bundled Go version, and a `go.mod` directive newer than that bundled
-   version breaks those checks.
+9. **Go toolchain version**: See [Go Toolchain Version](#go-toolchain-version) below.
 
-   To find MegaLinter's bundled Go version:
+## Go Toolchain Version
 
-   ```bash
-   # 1. Find the MegaLinter flavor and pinned version tag used in CI.
-   grep -A1 'oxsecurity/megalinter' .github/workflows/*.yml
-   # e.g. "uses: oxsecurity/megalinter/flavors/<flavor>@<sha>  # <tag>"
+Freely bump `go.mod`'s `go` directive to the latest available *patch*
+release (e.g. `1.X.Y` → `1.X.{Y+1}`) to pick up security fixes. Do **not**
+bump the *minor* version (e.g. `1.X.x` → `1.{X+1}.x`) unless the user
+explicitly asks for it, **and** you've validated it against the Go version
+MegaLinter itself bundles -- MegaLinter's `golangci-lint` and `govulncheck`
+(pulled in via its `osv-scanner` check) are guaranteed to lag behind the
+latest Go release by some amount (their binaries are built against
+whatever Go version was current when that MegaLinter flavor tag was cut),
+and a `go.mod` directive newer than what they were built with breaks them
+outright. This is a hard ceiling with no environment-variable workaround --
+`GOTOOLCHAIN: auto` only affects invocations of the `go` command itself
+and does nothing for these precompiled binaries' own internal version
+checks (confirmed empirically: setting it in both the workflow and
+`.mega-linter.yml` still failed).
 
-   # 2. Fetch that flavor's Dockerfile and read its GO_ALPINE_VERSION (or
-   #    GO_IMAGE_VERSION) build arg.
-   curl -s "https://raw.githubusercontent.com/oxsecurity/megalinter/<tag>/flavors/<flavor>/Dockerfile" \
-     | grep -i 'GO_ALPINE_VERSION\|GO_IMAGE_VERSION'
-   ```
+To find MegaLinter's bundled Go version:
 
-   `go.mod`'s `go` directive must never exceed that bundled version. Staying
-   one minor version behind it (rather than matching its minor *and* patch
-   exactly) leaves room to always take the latest patch release for security
-   fixes without ever being blocked by MegaLinter's own bundled patch version
-   lagging behind a newly disclosed vulnerability.
+```bash
+# 1. Find the MegaLinter flavor and pinned version tag used in CI.
+grep -A1 'oxsecurity/megalinter' .github/workflows/*.yml
+# e.g. "uses: oxsecurity/megalinter/flavors/<flavor>@<sha>  # <tag>"
 
-   There's no built-in `go` subcommand to look up the latest patch release
-   for a given minor version -- query the official `go.dev/dl` JSON feed
-   instead:
+# 2. Fetch that flavor's Dockerfile and read its GO_ALPINE_VERSION build
+#    arg -- this is what the final image installs as `go`, not
+#    GO_IMAGE_VERSION (which only applies to an intermediate builder
+#    stage).
+curl -s "https://raw.githubusercontent.com/oxsecurity/megalinter/<tag>/flavors/<flavor>/Dockerfile" \
+  | grep -i 'GO_ALPINE_VERSION'
+```
 
-   ```bash
-   # Find the latest patch release for the minor version pinned in go.mod.
-   MINOR=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)
-   curl -s "https://go.dev/dl/?mode=json&include=all" \
-     | jq -r --arg m "go${MINOR}." '.[].version | select(startswith($m))' \
-     | sort -V | tail -1
-   ```
+`go.mod`'s `go` directive must never exceed that bundled version. Staying
+one minor version behind it (rather than matching its minor *and* patch
+exactly) leaves room to always take the latest patch release for security
+fixes without ever being blocked by MegaLinter's own bundled patch version
+lagging a newly disclosed vulnerability.
+
+There's no built-in `go` subcommand to look up the latest patch release for
+a given minor version -- query the official `go.dev/dl` JSON feed instead:
+
+```bash
+# Find the latest patch release for the minor version pinned in go.mod.
+MINOR=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)
+curl -s "https://go.dev/dl/?mode=json&include=all" \
+  | jq -r --arg m "go${MINOR}." '.[].version | select(startswith($m))' \
+  | sort -V | tail -1
+```
 
 ## Release Process
 

--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,11 @@ ko-build:
 	@echo "Building ko image..."
 	KO_DOCKER_REPO=$(DOCKER_IMAGE) VERSION=$(VERSION) ko build -L --bare --tags local ./cmd/lfx-mcp-server
 
-# Run MegaLinter locally via Docker (matches CI Go flavor at v9).
+# Run MegaLinter locally via Docker (matches CI Go flavor at v9.6.0).
+# Keep this version in sync with .github/workflows/mega-linter.yml.
 megalinter:
-	docker pull oxsecurity/megalinter-go:v9
-	docker run --rm --platform linux/amd64 -v '$(CURDIR):/tmp/lint:rw' oxsecurity/megalinter-go:v9
+	docker pull ghcr.io/oxsecurity/megalinter-go:v9.6.0
+	docker run --rm --platform linux/amd64 -v '$(CURDIR):/tmp/lint:rw' ghcr.io/oxsecurity/megalinter-go:v9.6.0
 
 # Show help
 help:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 module github.com/linuxfoundation/lfx-mcp
 
-go 1.26.4
+go 1.26.3
 
 require (
 	github.com/knadh/koanf/providers/basicflag v1.1.0


### PR DESCRIPTION
## Summary

Applies the MegaLinter/GitHub Actions security baseline standardization from `linuxfoundation/lfx-cli` to this repo, per LFXV2-3338.

- Upgrade MegaLinter go flavor from v9.1.0 to v9.6.0 (SHA-pinned), add `persist-credentials: false` and pin checkout to v6.0.3.
- Add `ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN` so zizmor's artipacked audit can verify SHA-pinned action tags.
- Keep the `Makefile` `megalinter` target's Docker image tag in sync with the pinned v9.6.0 version.
- Document the Go toolchain minor-version policy in `AGENTS.md` (stay one minor version behind MegaLinter's bundled Go version), mirroring `lfx-cli`.
- Fix zizmor `template-injection`, `unpinned-uses`, `artipacked`, `cache-poisoning`, and `ref-version-mismatch` findings in `ko-build-main.yaml`/`ko-build-tag.yaml` (move untrusted `${{ }}` expansions into quoted `env:` vars, pin `slsa-github-generator` and `lfx-public-workflows` refs to SHAs with correct version comments).
- Re-pin `license-header-check.yml` and the `helm-chart-oci-publisher` action to `lfx-public-workflows`' new `v0.1.0` tag (SHA-pinned) instead of the moving `main` ref.
- Add an `env:` hygiene comment to `mega-linter.yml` clarifying that only Actions-specific values belong there vs. `.mega-linter.yml`.
- Correct `go.mod`'s `go` directive from `1.26.4` to `1.26.3` — MegaLinter v9.6.0's `go` flavor Dockerfile pins `GO_ALPINE_VERSION=1.26.3-r0`, which is a hard ceiling for its bundled `golangci-lint`/`govulncheck` binaries.

## Known follow-up

Per the corrected policy, `go.mod` should ideally stay one full minor version *behind* MegaLinter's bundled ceiling (i.e. `1.25.x`), not just at the ceiling. That's still blocked here: `github.com/linuxfoundation/lfx-v2-member-service`'s latest released tag (`v0.9.0`) requires `go >=1.26.0`. A fix is in flight upstream ([lfx-v2-member-service#95](https://github.com/linuxfoundation/lfx-v2-member-service/pull/95), open, not yet merged/tagged) — once that merges and this repo bumps the dependency, `go.mod` can drop to `1.25.x`.

Separately, MegaLinter's `osv-scanner` check currently fails (pre-existing, reproduces identically on `main`/the prior commit of this branch): it flags the pinned `go.mod` stdlib version against newer OSV-listed CVE fixes (e.g. wants `>=1.26.4`/`1.26.6`), which directly conflicts with the `1.26.3` ceiling imposed by MegaLinter's own bundled `golangci-lint`/`govulncheck` binaries for this MegaLinter version tag. No `go.mod` value satisfies both constraints simultaneously; not addressed in this PR.

## Jira

LFXV2-3338

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)
