### PR TITLE
fix(tools): clarify semantic scope and time windows

### DIFF
--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -55,6 +55,8 @@ Important: contributor, activity and membership questions belong to the semantic
 
 Use search_projects first to find the project slug.
 
+WINDOW — "last 12 months" means the 365 complete UTC days before today: [UTC today-365d, UTC today), excluding today and never data-max anchored. State inclusive dates plus the exclusive UTC anchor.
+
 This tool runs synchronously. Queries take 15–30 seconds — please wait for the result without retrying.
 Tips:
 - This tool returns at most 200 rows per request. If you need more results, explicitly request pagination, for example "page 2", "next 200 rows", or "use LIMIT/OFFSET pagination with a stable ORDER BY" (e.g. all registrations for an event).`,

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -61,6 +61,31 @@ func TestAllLensToolDescriptionsFitBudget(t *testing.T) {
 	}
 }
 
+// TestDataToolDescriptionsShareLastTwelveMonthsConvention guards RC-2. Lens
+// and the two semantic-layer tools must give the model one boundary convention,
+// and must require the answer to expose the concrete range so users can compare
+// results across tools.
+func TestDataToolDescriptionsShareLastTwelveMonthsConvention(t *testing.T) {
+	const convention = `"last 12 months" means the 365 complete UTC days before today: [UTC today-365d, UTC today), excluding today and never data-max anchored.`
+
+	for _, tc := range []struct {
+		name     string
+		register func(*mcp.Server)
+	}{
+		{"explore_lfx_semantic_layer", RegisterExploreSemanticLayer},
+		{"query_lfx_semantic_layer", RegisterQuerySemanticLayer},
+		{"query_lfx_lens", RegisterQueryLFXLens},
+	} {
+		desc := listRegisteredTool(t, tc.name, tc.register).Description
+		if !strings.Contains(desc, convention) {
+			t.Errorf("%s description does not carry the shared RC-2 convention", tc.name)
+		}
+		if !strings.Contains(desc, "State inclusive dates plus the exclusive UTC anchor") {
+			t.Errorf("%s description does not require a concrete date range and anchor", tc.name)
+		}
+	}
+}
+
 // listRegisteredTool returns the named tool, failing the test if it is absent.
 func listRegisteredTool(t *testing.T, name string, register func(*mcp.Server)) *mcp.Tool {
 	t.Helper()

--- a/internal/tools/semanticlayer.go
+++ b/internal/tools/semanticlayer.go
@@ -42,41 +42,47 @@ func SetSemanticLayerConfig(cfg *SemanticLayerConfig) {
 // QuerySemanticLayerArgs for why that distinction matters. Anything that still
 // does not fit belongs in the help action, whose output is a tool result and
 // carries no limit; help is a fallback for a failed query, not a prerequisite.
-const exploreSemanticLayerDescription = `The LFX Insights Semantic Layer is the query and data-exploration tool for Linux Foundation data. This half discovers what can be measured; query_lfx_semantic_layer runs it. Start here whenever you do not already know the exact metric, dimension and value names.
+const exploreSemanticLayerDescription = `The LFX Insights Semantic Layer discovers Linux Foundation metrics/dimensions; query_lfx_semantic_layer runs them. Start here unless exact names/values came from this tool.
 
-COVERS — search one of these topic words:
-- contributor, contribution — activity and org counts, commits, PRs
+COVERS — search a topic:
+- contributor, contribution — activity/org counts, commits, PRs
 - membership, revenue, churn — counts, discounts, invoices
-- event, registration, speaker — counts and revenue
+- event, registration, speaker — counts, revenue
 - enrollment, certification — education
-- maintainer — total and active counts
-- health, project — health scores, software value, cost
+- maintainer — total/active counts
+- health, project — scores, value, cost
 - any of the above sliced by country or region — always here, never query_lfx_lens
 
-A metric is the number measured (total_contributors); a dimension is how you slice, filter or list it (country__lf_region). Names are entity__field and the prefix differs per metric, so copy qualified_names from this tool rather than assembling one — country__lf_region is a person's country, activity_project_id__organization_lf_region an organization's HQ.
+A metric is measured; a dimension slices/filters it. Names are entity__field; prefixes vary by metric, so copy qualified_names from here, never guess. country__lf_region is a person's country; activity_project_id__organization_lf_region an organization's HQ.
+
+SCOPE COLLISION — Same literal, different populations: 'agentic-ai-foundation' with activity_project_id__project_slug selects one leaf/catch-all project; with activity_project_id__project_spine_slug it selects the conformed foundation rollup. Discover/copy qualified names; never guess. Prefer project_spine_slug for project-scoped questions; use segment_slug only for an explicit Insights-segment question.
 
 ACTIONS
-- list_metrics(search): searches metric names and descriptions only, so search a topic word above, not a dimension word like "country". When 15 or fewer match, each returns its dimension qualified_names — usually enough to query.
-- get_dimensions(metrics, search): dimensions available to those metrics; needs at least one. Passing several returns only the ones they share — what a cross-domain query can group by.
-- get_dimension_values(dimension, metrics, search): the literals a dimension holds. Call it before filtering on any value not already seen in output: an unknown literal returns zero rows, not an error, so a wrong guess reads as missing data. Spellings surprise — 'Asia Pacific' not 'APAC', 'Viet Nam' not 'Vietnam'.
-- help(target): worked query examples, for when a query fails.
+- list_metrics(search): names/descriptions by topic; up to 15 matches include dimension qualified_names.
+- get_dimensions(metrics, search): available dimensions; several metrics return only shared ones.
+- get_dimension_values(dimension, metrics, search): exact literals. Call before filtering unseen values: an unknown literal returns zero rows, not an error. 'Asia Pacific' not 'APAC'; 'Viet Nam' not 'Vietnam'.
+- help(target): worked queries.
 
-USE query_lfx_lens INSTEAD for questions that do not reduce to a metric above: narrative or "why", subprojects, maintainer trends, event sponsorships.`
+WINDOW — "last 12 months" means the 365 complete UTC days before today: [UTC today-365d, UTC today), excluding today and never data-max anchored. State inclusive dates plus the exclusive UTC anchor.
 
