### PR TITLE
fix(tools): clarify Lens project context

### DIFF
--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -59,11 +59,9 @@ Also use this tool for:
 
 Important: contributor, activity and membership questions belong to the semantic layer — explore_lfx_semantic_layer then query_lfx_semantic_layer.
 
-Use search_projects first to find the project slug.
+project_slug is required default context, NOT a scope boundary. Find it via search_projects. For multiple foundations, pass one slug and name the others in input: "compare cncf with lf-ai-foundation and openssf". LF-wide: use project_slug='tlf' (The Linux Foundation).
 
-This tool runs synchronously. Queries take 15–30 seconds — please wait for the result without retrying.
-Tips:
-- This tool returns at most 200 rows per request. If you need more results, explicitly request pagination, for example "page 2", "next 200 rows", or "use LIMIT/OFFSET pagination with a stable ORDER BY" (e.g. all registrations for an event).`,
+Runs synchronously; wait 15–30 seconds without retrying. Returns ≤200 rows; request explicit pagination ("page 2", "next 200 rows", or stable ORDER BY with LIMIT/OFFSET).`,
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Query LFX Lens",
 			ReadOnlyHint: true,
@@ -73,7 +71,7 @@ Tips:
 
 // QueryLFXLensArgs defines the input for query_lfx_lens.
 type QueryLFXLensArgs struct {
-	ProjectSlug string `json:"project_slug" jsonschema:"Project slug from search_projects (e.g. 'cncf') (required)"`
+	ProjectSlug string `json:"project_slug" jsonschema:"Required default context slug from search_projects, not a scope boundary. For multiple foundations, pass one here and name the others in input; use 'tlf' for LF-wide questions."`
 	Input       string `json:"input" jsonschema:"Natural language question. Use for maintainer names/trends, social listening (mentions/sentiment/reach), open-ended analysis, subproject questions, cross-domain joins, and exploratory questions. Contributor, activity and membership questions belong to the semantic layer. Takes 15-30s. (required)"`
 }
 

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -720,6 +720,46 @@ func TestHelpActionAndDescribeAlias(t *testing.T) {
 	}
 }
 
+// TestQueryLFXLensScopeIsContextNotBoundary pins the staff-only cross-project
+// contract. project_slug remains required as a default context for the Lens
+// workflow, but it must not be described as an authorization or scope boundary.
+func TestQueryLFXLensScopeIsContextNotBoundary(t *testing.T) {
+	tool := listRegisteredTool(t, "query_lfx_lens", RegisterQueryLFXLens)
+
+	for _, want := range []string{
+		"project_slug is required default context, NOT a scope boundary",
+		"Find it via search_projects",
+		"For multiple foundations",
+		"name the others in input",
+		"compare cncf with lf-ai-foundation and openssf",
+		"LF-wide",
+		"project_slug='tlf' (The Linux Foundation)",
+	} {
+		if !strings.Contains(tool.Description, want) {
+			t.Errorf("query_lfx_lens description missing scope guidance %q", want)
+		}
+	}
+
+	required := schemaRequired(t, tool)
+	for _, want := range []string{"project_slug", "input"} {
+		if !contains(required, want) {
+			t.Errorf("query_lfx_lens required = %v; expected %s to remain compulsory", required, want)
+		}
+	}
+
+	slug := schemaPropertyDescription(t, tool, "project_slug")
+	for _, want := range []string{
+		"Required default context slug",
+		"not a scope boundary",
+		"name the others in input",
+		"'tlf' for LF-wide questions",
+	} {
+		if !strings.Contains(slug, want) {
+			t.Errorf("project_slug schema description missing %q: %q", want, slug)
+		}
+	}
+}
+
 // TestQueryLFXLensDoesNotClaimMemberships guards the other half of the routing
 // contract. query_lfx_lens used to open with "Always use this tool for:
 // Membership questions", carved out only for country/region. Memberships now


### PR DESCRIPTION
## Summary

- keep `query_lfx_lens.project_slug` compulsory while clarifying that it supplies default context rather than a scope boundary
- document multi-foundation questions: pass one default slug and name the other foundation slugs in the natural-language `input`
- document LF-wide questions with the live-verified `project_slug='tlf'`
- preserve every existing routing carve-out and all handler/multipart payload behavior
- pin the required schema and new description contract in tests while remaining under the 2048-byte budget

## Deploy order

**[lfx-lens PR #32](https://github.com/linuxfoundation/lfx-lens/pull/32) must merge and deploy first.** Until Lens disables single-slug backend enforcement for MCP sessions, this wording would over-promise multi-foundation and LF-wide behavior. Do not merge/deploy this PR before that companion is live.

## Test plan

- [x] `go test ./internal/tools`
- [x] `make fmt`
- [x] `make vet`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] verify `query_lfx_lens` description is 2040/2048 bytes with no literal tabs
- [x] verify `query_lfx_lens` retains the `canRead && isStaff` registration gate
- [x] verify the diff does not change `QueryLFXLensArgs` fields/requiredness, handler logic, or multipart request wiring