-const querySemanticLayerDescription = `The LFX Insights Semantic Layer is the query and data-exploration tool for Linux Foundation data; this half runs the query. Covers contributions, memberships, events, education, maintainers and project health — and anything sliced by country or region. ALWAYS call explore_lfx_semantic_layer first unless you already have the exact metric, dimension and entity names — never guess or assemble one: a wrong name errors, and a wrong filter value returns no rows rather than an error, so confirm literals with get_dimension_values. Use query_lfx_lens for narrative or "why" questions that do not reduce to a metric.
+USE query_lfx_lens INSTEAD for narrative/"why", subprojects, maintainer trends or event sponsorships.`
 
-  metrics (required): comma-separated names. List several to combine them in one result, even across domains — they are joined on the dimensions they have in common, the only set such a query can group by. The join is outer, so a group in only one domain still appears with NULL for the other.
-  group_by: dimension qualified_names, comma-separated, copied verbatim. Group by a name dimension for a ranked list of organizations, people or projects. For a trend add metric_time__year, or __quarter, __month, __week, __day.
-  where: MetricFlow filter; this does the filtering, including by project or foundation.
+const querySemanticLayerDescription = `The LFX Insights Semantic Layer runs metrics for contributions, memberships, events, education, maintainers, project health and country/region slices. ALWAYS call explore_lfx_semantic_layer first unless exact names/values came from it — never guess; confirm literals with get_dimension_values because a wrong value returns zero rows, not an error. Use query_lfx_lens for narrative/"why".
+
+  metrics (required): comma-separated. The join is outer on shared dimensions; a group in only one domain has NULL for the other. Group only by shared dimensions.
+  group_by: copied dimension qualified_names. Use a name dimension for a ranked list; add metric_time__year, __quarter, __month, __week or __day for trends.
+  where: MetricFlow filter; also sets project/foundation scope.
     categorical  {{ Dimension('country__lf_region') }} = 'Europe'
     time         {{ TimeDimension('asset_id__install_date', 'DAY') }} >= '2024-01-01'
     Dates are yyyy-mm-dd.
-  order_by: comma-separated; each field must also appear in group_by or metrics. Prefix - for descending.
-  limit: ceiling 500. Use 10-20 for top-N, 50-100 for full breakdowns.
+  order_by: fields also in group_by/metrics; prefix - for descending.
+  limit: ceiling 500. Use 10-20 for top-N, 50-100 for breakdowns.
 
-Queries are global by default. To restrict one to a project or foundation, put that filter in where — there is no separate scope parameter.
+SCOPE COLLISION — Same literal, different populations: 'agentic-ai-foundation' with activity_project_id__project_slug selects one leaf/catch-all project; with activity_project_id__project_spine_slug it selects the conformed foundation rollup. Discover/copy qualified names with explore_lfx_semantic_layer; never guess. Prefer project_spine_slug for project-scoped questions; use segment_slug only for an explicit Insights-segment question. Queries are global without a scope filter.
 
-Many metrics are pre-filtered — current_* is active-only, total_contributors excludes bots — so do not re-filter those. Entities listed with a metric are join keys, not group-by values: grouping by one returns raw IDs, so use the name dimension.`
+WINDOW — "last 12 months" means the 365 complete UTC days before today: [UTC today-365d, UTC today), excluding today and never data-max anchored. State inclusive dates plus the exclusive UTC anchor.
+
+Many metrics are pre-filtered — current_* is active-only, total_contributors excludes bots — do not re-filter them. Entities are join keys, not group-by values: grouping by one returns raw IDs; use a name dimension.`
 
 // The two semantic layer tools register independently so that LFXMCP_TOOLS can
 // select either by name. They are meant to be enabled together — each

--- a/internal/tools/semanticlayer_test.go
+++ b/internal/tools/semanticlayer_test.go
@@ -484,10 +484,10 @@ func TestExploreSemanticLayerDescription(t *testing.T) {
 		"returns zero rows, not an error",
 		"'Asia Pacific' not 'APAC'",
 		"'Viet Nam' not 'Vietnam'",
-		// Either tool can be loaded without the other, so each states what the
-		// semantic layer is. Here the regional rule sits in COVERS, asserted
-		// above, rather than in the opening line.
-		"query and data-exploration tool",
+		// Either tool can be loaded without the other, so each identifies the
+		// semantic layer and what this half does. Here the regional rule sits
+		// in COVERS, asserted above, rather than in the opening line.
+		"discovers Linux Foundation metrics/dimensions",
 	} {
 		if !strings.Contains(exploreSemanticLayerDescription, want) {
 			t.Errorf("explore description missing %q", want)
@@ -516,6 +516,35 @@ func TestExploreSemanticLayerDescription(t *testing.T) {
 	}
 }
 
+// TestSemanticLayerDescriptionsExplainScopeCollision guards RC-1. The two
+// activity dimensions accept many of the same literals but select different
+// populations, making a guessed dimension a silent wrong answer rather than a
+// query error. Both tools must carry the warning because either can be loaded
+// or selected without the other.
+func TestSemanticLayerDescriptionsExplainScopeCollision(t *testing.T) {
+	for name, desc := range map[string]string{
+		"explore_lfx_semantic_layer": exploreSemanticLayerDescription,
+		"query_lfx_semantic_layer":   querySemanticLayerDescription,
+	} {
+		for _, want := range []string{
+			"SCOPE COLLISION",
+			"Same literal, different populations",
+			"'agentic-ai-foundation' with activity_project_id__project_slug",
+			"selects one leaf/catch-all project",
+			"with activity_project_id__project_spine_slug",
+			"selects the conformed foundation rollup",
+			"Discover/copy qualified names",
+			"never guess",
+			"Prefer project_spine_slug for project-scoped questions",
+			"segment_slug only for an explicit Insights-segment question",
+		} {
+			if !strings.Contains(desc, want) {
+				t.Errorf("%s description missing RC-1 guidance %q", name, want)
+			}
+		}
+	}
+}
+
 // TestQuerySemanticLayerDescription checks the query tool is self-sufficient:
 // its own description carries the syntax, so a caller never has to call help
 // first.
@@ -538,8 +567,8 @@ func TestQuerySemanticLayerDescription(t *testing.T) {
 		// Both neighbours are named so routing works from this tool too.
 		"explore_lfx_semantic_layer",
 		"query_lfx_lens",
-		"query and data-exploration tool",
-		"anything sliced by country or region",
+		"The LFX Insights Semantic Layer",
+		"country/region slices",
 		// The silent-zero-rows warning is only actionable if it names the way
 		// out; without this the model retries the same wrong literal.
 		"get_dimension_values",


### PR DESCRIPTION
## Summary

- warn in both semantic-layer tool descriptions that activities'
  `project_slug` and `project_spine_slug` accept overlapping literals but
  select different populations; show a worked `agentic-ai-foundation` example
  using the exact qualified names, require discovery through
  `explore_lfx_semantic_layer`, and prefer the spine scope unless the question
  explicitly asks for an Insights segment
- align `query_lfx_lens` and both semantic-layer tools on one definition of
  "last 12 months": the 365 complete UTC days before today's UTC date,
  `[today-365d, today)`, excluding partial today and never data-max anchored;
  require answers to state inclusive dates plus the exclusive UTC anchor
- add regression tests for the RC-1 collision, the cross-tool RC-2 contract,
  and the existing 2048-byte description ceilings

Jira: [LFXV2-2891](https://linuxfoundation.atlassian.net/browse/LFXV2-2891)

## Evidence

The semantic-layer sibling live-verified RC-1 on 2026-08-28:
`agentic-ai-foundation` returned **39,693** activities through
`activity_project_id__project_slug` and **820,101** through
`activity_project_id__project_spine_slug` (~21x). The descriptions keep the
stable population distinction and qualified names, not the volatile counts.
The dbt-side definitions are in
[lf-dbt#2810](https://github.com/linuxfoundation/lf-dbt/pull/2810).

The Lens sibling confirmed in [lfx-lens#30](https://github.com/linuxfoundation/lfx-lens/pull/30) that its provenance patch preserves the existing HTTP response schema: `compiled_sql`, window, scope, and tables are labelled inside the existing `content` string. No lfx-mcp passthrough adapter is needed.

This is stacked on #111 because `internal/tools/semanticlayer.go` is introduced
there. Retarget to `main` after #111 merges.

## Human decisions requested

### Window convention — Josep sign-off requested

Please explicitly approve the shared convention before merge. With a
2026-08-28 UTC anchor it displays **2025-08-28 through 2026-08-27**, with
**2026-08-28 UTC exclusive**. This is a product choice, not an implementation
necessity; the Lens workflow patch uses the same boundary.

### Optional runtime guard — proposal only, not shipped here

A follow-up could append a second content-block note whenever a semantic query's
`where` uses `activity_project_id__project_slug`, reminding the model that this
is leaf scope and pointing to `project_spine_slug` for a foundation rollup. It
would cost no description bytes and fire at the mistake site, like the existing
slug-lookup note.

I did **not** ship it in this patch: leaf scope is sometimes intentional, and a
string-level MetricFlow filter detector would be brittle unless we define the
accepted patterns. Josep: should we implement this targeted result note in a
follow-up, or keep the warning description-only?

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `make vet`
- [x] `revive -set_exit_status ./...`
- [x] `golangci-lint run ./...`
- [x] real stdio MCP `tools/list` check: all RC-1/RC-2 guidance visible
- [x] description budgets: explore 2014/2048 bytes; semantic query 1997/2048;
      Lens query 1829/2048
- [x] semantic registration gate remains `canRead && isStaff`; `main.go` is
      untouched
- [ ] `make megalinter` — local Docker daemon is unavailable; all changed files
      are Go and the matching local Go linters above pass

🤖 AI-assisted implementation


[LFXV2-2891]: https://linuxfoundation.atlassian.net/browse/LFXV2-2891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
