### PR TITLE
feat: eval-verified semantic-layer guidance, doctrine help, and lens stdio fix

### DIFF
--- a/internal/tools/committee.go
+++ b/internal/tools/committee.go
@@ -60,7 +60,7 @@ func RegisterSearchCommittees(server *mcp.Server, asGroups bool) {
 	if asGroups {
 		mcp.AddTool(server, &mcp.Tool{
 			Name:        "search_groups",
-			Description: "Search for LFX groups (also called committees) by name using the LFX query service. Optionally filter by project UID.",
+			Description: "Search for LFX groups (also called committees) by name using the LFX query service. Optionally filter by project UID. Groups are the system of record for governance bodies - boards, TOCs/TACs, working groups, ambassador programs. Prefer this over the semantic layer or query_lfx_lens for who-sits-on-what and roster questions.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Search Groups",
 				ReadOnlyHint: true,
@@ -70,7 +70,7 @@ func RegisterSearchCommittees(server *mcp.Server, asGroups bool) {
 	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_committees",
-		Description: "Search for LFX committees by name using the LFX query service. Optionally filter by project UID.",
+		Description: "Search for LFX committees by name using the LFX query service. Optionally filter by project UID. Committees are the system of record for governance bodies - boards, TOCs/TACs, working groups, ambassador programs. Prefer this over the semantic layer or query_lfx_lens for who-sits-on-what and roster questions.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Committees",
 			ReadOnlyHint: true,
@@ -135,7 +135,7 @@ func RegisterSearchCommitteeMembers(server *mcp.Server, asGroups bool) {
 	if asGroups {
 		mcp.AddTool(server, &mcp.Tool{
 			Name:        "search_group_members",
-			Description: "Search for LFX group (also called committee) members. Optionally filter by group UID, project UID, and/or name. At least one filter is recommended but not required.",
+			Description: "Search for LFX group (also called committee) members. Optionally filter by group UID, project UID, and/or name. At least one filter is recommended but not required. The authoritative roster source - prefer over the semantic layer or query_lfx_lens for board/TOC/ambassador membership. For counts, paginate until page_token is absent; records carry organization, role and voting status but no country.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Search Group Members",
 				ReadOnlyHint: true,
@@ -145,7 +145,7 @@ func RegisterSearchCommitteeMembers(server *mcp.Server, asGroups bool) {
 	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_committee_members",
-		Description: "Search for LFX committee members. Optionally filter by committee UID, project UID, and/or name. At least one filter is recommended but not required.",
+		Description: "Search for LFX committee members. Optionally filter by committee UID, project UID, and/or name. At least one filter is recommended but not required. The authoritative roster source - prefer over the semantic layer or query_lfx_lens for board/TOC/ambassador membership. For counts, paginate until page_token is absent; records carry organization, role and voting status but no country.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Committee Members",
 			ReadOnlyHint: true,

--- a/internal/tools/committee_test.go
+++ b/internal/tools/committee_test.go
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+// Package tools provides MCP tool implementations for the LFX MCP server.
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestCommitteeToolsClaimGovernanceRosters guards the routing contract from
+// the committee side. The semantic-layer and lens descriptions redirect
+// governance-roster questions here; these descriptions must claim that
+// ownership in both terminology modes, or an agent arriving from the
+// redirect finds a tool that does not say it is the right one. The eval's
+// board/ambassador questions were answered "unavailable" or fabricated when
+// no surface named the committee tools as the roster source.
+func TestCommitteeToolsClaimGovernanceRosters(t *testing.T) {
+	for _, tc := range []struct {
+		toolName string
+		asGroups bool
+		register func(*mcp.Server)
+		wants    []string
+	}{
+		{
+			toolName: "search_committees",
+			register: func(s *mcp.Server) { RegisterSearchCommittees(s, false) },
+			wants: []string{
+				"system of record for governance bodies",
+				"boards, TOCs/TACs, working groups, ambassador programs",
+				"Prefer this over the semantic layer or query_lfx_lens",
+			},
+		},
+		{
+			toolName: "search_groups",
+			register: func(s *mcp.Server) { RegisterSearchCommittees(s, true) },
+			wants: []string{
+				"system of record for governance bodies",
+				"Prefer this over the semantic layer or query_lfx_lens",
+			},
+		},
+		{
+			toolName: "search_committee_members",
+			register: func(s *mcp.Server) { RegisterSearchCommitteeMembers(s, false) },
+			wants: []string{
+				"authoritative roster source",
+				"paginate until page_token is absent",
+				"no country",
+			},
+		},
+		{
+			toolName: "search_group_members",
+			register: func(s *mcp.Server) { RegisterSearchCommitteeMembers(s, true) },
+			wants: []string{
+				"authoritative roster source",
+				"paginate until page_token is absent",
+			},
+		},
+	} {
+		t.Run(tc.toolName, func(t *testing.T) {
+			tool := listRegisteredTool(t, tc.toolName, tc.register)
+			for _, want := range tc.wants {
+				if !strings.Contains(tool.Description, want) {
+					t.Errorf("%s description missing %q", tc.toolName, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -438,7 +438,18 @@ query_lfx_lens's lane.
 14. REGION LENSES. country__* dimensions follow the person (contributor);
 organization-side region analysis uses the organization_* dimensions
 (organization_lf_region etc.) - the organization's HQ country, not its
-contributors' countries.`
+contributors' countries.
+
+15. BOARDS, TOCs, TACs, AMBASSADORS. Governance and committee rosters (who
+sits on a board, who chairs a TOC/TAC, how many ambassadors a foundation
+has) live in the committee tools when they are available - search_committees
+to find the body (committees named 'Ambassadors', 'Governing Board',
+'Technical Advisory Board' etc. exist per project), then
+search_committee_members with its committee_uid, paginating until page_token
+is absent. They are NOT in this layer and not query_lfx_lens's lane. Member
+records carry name, organization, role and voting status but no country.
+Never infer a roster from membership tiers or event data - fabricated board
+seats have been reported as fact.`
 
 // lensHelpOverview is returned by help with no target.
 const lensHelpOverview = `LFX Insights Semantic Layer — how to use it

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -339,9 +339,11 @@ filed under a different spelling.`,
 const lensDoctrineHelp = `WORKED RECIPES AND CAVEATS - consult this before concluding the semantic layer cannot answer, and always before falling back to query_lfx_lens.
 
 1. DEFAULT WINDOW. When the asker gives no window, use the trailing 12 months
-and say so: {{ TimeDimension('metric_time','DAY') }} >= '<today minus 12
-months>' AND {{ TimeDimension('metric_time','DAY') }} < '<today>'. State the
-concrete dates in the answer.
+- the prior 365 complete UTC days - and say so:
+{{ TimeDimension('metric_time','DAY') }} >= '<today minus 365 days>' AND
+{{ TimeDimension('metric_time','DAY') }} < '<today>'. State the concrete
+dates in the answer, and pass the same concrete dates into any
+query_lfx_lens question so both lanes read the same window.
 
 2. MEMBERS AS OF A DATE D (the PCC-parity recipe): metric membership_count
 with where "{{ TimeDimension('metric_time','day') }} <= 'D' AND

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -449,7 +449,10 @@ search_committee_members with its committee_uid, paginating until page_token
 is absent. They are NOT in this layer and not query_lfx_lens's lane. Member
 records carry name, organization, role and voting status but no country.
 Never infer a roster from membership tiers or event data - fabricated board
-seats have been reported as fact.`
+seats have been reported as fact. Meetings likewise: schedules, occurrences,
+registrants, attendance and summaries live in the meeting tools
+(search_meetings, search_past_meetings and friends), not in this layer and
+not in query_lfx_lens.`
 
 // lensHelpOverview is returned by help with no target.
 const lensHelpOverview = `LFX Insights Semantic Layer — how to use it

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -333,9 +333,10 @@ filed under a different spelling.`,
 
 // lensDoctrineHelp is the overflow doctrine: every worked recipe and caveat
 // that does not fit the 2048-byte tool descriptions. It is a tool result, so
-// it carries no budget - keep it rich. Figures were verified live against the
-// deployed semantic layer in August 2026; treat them as illustrations of the
-// trap sizes, not as current data.
+// it carries no budget - keep it rich. The data is fluid, so the doctrine
+// carries no absolute figures: trap sizes are ratios measured live against
+// the deployed semantic layer in August 2026, and answers always come from
+// fresh queries.
 const lensDoctrineHelp = `WORKED RECIPES AND CAVEATS - consult this before concluding the semantic layer cannot answer, and always before falling back to query_lfx_lens.
 
 1. DEFAULT WINDOW. When the asker gives no window, use the trailing 12 months
@@ -347,18 +348,19 @@ query_lfx_lens question so both lanes read the same window.
 
 2. MEMBERS AS OF A DATE D (the PCC-parity recipe): metric membership_count
 with where "{{ TimeDimension('metric_time','day') }} <= 'D' AND
-{{ TimeDimension('asset_id__end_date','day') }} >= 'D'". Verified: CNCF as of
-2022-12-31 = 847. Today's active members: current_membership_count (CNCF =
-722, PCC-exact). New members: new_membership_count by install date - but any
-YTD/current-year count needs AND metric_time <= today, because installs can
-be future-dated (2026: 87 in the year bucket vs 77 up to today).
+{{ TimeDimension('asset_id__end_date','day') }} >= 'D'". Verified to
+reproduce PCC Health Metrics' member counts exactly; today's active members
+are current_membership_count. New members: new_membership_count by install
+date - but any YTD/current-year count needs AND metric_time <= today,
+because installs can be future-dated and the unbounded year bucket runs
+high.
 
 3. FOUNDATION SCOPE. {{ Dimension('project__foundation_slug') }} = '<slug>'
 is the conformed scope: the same filter works on every metric family and
 counts each row once. project_slug matches only a foundation's catch-all
-bucket (cncf: 1.4M activities vs 58M) - a silent undercount, never an error.
+bucket - a silent ~40x undercount on activities, never an error.
 activity_project_id__project_spine_slug returns identical activity counts
-(verified: CNCF 39,371,064 both ways) and is the tool for sub-foundation
+(verified) and is the tool for sub-foundation
 umbrella nodes and hierarchy walks: spine_hierarchy_level = 2 lists a
 foundation's direct children. Some families split across several Salesforce
 entities (risc-v-international/riscv, cff/cloud-foundry,
@@ -368,10 +370,10 @@ slug dimension and check for twins.
 4. BOTS. Bot exclusion is the LFX Insights default and is built into the
 contributor and activity metrics; adding {{
 Dimension('activity_project_id__member_is_bot') }} = false yourself is
-redundant but always safe. The gap this default closes is large (CNCF code
-contributions, trailing 12 months: 6,561,768 with bots vs 3,619,940
-without). bot_activities is the explicit bot view when bot traffic itself
-is the question.
+redundant but always safe. The gap this default closes is large - code
+contributions measured roughly 1.8x higher with bots than without on a
+large foundation. bot_activities is the explicit bot view when bot traffic
+itself is the question.
 
 5. ORG SHARES AND CONCENTRATION. Share of an org's work = ACTIVITY VOLUMES
 (e.g. code_contribution_activities by organization), never contributor
@@ -513,10 +515,10 @@ Foundation scope, any domain: filter
 
 This is the conformed lens: the same filter works on every metric family and
 counts each row once. NEVER scope a foundation with project_slug - the same
-'cncf' literal is 58M activities through the foundation lens but 1.4M through
-project_slug (its catch-all bucket): a silent undercount, not an error.
+'cncf' literal reaches ~40x fewer activities through project_slug (its
+catch-all bucket): a silent undercount, not an error.
 activity_project_id__project_spine_slug returns identical activity counts
-(verified: CNCF 39,371,064 both ways) and handles sub-foundation umbrella
+(verified) and handles sub-foundation umbrella
 nodes and hierarchy walks - spine_hierarchy_level = 2 lists a foundation's
 direct children. Keep the spine filter for sum metrics: insertions and
 deletions inflate 2-4x under non-hierarchical filters.

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -50,7 +50,7 @@ Everything else - contributors, activities, memberships, events and sponsorships
 
 project_slug is required default context, NOT a scope boundary. Find it via search_projects. For multiple foundations, pass one slug and name the others in input. LF-wide: use project_slug='tlf'.
 
-Runs synchronously; wait 15-30 seconds without retrying. Returns <=200 rows; request explicit pagination ("page 2", "next 200 rows", or stable ORDER BY with LIMIT/OFFSET).`,
+Runs synchronously; wait 15-30 seconds without retrying. Returns <=200 rows; request explicit pagination ("page 2", or stable ORDER BY with LIMIT/OFFSET). Windows: default trailing 12 months; state concrete yyyy-mm-dd dates or the SQL picks its own.`,
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Query LFX Lens",
 			ReadOnlyHint: true,

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -40,28 +40,17 @@ func RegisterQueryLFXLens(server *mcp.Server) {
 		Name: "query_lfx_lens",
 		Description: `Ask natural language questions about a project's data using ad-hoc SQL generation.
 
-Always use this tool for:
-- Maintainer names or maintainer+activities data joins, where activities data is the code activities model
-  with code contributions, PRs, commits etc (e.g. "top maintainers by contributions", "who maintains Kubernetes?").
-  IMPORTANT: activities data (contributors, PRs, code contributions etc) not involving maintainers should use query_lfx_semantic_layer.
-- Maintainer time series and trends (the maintainer model lacks good time granularity)
-- Event sponsorships (the semantic layer should be used for events and event registration data not related to sponsorships)
-- Social listening: mentions of a project on social media and the web (Twitter/X, Bluesky, Reddit, Hacker News, DEV,
-  Podcasts, YouTube, LinkedIn, TikTok), sentiment, share of voice by platform, and author reach/followers
-  (e.g. "how is Kubernetes trending on social media?", "sentiment split of our mentions last month").
-  The semantic layer has no social listening data.
+Use this tool ONLY for:
+- Maintainer x activity joins: contribution volumes attributed to maintainers (e.g. "top maintainers by contributions", "what share of work comes from maintainers", "is maintainer activity declining"). The semantic layer holds maintainer rosters and activity metrics but cannot join them at person grain.
+- Social listening: mentions of a project on social media and the web (Twitter/X, Bluesky, Reddit, Hacker News, DEV, Podcasts, YouTube, LinkedIn, TikTok), sentiment, share of voice by platform, and author reach/followers. The semantic layer has no social listening data.
 
-Also use this tool for:
-- Open-ended or exploratory analysis (e.g. "which projects need attention?", "contribution overview")
-- Questions involving subprojects (e.g. "maintainers per project", "health scores by project")
-- Cross-domain joins that the semantic layer cannot do (e.g. maintainers + activities)
-- Any question where query_lfx_semantic_layer is struggling or returning errors
+FALLBACK (the only other use): switch here when the semantic layer genuinely cannot express the question - but do not give up on it too fast. Genuine means you searched list_metrics with the right topic words, ran get_dimensions, checked get_dimension_values for your filter literals, consulted explore's help('doctrine') recipes, and tried at least two differently-formulated queries. Zero rows or an unknown-name error is NOT struggling: zero rows means a misspelled stored literal or the wrong scope dimension, an unknown name means you guessed instead of copying - both are fixed by discovery, not by switching tools. Fall back quickly only when no metric family covers the concept at all.
 
-Important: contributor, activity and membership questions belong to the semantic layer — explore_lfx_semantic_layer then query_lfx_semantic_layer.
+Everything else - contributors, activities, memberships, events and sponsorships, registrations, education, maintainer rosters/counts/names, health - belongs to explore_lfx_semantic_layer + query_lfx_semantic_layer.
 
-project_slug is required default context, NOT a scope boundary. Find it via search_projects. For multiple foundations, pass one slug and name the others in input: "compare cncf with lf-ai-foundation and openssf". LF-wide: use project_slug='tlf' (The Linux Foundation).
+project_slug is required default context, NOT a scope boundary. Find it via search_projects. For multiple foundations, pass one slug and name the others in input. LF-wide: use project_slug='tlf'.
 
-Runs synchronously; wait 15–30 seconds without retrying. Returns ≤200 rows; request explicit pagination ("page 2", "next 200 rows", or stable ORDER BY with LIMIT/OFFSET).`,
+Runs synchronously; wait 15-30 seconds without retrying. Returns <=200 rows; request explicit pagination ("page 2", "next 200 rows", or stable ORDER BY with LIMIT/OFFSET).`,
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Query LFX Lens",
 			ReadOnlyHint: true,
@@ -72,7 +61,7 @@ Runs synchronously; wait 15–30 seconds without retrying. Returns ≤200 rows; 
 // QueryLFXLensArgs defines the input for query_lfx_lens.
 type QueryLFXLensArgs struct {
 	ProjectSlug string `json:"project_slug" jsonschema:"Required default context slug from search_projects, not a scope boundary. For multiple foundations, pass one here and name the others in input; use 'tlf' for LF-wide questions."`
-	Input       string `json:"input" jsonschema:"Natural language question. Use for maintainer names/trends, social listening (mentions/sentiment/reach), open-ended analysis, subproject questions, cross-domain joins, and exploratory questions. Contributor, activity and membership questions belong to the semantic layer. Takes 15-30s. (required)"`
+	Input       string `json:"input" jsonschema:"Natural language question. Use for maintainer-contribution joins and social listening (mentions/sentiment/reach). Contributor, activity, membership, event, education and health questions belong to the semantic layer - explore it and consult its help('doctrine') before falling back here. Takes 15-30s. (required)"`
 }
 
 type lensWorkflowAdditional struct {
@@ -170,31 +159,33 @@ const exploreSemanticLayerDescription = `The LFX Insights Semantic Layer is the 
 COVERS — search one topic word:
 - contributor, contribution — activity/org counts, commits, PRs
 - membership, revenue, churn — counts, discounts, invoices
-- event, registration, speaker — counts and revenue
+- event, registration, speaker, sponsorship — counts and revenue
 - enrollment, certification — education
-- maintainer — total and active counts
+- maintainer — rosters (names), total and active counts
 - health, project — health scores, software value, cost
 - any of the above sliced by country or region — always here, never query_lfx_lens
 
-A metric is measured (total_contributors); a dimension slices, filters or lists it (country__lf_region). Names are entity__field and prefixes differ per metric, so copy qualified_names; never assemble them. country__lf_region is a person's country; activity_project_id__organization_lf_region is an organization's HQ.
+A metric is measured (total_contributors); a dimension slices, filters or lists it (country__lf_region). Names are entity__field and prefixes differ per metric, so copy qualified_names; never assemble them.
 
 ACTIONS
-- list_metrics(search): searches metric names/descriptions, so use a topic above, not a dimension like "country". At ≤15 matches, each includes dimension qualified_names.
+- list_metrics(search): searches metric names/descriptions, so use a topic above, not a dimension like "country". At <=15 matches, each includes dimension qualified_names.
 - get_dimensions(metrics, search): available dimensions; needs a metric. Several metrics return only shared dimensions—a cross-domain query's valid group_by set.
 - get_dimension_values(dimension, metrics, search): stored literals. Call before filtering on unseen values: an unknown returns zero rows, not an error. Spellings surprise—'Asia Pacific' not 'APAC', 'Viet Nam' not 'Vietnam'.
-- help(target): worked query examples after failure.
+- help('doctrine'): worked recipes - windows, as-of membership, bots, health, org shares, tiers, name discovery. ALWAYS call it before a query_lfx_lens fallback.
 
 Project scope lives in query's where clause (no parameter): resolve slugs via search_projects, then see query_lfx_semantic_layer for which dimension scopes each domain.
 
-USE query_lfx_lens INSTEAD for non-metric narrative/"why", subprojects, maintainer trends, event sponsorships.`
+USE query_lfx_lens INSTEAD only for maintainer-contribution joins, social listening, or - after discovery AND help('doctrine') have failed, never on a first empty result - a question this layer cannot express.`
 
-const querySemanticLayerDescription = `Metrics: contributions, memberships, events, education, maintainers, health, country/region. ALWAYS use explore_lfx_semantic_layer first unless exact names are known; never guess. query_lfx_lens: narrative/"why"/carve-outs.
+const querySemanticLayerDescription = `Metrics: contributions, memberships, events, sponsorships, education, maintainers, health, country/region. ALWAYS explore_lfx_semantic_layer first unless exact names are known; never guess.
 
-SYNTAX: metrics (required), CSV. Multiple metrics are outer-joined on shared dimensions; group_by only those; absent sides NULL. group_by qualified names: names for ranked lists; metric_time__year/quarter/month/week/day for trends; entities give raw IDs. where is MetricFlow: {{ Dimension('country__lf_region') }} = 'Europe'; {{ TimeDimension('metric_time','DAY') }} >= '2024-01-01'. Dates yyyy-mm-dd. order_by selected fields; - means descending. limit ceiling 500. current_* is active-only; total_contributors excludes bots—do not re-filter.
+SYNTAX: metrics (required), CSV. Multiple metrics outer-join on shared dims (group_by only those; absent sides NULL; '-metric' sorts NULLs FIRST - re-sort before top-N). group_by: names for ranked lists, metric_time__year/quarter/month trends. where is MetricFlow: {{ Dimension('country__lf_region') }} = 'Europe'; {{ TimeDimension('metric_time','DAY') }} >= '2024-01-01' (dates yyyy-mm-dd). limit ceiling 500. current_* is active-only.
 
-SCOPE: resolve slugs via search_projects first—stored slugs differ (Kubernetes='k8s', kernel='korg', PyTorch segment='ptproject'). Activities/contributions: {{ Dimension('activity_project_id__project_spine_slug') }} = '<slug>' selects project+descendants. It is the ONLY foundation scope (spine 'cncf'=58M activities; project_slug 'cncf'=1.4M) and REQUIRED for sums: insertions/deletions inflate 2–4x under any other filter. Memberships: asset_id__project_slug. Event registrations: registration_id__project_slug. Events/speakers/sponsorships have NO slug dimension: use event_id__project_name and the EXACT display name from get_dimension_values (e.g. 'Cloud Native Computing Foundation (CNCF)'). NEVER slice sponsorship metrics by asset_id__project_slug: one NULL row with all sponsorships. Maintainers: maintainer_key__cm_project_grandparents_slug; add is_lf_project=true to exclude non-LF. Health: health_metric_key__foundation_slug. Comparing: IN (...) + group_by the same dimension; never total across spine groups. 0 rows = misspelled literal—confirm with get_dimension_values.
+SCOPE: resolve slugs via search_projects. Foundation: {{ Dimension('project__foundation_slug') }} = '<slug>' - conformed, every domain, counts rows once. NEVER scope a foundation with project_slug - matches only its catch-all bucket: silent 40x undercount. Memberships: asset_id__project_slug. Registrations: registration_id__project_slug. Events/speakers: event_id__project_name (EXACT name). Maintainers: maintainer_key__cm_project_grandparents_slug + is_lf_project=true. 0 rows = misspelled literal - get_dimension_values first; org/account names are FULL LEGAL names (IBM = 'International Business Machines Corporation') - short-name searches miss them.
 
-WINDOWS: “last 12 months” = prior 365 complete UTC days: {{ TimeDimension('metric_time','DAY') }} >= start AND < today. YTD: >= 'YYYY-01-01'. Always state concrete dates used.`
+CONTRACT: compute shares/rankings yourself; state definition+window; default trailing 12 months, say so. Raw *_activities: add {{ Dimension('activity_project_id__member_is_bot') }} = false - the Insights default; always safe. total_contributors is code-only non-bot; _with_collaboration only when non-code participants are explicitly wanted. Org shares: use the org-attributed base (drop NULL/unaffiliated) and report that %. Economic/software value = total_software_value (COCOMO). Org headcounts run below published counts - caveat.
+
+WINDOWS: YTD needs AND <= today (installs can be future-dated). Active as of D: metric_time <= 'D' AND asset_id__end_date >= 'D' on membership_count. Struggling? help('doctrine') BEFORE query_lfx_lens - it has the recipes.`
 
 // The two semantic layer tools register independently so that LFXMCP_TOOLS can
 // select either by name. They are meant to be enabled together — each
@@ -244,10 +235,10 @@ func RegisterQuerySemanticLayer(server *mcp.Server) {
 // across the optional fields.
 type ExploreSemanticLayerArgs struct {
 	Action    string `json:"action" jsonschema:"Required. One of: list_metrics, get_dimensions, get_dimension_values, help. Use get_dimension_values before filtering on any value you have not seen in output: a where clause with a real dimension but an unknown literal returns zero rows instead of an error, so a wrong guess looks exactly like missing data."`
-	Search    string `json:"search,omitempty" jsonschema:"For list_metrics, a topic word ('contributor', 'membership', 'event', 'enrollment', 'maintainer', 'health'). For get_dimensions, the slice you are after, e.g. 'region', 'tier', 'name'. For get_dimension_values, a fragment of the value — keep it short, since the stored spelling often differs from the everyday one."`
+	Search    string `json:"search,omitempty" jsonschema:"For list_metrics, a topic word ('contributor', 'membership', 'event', 'sponsorship', 'enrollment', 'maintainer', 'health'). For get_dimensions, the slice you are after, e.g. 'region', 'tier', 'name'. For get_dimension_values, a fragment of the value — keep it short, since the stored spelling often differs from the everyday one."`
 	Metrics   string `json:"metrics,omitempty" jsonschema:"Comma-separated metric names. Required for get_dimensions and get_dimension_values; pass several to get_dimensions to see only the dimensions they share."`
 	Dimension string `json:"dimension,omitempty" jsonschema:"For action=get_dimension_values only: one dimension qualified_name, copied from get_dimensions (e.g. 'country__lf_region')."`
-	Target    string `json:"target,omitempty" jsonschema:"For action=help only: which action to get examples for (e.g. 'query'). Omit for an overview."`
+	Target    string `json:"target,omitempty" jsonschema:"For action=help only: 'doctrine' for the worked recipes and caveats, 'query' for query examples, or an action name. Omit for an overview. An unrecognised target returns the closest matching help rather than an error."`
 }
 
 // QuerySemanticLayerArgs defines the input for query_lfx_semantic_layer.
@@ -267,10 +258,10 @@ type ExploreSemanticLayerArgs struct {
 // through unchanged; they just are not the only copy.
 // TestCriticalGuidanceSurvivesSchemaCompaction guards that split.
 type QuerySemanticLayerArgs struct {
-	Metrics string `json:"metrics" jsonschema:"Required. Comma-separated metric names taken from explore_lfx_semantic_layer — never guessed. List several to combine them in one result, even across domains: they are outer-joined on the dimensions they share, so a group present in only one domain still appears with NULL for the other metric, and you can only group by dimensions they have in common. Many metrics are already filtered — current_* means active-only, total_contributors excludes bots — so do not repeat those conditions in where."`
+	Metrics string `json:"metrics" jsonschema:"Required. Comma-separated metric names taken from explore_lfx_semantic_layer — never guessed. List several to combine them in one result, even across domains: they are outer-joined on the dimensions they share, so a group present in only one domain still appears with NULL for the other metric, and you can only group by dimensions they have in common. Many metrics are already filtered — current_* means active-only, total_contributors excludes bots — so do not repeat those conditions in where. Group by dimension names, never bare entities - entities return raw IDs."`
 	GroupBy string `json:"group_by,omitempty" jsonschema:"Comma-separated dimension qualified_names, copied verbatim from explore_lfx_semantic_layer — they are entity__field and the prefix differs per metric. Group by a name dimension for a ranked list of organizations, people or projects; add metric_time__year (or __quarter, __month, __week, __day) for a trend."`
 	Where   string `json:"where,omitempty" jsonschema:"MetricFlow filter; this clause does the actual data filtering. Categorical: {{ Dimension('country__lf_region') }} = 'Europe'. Time: {{ TimeDimension('metric_time','DAY') }} >= '2024-01-01'. Dates are yyyy-mm-dd."`
-	OrderBy string `json:"order_by,omitempty" jsonschema:"Comma-separated sort fields. Each must also appear in group_by or metrics. Prefix with - for descending, e.g. -current_membership_revenue."`
+	OrderBy string `json:"order_by,omitempty" jsonschema:"Comma-separated sort fields. Each must also appear in group_by or metrics. Prefix with - for descending, e.g. -current_membership_revenue. In combined-metric results NULL rows sort first on a descending metric - re-sort client-side before reading a top-N."`
 	Limit   int    `json:"limit,omitempty" jsonschema:"Maximum rows to return, ceiling 500. Use 10-20 for top-N questions and 50-100 for full breakdowns."`
 }
 
@@ -336,8 +327,109 @@ unnormalized free text and holds both 'Viet Nam' and 'Vietnam' alongside
 entries like 'na', 'US' and 'Untied States'. Filtering on it drops members
 filed under a different spelling.`,
 
-	"query": lensQueryHelp,
+	"query":    lensQueryHelp,
+	"doctrine": lensDoctrineHelp,
 }
+
+// lensDoctrineHelp is the overflow doctrine: every worked recipe and caveat
+// that does not fit the 2048-byte tool descriptions. It is a tool result, so
+// it carries no budget - keep it rich. Figures were verified live against the
+// deployed semantic layer in August 2026; treat them as illustrations of the
+// trap sizes, not as current data.
+const lensDoctrineHelp = `WORKED RECIPES AND CAVEATS - consult this before concluding the semantic layer cannot answer, and always before falling back to query_lfx_lens.
+
+1. DEFAULT WINDOW. When the asker gives no window, use the trailing 12 months
+and say so: {{ TimeDimension('metric_time','DAY') }} >= '<today minus 12
+months>' AND {{ TimeDimension('metric_time','DAY') }} < '<today>'. State the
+concrete dates in the answer.
+
+2. MEMBERS AS OF A DATE D (the PCC-parity recipe): metric membership_count
+with where "{{ TimeDimension('metric_time','day') }} <= 'D' AND
+{{ TimeDimension('asset_id__end_date','day') }} >= 'D'". Verified: CNCF as of
+2022-12-31 = 847. Today's active members: current_membership_count (CNCF =
+722, PCC-exact). New members: new_membership_count by install date - but any
+YTD/current-year count needs AND metric_time <= today, because installs can
+be future-dated (2026: 87 in the year bucket vs 77 up to today).
+
+3. FOUNDATION SCOPE. {{ Dimension('project__foundation_slug') }} = '<slug>'
+is the conformed scope: the same filter works on every metric family and
+counts each row once. project_slug matches only a foundation's catch-all
+bucket (cncf: 1.4M activities vs 58M) - a silent undercount, never an error.
+activity_project_id__project_spine_slug returns identical activity counts
+(verified: CNCF 39,371,064 both ways) and is the tool for sub-foundation
+umbrella nodes and hierarchy walks: spine_hierarchy_level = 2 lists a
+foundation's direct children. Some families split across several Salesforce
+entities (risc-v-international/riscv, cff/cloud-foundry,
+opensearch-foundation/opensearch-project); if a total looks low, group by the
+slug dimension and check for twins.
+
+4. BOTS. Bot exclusion is the LFX Insights default. total_contributors and
+the other contributor metrics already exclude bots. On raw *_activities
+metrics add {{ Dimension('activity_project_id__member_is_bot') }} = false -
+it is always safe to include. The gap is large: CNCF code contributions,
+trailing 12 months, 6,561,768 raw vs 3,619,940 non-bot. bot_activities is
+the explicit bot view.
+
+5. ORG SHARES AND CONCENTRATION. Compute shares on the org-ATTRIBUTED base:
+drop NULL organization rows (and 'Individual - No Account') from the
+denominator and report the unattributed share separately - it is large
+(roughly 40-70% depending on the metric). For percentile/concentration
+questions pull the full grouped distribution (high limit) and compute
+client-side. Always state the population definition.
+
+6. NAME DISCOVERY. Org and account names are stored as FULL LEGAL names.
+IBM is 'International Business Machines Corporation' - the string 'IBM' does
+not appear in it, so a value search for 'IBM' misses the main account and
+finds only subsidiaries like 'Turbonomic, an IBM Company'. Search a
+distinctive token instead ('Machines'), or pull top values and scan. Red Hat
+is 'Red Hat LLC' in account dimensions but 'Red Hat' in the activity-side
+organization_name. Corporate families are fragmented across many accounts:
+for 'including subsidiaries' questions, sum the sub-entities explicitly and
+name the ones you included.
+
+7. TIER LITERALS differ per foundation ('Premier Membership' vs 'Premier
+Member'; CNCF has 'Platinum Membership' and no Diamond tier) -
+get_dimension_values per foundation, never reuse literals across foundations.
+
+8. HEALTH SCORES are daily snapshots. Aggregate only after filtering to the
+latest date: first query the ungrouped max of metric_time, then filter
+{{ TimeDimension('metric_time','day') }} = that date. Unfiltered
+category grouping counts a project once per day and per category it passed
+through (~8-9x inflation). Category bands: Critical <20, Unsteady 20-39,
+then Stable/Healthy above.
+
+9. SOFTWARE / ECONOMIC VALUE. Questions about economic value, economic
+impact or the dollar value of code = total_software_value and
+total_estimated_cost (COCOMO model). They are non-additive daily snapshots:
+each project contributes its latest row in the queried window, so a
+project whose latest row lacks a value snapshot contributes nothing -
+totals can read low, never inflated.
+
+10. COMBINED METRICS share only the conformed project__ dimensions and
+metric_time; group_by only those. order_by '-metric' sorts NULL rows FIRST -
+re-sort client-side before reading a top-N.
+
+11. ORG HEADCOUNT CAVEAT. Contributor headcounts by organization run 2-4x
+below externally published counts (conservative member-to-org attribution);
+contribution volumes reconcile to ~1-4%. State the caveat when reporting.
+
+12. CONTRIBUTOR POPULATIONS. total_contributors = code contributions only,
+non-bot (the Insights default) - use it unless non-code participants are
+explicitly wanted, then total_contributors_with_collaboration (adds
+issues/docs/chat) and say so. Neither counts passive activity (stars,
+forks); total_activities is the any-activity volume.
+
+13. MAINTAINERS. Scope with maintainer_key__cm_project_grandparents_slug
+plus {{ Dimension('maintainer_key__is_lf_project') }} = true. Active = no
+recorded end date. start_date carries a 2000-01-01 sentinel on most
+historical records (start unknown) - never build a trend on it.
+Person-grain maintainer x activity joins are not expressible here: that is
+query_lfx_lens's lane.
+
+14. REGION LENSES. country__* dimensions follow the person (contributor);
+organization-side region analysis uses the organization_* dimensions
+(organization_lf_region etc.) - the organization's HQ country, not its
+contributors' countries.`
 
 // lensHelpOverview is returned by help with no target.
 const lensHelpOverview = `LFX Insights Semantic Layer — how to use it
@@ -359,7 +451,11 @@ Dimension qualified_names are entity__field. The prefix is the primary key of
 the metric's own table, so it differs from metric to metric. Always copy the
 name from list_metrics or get_dimensions.
 
-help targets: query, list_metrics, get_dimensions, get_dimension_values`
+help targets: doctrine, query, list_metrics, get_dimensions, get_dimension_values
+
+Struggling with a question? help('doctrine') holds the worked recipes -
+windows, membership as-of dates, bots, org shares, name discovery, health
+snapshots, software value. Consult it BEFORE falling back to query_lfx_lens.`
 
 const lensQueryHelp = `query — run a governed metric query.
 
@@ -388,14 +484,19 @@ Resolve slugs with search_projects first. Stored slugs are not everyday names:
 Kubernetes is 'k8s', kernel is 'korg', and the PyTorch segment is 'ptproject'.
 There is no separate project parameter; scope lives in where.
 
-Activities and contributions: filter
+Foundation scope, any domain: filter
 
-  {{ Dimension('activity_project_id__project_spine_slug') }} = '<slug>'
+  {{ Dimension('project__foundation_slug') }} = '<slug>'
 
-This selects the project and everything under it. It is the ONLY correct scope
-for foundations: the same 'cncf' literal represents 58M activities through the
-spine but 1.4M through project_slug. It is also REQUIRED for sum metrics;
-insertions and deletions inflate 2-4x under any other filter.
+This is the conformed lens: the same filter works on every metric family and
+counts each row once. NEVER scope a foundation with project_slug - the same
+'cncf' literal is 58M activities through the foundation lens but 1.4M through
+project_slug (its catch-all bucket): a silent undercount, not an error.
+activity_project_id__project_spine_slug returns identical activity counts
+(verified: CNCF 39,371,064 both ways) and handles sub-foundation umbrella
+nodes and hierarchy walks - spine_hierarchy_level = 2 lists a foundation's
+direct children. Keep the spine filter for sum metrics: insertions and
+deletions inflate 2-4x under non-hierarchical filters.
 
 Domain-specific scope dimensions:
 
@@ -428,7 +529,7 @@ Worked examples
 
   CNCF contributors, last 12 months
     metrics   total_contributors
-    where     {{ Dimension('activity_project_id__project_spine_slug') }} = 'cncf'
+    where     {{ Dimension('project__foundation_slug') }} = 'cncf'
               AND {{ TimeDimension('metric_time','DAY') }} >= '<start YYYY-MM-DD>'
               AND {{ TimeDimension('metric_time','DAY') }} < '<today UTC YYYY-MM-DD>'
 
@@ -470,8 +571,9 @@ Some foundations have twin Salesforce entities:
 
 If a total looks low, group_by the slug dimension and check for a twin.
 
-"Direct children of X" and "sub-foundations of X" are not expressible today.
-Say so rather than guessing.`
+"Direct children of X": filter the spine slug to X, add
+{{ Dimension('activity_project_id__spine_hierarchy_level') }} = 2, and
+group_by the project slug. help('doctrine') holds the rest of the recipes.`
 
 func handleExploreSemanticLayer(ctx context.Context, _ *mcp.CallToolRequest, args ExploreSemanticLayerArgs) (*mcp.CallToolResult, any, error) {
 	if lensConfig == nil {
@@ -511,21 +613,44 @@ func handleExploreSemanticLayer(ctx context.Context, _ *mcp.CallToolRequest, arg
 	}
 }
 
+// lensHelpAliases routes common words a model reaches for to the help text
+// that answers them, so help lands somewhere useful instead of erroring.
+var lensHelpAliases = []struct {
+	keywords []string
+	target   string
+}{
+	{[]string{"doctrine", "recipe", "caveat", "guide", "guidance", "gotcha", "trick", "advanced", "bot", "window", "date", "member", "org", "share", "concentration", "name", "ibm", "legal", "tier", "health", "value", "cocomo", "economic", "maintainer", "region", "population", "scope", "foundation", "struggl"}, "doctrine"},
+	{[]string{"query", "example", "syntax", "where", "filter", "group", "order", "limit"}, "query"},
+	{[]string{"list_metric", "metrics"}, "list_metrics"},
+	{[]string{"dimension_value", "values", "literal", "spelling"}, "get_dimension_values"},
+	{[]string{"get_dimension", "dimension"}, "get_dimensions"},
+}
+
+// handleLensHelp always returns help: an exact target, the closest alias
+// match, or - for anything unrecognised - the overview plus the full
+// doctrine. A failed help call would push the model toward guessing or a
+// premature query_lfx_lens fallback, which is worse than over-answering.
 func handleLensHelp(target string) (*mcp.CallToolResult, any, error) {
-	if target == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: lensHelpOverview}},
-		}, nil, nil
+	t := strings.ToLower(strings.TrimSpace(target))
+	if t == "" || t == "overview" {
+		return lensHelpResult(lensHelpOverview)
 	}
-
-	text, ok := lensHelpTexts[target]
-	if !ok {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Unknown help target %q. Valid targets: list_metrics, get_dimensions, get_dimension_values, query", target)}},
-			IsError: true,
-		}, nil, nil
+	if text, ok := lensHelpTexts[t]; ok {
+		return lensHelpResult(text)
 	}
+	for _, alias := range lensHelpAliases {
+		for _, kw := range alias.keywords {
+			if strings.Contains(t, kw) {
+				return lensHelpResult(lensHelpTexts[alias.target])
+			}
+		}
+	}
+	return lensHelpResult(fmt.Sprintf(
+		"No help target %q; the closest thing is the full doctrine, below. Named targets: doctrine, query, list_metrics, get_dimensions, get_dimension_values.\n\n%s",
+		target, lensHelpTexts["doctrine"]))
+}
 
+func lensHelpResult(text string) (*mcp.CallToolResult, any, error) {
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: text}},
 	}, nil, nil

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -42,11 +42,11 @@ func RegisterQueryLFXLens(server *mcp.Server) {
 
 Use this tool ONLY for:
 - Maintainer x activity joins: contribution volumes attributed to maintainers (e.g. "top maintainers by contributions", "what share of work comes from maintainers", "is maintainer activity declining"). The semantic layer holds maintainer rosters and activity metrics but cannot join them at person grain.
-- Social listening: mentions of a project on social media and the web (Twitter/X, Bluesky, Reddit, Hacker News, DEV, Podcasts, YouTube, LinkedIn, TikTok), sentiment, share of voice by platform, and author reach/followers. The semantic layer has no social listening data.
+- Social listening: mentions of a project on social media and the web (X, Bluesky, Reddit, Hacker News, YouTube, LinkedIn, TikTok), sentiment, share of voice, author reach. The semantic layer has no social listening data.
 
 FALLBACK (the only other use): switch here when the semantic layer genuinely cannot express the question - but do not give up on it too fast. Genuine means you searched list_metrics with the right topic words, ran get_dimensions, checked get_dimension_values for your filter literals, consulted explore's help('doctrine') recipes, and tried at least two differently-formulated queries. Zero rows or an unknown-name error is NOT struggling: zero rows means a misspelled stored literal or the wrong scope dimension, an unknown name means you guessed instead of copying - both are fixed by discovery, not by switching tools. Fall back quickly only when no metric family covers the concept at all.
 
-Everything else - contributors, activities, memberships, events and sponsorships, registrations, education, maintainer rosters/counts/names, health - belongs to explore_lfx_semantic_layer + query_lfx_semantic_layer.
+Everything else - contributors, activities, memberships, events and sponsorships, registrations, education, maintainer rosters/counts/names, health - belongs to explore_lfx_semantic_layer + query_lfx_semantic_layer. Committee/board rosters: the committee tools.
 
 project_slug is required default context, NOT a scope boundary. Find it via search_projects. For multiple foundations, pass one slug and name the others in input. LF-wide: use project_slug='tlf'.
 
@@ -154,7 +154,7 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 // QuerySemanticLayerArgs for why that distinction matters. Anything that still
 // does not fit belongs in the help action, whose output is a tool result and
 // carries no limit; help is a fallback for a failed query, not a prerequisite.
-const exploreSemanticLayerDescription = `The LFX Insights Semantic Layer is the query and data-exploration tool for Linux Foundation data. This tool discovers what can be measured; query_lfx_semantic_layer runs it. Start here unless exact metric, dimension and value names are already known.
+const exploreSemanticLayerDescription = `The LFX Insights Semantic Layer is the query and data-exploration tool for Linux Foundation data. This tool discovers what can be measured; query_lfx_semantic_layer runs it. Start here unless exact names are already known.
 
 COVERS — search one topic word:
 - contributor, contribution — activity/org counts, commits, PRs
@@ -168,14 +168,14 @@ COVERS — search one topic word:
 A metric is measured (total_contributors); a dimension slices, filters or lists it (country__lf_region). Names are entity__field and prefixes differ per metric, so copy qualified_names; never assemble them.
 
 ACTIONS
-- list_metrics(search): searches metric names/descriptions, so use a topic above, not a dimension like "country". At <=15 matches, each includes dimension qualified_names.
+- list_metrics(search): searches metric names/descriptions, so use a topic above, not a dimension like "country". At <=15 matches, each includes qualified_names.
 - get_dimensions(metrics, search): available dimensions; needs a metric. Several metrics return only shared dimensions—a cross-domain query's valid group_by set.
-- get_dimension_values(dimension, metrics, search): stored literals. Call before filtering on unseen values: an unknown returns zero rows, not an error. Spellings surprise—'Asia Pacific' not 'APAC', 'Viet Nam' not 'Vietnam'.
+- get_dimension_values(dimension, metrics, search): stored literals. Call before filtering on unseen values: an unknown returns zero rows, not an error. Spellings surprise—'Asia Pacific' not 'APAC'.
 - help('doctrine'): worked recipes - windows, as-of membership, bots, health, org shares, tiers, name discovery. ALWAYS call it before a query_lfx_lens fallback.
 
 Project scope lives in query's where clause (no parameter): resolve slugs via search_projects, then see query_lfx_semantic_layer for which dimension scopes each domain.
 
-USE query_lfx_lens INSTEAD only for maintainer-contribution joins, social listening, or - after discovery AND help('doctrine') have failed, never on a first empty result - a question this layer cannot express.`
+USE query_lfx_lens INSTEAD only for maintainer-contribution joins, social listening, or - after discovery AND help('doctrine') have failed, never on a first empty result - a question this layer cannot express. Board/committee/ambassador rosters: committee tools, not here.`
 
 const querySemanticLayerDescription = `Metrics: contributions, memberships, events, sponsorships, education, maintainers, health, country/region. ALWAYS explore_lfx_semantic_layer first unless exact names are known; never guess.
 

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -179,13 +179,13 @@ USE query_lfx_lens INSTEAD only for maintainer-contribution joins, social listen
 
 const querySemanticLayerDescription = `Metrics: contributions, memberships, events, sponsorships, education, maintainers, health, country/region. ALWAYS explore_lfx_semantic_layer first unless exact names are known; never guess.
 
-SYNTAX: metrics (required), CSV. Multiple metrics outer-join on shared dims (group_by only those; absent sides NULL; '-metric' sorts NULLs FIRST - re-sort before top-N). group_by: names for ranked lists, metric_time__year/quarter/month trends. where is MetricFlow: {{ Dimension('country__lf_region') }} = 'Europe'; {{ TimeDimension('metric_time','DAY') }} >= '2024-01-01' (dates yyyy-mm-dd). limit ceiling 500. current_* is active-only.
+SYNTAX: metrics (required), CSV. Multiple metrics outer-join on shared dims (group_by only those; absent sides NULL; '-metric' sorts NULLs FIRST). group_by: names for ranked lists, metric_time__year/quarter/month trends. where is MetricFlow: {{ Dimension('country__lf_region') }} = 'Europe'; {{ TimeDimension('metric_time','DAY') }} >= '2024-01-01' (dates yyyy-mm-dd). limit ceiling 500.
 
-SCOPE: resolve slugs via search_projects. Foundation: {{ Dimension('project__foundation_slug') }} = '<slug>' - conformed, every domain, counts rows once. NEVER scope a foundation with project_slug - matches only its catch-all bucket: silent 40x undercount. Memberships: asset_id__project_slug. Registrations: registration_id__project_slug. Events/speakers: event_id__project_name (EXACT name). Maintainers: maintainer_key__cm_project_grandparents_slug + is_lf_project=true. 0 rows = misspelled literal - get_dimension_values first; org/account names are FULL LEGAL names (IBM = 'International Business Machines Corporation') - short-name searches miss them.
+SCOPE: resolve slugs via search_projects. Foundation: {{ Dimension('project__foundation_slug') }} = '<slug>' - conformed, every domain, counts rows once. NEVER scope a foundation with project_slug: its catch-all bucket, a silent 40x undercount. Memberships: asset_id__project_slug. Registrations: registration_id__project_slug. Events/speakers: event_id__project_name (EXACT name). Maintainers: maintainer_key__cm_project_grandparents_slug + is_lf_project=true. 0 rows = misspelled literal - get_dimension_values first; org/account names are FULL LEGAL names (IBM = 'International Business Machines Corporation') - short-name searches miss them.
 
-CONTRACT: compute shares/rankings yourself; state definition+window; default trailing 12 months, say so. Raw *_activities: add {{ Dimension('activity_project_id__member_is_bot') }} = false - the Insights default; always safe. total_contributors is code-only non-bot; _with_collaboration only when non-code participants are explicitly wanted. Org shares: use the org-attributed base (drop NULL/unaffiliated) and report that %. Economic/software value = total_software_value (COCOMO). Org headcounts run below published counts - caveat.
+CONTRACT: compute shares/rankings yourself; state definition+window; default trailing 12 months. Bot exclusion is the Insights default; bot_activities counts bots. total_contributors is code-only; _with_collaboration only when non-code participants are explicitly wanted. Share of work = activity volumes, not headcounts. Org shares: use the org-attributed base (drop NULL/unaffiliated), report that %; org headcounts run below published counts. Economic/software value = total_software_value (COCOMO). Health scores are DAILY snapshots - aggregate only the latest metric_date; bands Critical <20, Unsteady 20-39.
 
-WINDOWS: YTD needs AND <= today (installs can be future-dated). Active as of D: metric_time <= 'D' AND asset_id__end_date >= 'D' on membership_count. Struggling? help('doctrine') BEFORE query_lfx_lens - it has the recipes.`
+WINDOWS: YTD needs AND <= today (installs can be future-dated). Active as of D: metric_time <= 'D' AND asset_id__end_date >= 'D' on membership_count. Struggling? help('doctrine') BEFORE query_lfx_lens.`
 
 // The two semantic layer tools register independently so that LFXMCP_TOOLS can
 // select either by name. They are meant to be enabled together — each
@@ -363,19 +363,26 @@ entities (risc-v-international/riscv, cff/cloud-foundry,
 opensearch-foundation/opensearch-project); if a total looks low, group by the
 slug dimension and check for twins.
 
-4. BOTS. Bot exclusion is the LFX Insights default. total_contributors and
-the other contributor metrics already exclude bots. On raw *_activities
-metrics add {{ Dimension('activity_project_id__member_is_bot') }} = false -
-it is always safe to include. The gap is large: CNCF code contributions,
-trailing 12 months, 6,561,768 raw vs 3,619,940 non-bot. bot_activities is
-the explicit bot view.
+4. BOTS. Bot exclusion is the LFX Insights default and is built into the
+contributor and activity metrics; adding {{
+Dimension('activity_project_id__member_is_bot') }} = false yourself is
+redundant but always safe. The gap this default closes is large (CNCF code
+contributions, trailing 12 months: 6,561,768 with bots vs 3,619,940
+without). bot_activities is the explicit bot view when bot traffic itself
+is the question.
 
-5. ORG SHARES AND CONCENTRATION. Compute shares on the org-ATTRIBUTED base:
+5. ORG SHARES AND CONCENTRATION. Share of an org's work = ACTIVITY VOLUMES
+(e.g. code_contribution_activities by organization), never contributor
+headcounts. Compute shares on the org-ATTRIBUTED base of the same metric:
 drop NULL organization rows (and 'Individual - No Account') from the
 denominator and report the unattributed share separately - it is large
-(roughly 40-70% depending on the metric). For percentile/concentration
-questions pull the full grouped distribution (high limit) and compute
-client-side. Always state the population definition.
+(roughly 40-70% depending on the metric). For concentration questions pull
+the full grouped distribution and compute client-side. Always state the
+population definition. PERCENTILE CAP: the query limit ceiling is 500 rows,
+so a full per-person distribution over a large population is not
+retrievable - for median/percentile claims over big pools, combine the
+population total with the top-500 slice, state the approximation, or say
+the exact percentile needs ad-hoc SQL.
 
 6. NAME DISCOVERY. Org and account names are stored as FULL LEGAL names.
 IBM is 'International Business Machines Corporation' - the string 'IBM' does

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -92,7 +92,7 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 	}
 
 	userID := AnonymousUserID
-	if req.Extra.TokenInfo != nil && req.Extra.TokenInfo.UserID != "" {
+	if req.Extra != nil && req.Extra.TokenInfo != nil && req.Extra.TokenInfo.UserID != "" {
 		userID = req.Extra.TokenInfo.UserID
 	}
 

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -255,16 +255,17 @@ func TestExploreSemanticLayerDescription(t *testing.T) {
 		// query_lfx_lens. These singular forms are verified against the API.
 		"contributor, contribution —",
 		"membership, revenue, churn —",
-		"event, registration, speaker —",
+		"event, registration, speaker, sponsorship —",
 		"enrollment, certification —",
 		"maintainer —",
 		"health, project —",
 		// Regional questions route here for every topic, memberships included.
 		"any of the above sliced by country or region — always here, never query_lfx_lens",
-		// Dimension naming, and the regional person-vs-organization split.
+		// Dimension naming. The regional person-vs-organization split moved to
+		// help('doctrine') (asserted in TestDoctrineHelp) to make room for the
+		// eval-verified failure patterns.
 		"entity__field",
 		"country__lf_region",
-		"activity_project_id__organization_lf_region",
 		// Discovery must hand off to the query tool by name and explain where
 		// project scope is expressed now that there is no project parameter.
 		"query_lfx_semantic_layer",
@@ -277,6 +278,12 @@ func TestExploreSemanticLayerDescription(t *testing.T) {
 		// escaping via a country code.
 		"get_dimension_values(dimension, metrics, search)",
 		"returns zero rows, not an error",
+		// The 207-question eval showed models falling back to query_lfx_lens
+		// without ever reading the recipes; the description now routes
+		// struggling through help('doctrine') first.
+		"help('doctrine')",
+		"ALWAYS call it before a query_lfx_lens fallback",
+		"maintainer-contribution joins, social listening",
 		"'Asia Pacific' not 'APAC'",
 		"'Viet Nam' not 'Vietnam'",
 		// Either tool can be loaded without the other, so each states what the
@@ -289,12 +296,12 @@ func TestExploreSemanticLayerDescription(t *testing.T) {
 		}
 	}
 
-	// Event sponsorships stay with query_lfx_lens, which does them better, so
-	// this tool must not advertise them. Listing "sponsorship" as a topic here
-	// put two tools in charge of the same question and contradicted the
-	// carve-out query_lfx_lens still states.
-	if strings.Contains(exploreSemanticLayerDescription, "sponsorship,") {
-		t.Error("explore description claims sponsorships as a topic; query_lfx_lens owns them")
+	// Sponsorships flipped owners: the semantic layer covers them now
+	// (sponsored_events_count and the sponsorship revenue metrics), and
+	// query_lfx_lens keeps exactly two lanes. Both descriptions must agree.
+	if strings.Contains(exploreSemanticLayerDescription, "never query_lfx_lens") &&
+		!strings.Contains(exploreSemanticLayerDescription, "sponsorship") {
+		t.Error("explore description no longer claims sponsorships; the semantic layer owns them now")
 	}
 
 	// The description used to warn that a plural search matches nothing. That
@@ -322,44 +329,47 @@ func TestQuerySemanticLayerDescription(t *testing.T) {
 		"yyyy-mm-dd",
 		"ceiling 500",
 		"metric_time__year",
-		"outer-joined",
+		"outer-join",
 		"ranked list",
 		// Splitting discovery out made it possible to query without ever
 		// exploring, and a live client did exactly that — going straight to a
 		// query with guessed names. The rule has to be an instruction, not a
 		// conditional suggestion.
-		"ALWAYS use explore_lfx_semantic_layer first",
+		"ALWAYS explore_lfx_semantic_layer first",
 		"never guess",
 		// Both neighbours are named so routing works from this tool too.
 		"explore_lfx_semantic_layer",
 		"query_lfx_lens",
 		"country/region",
-		// Scope dimensions and literals are copied exactly from the current
-		// live layer. A wrong dimension can return a plausible wrong population.
-		"search_projects first",
-		"Kubernetes='k8s'",
-		"kernel='korg'",
-		"PyTorch segment='ptproject'",
-		"activity_project_id__project_spine_slug",
-		"ONLY foundation scope",
-		"REQUIRED for sums",
-		"insertions/deletions inflate 2–4x",
+		// Scope dimensions are copied exactly from the current live layer. A
+		// wrong dimension returns a plausible wrong population. The conformed
+		// project entity replaced the spine as the primary foundation scope;
+		// the spine, per-domain long-form guidance and slug examples moved to
+		// help('query') and help('doctrine'), asserted in their own tests.
+		"resolve slugs via search_projects",
+		"project__foundation_slug",
+		"NEVER scope a foundation with project_slug",
 		"asset_id__project_slug",
 		"registration_id__project_slug",
 		"event_id__project_name",
-		"Cloud Native Computing Foundation (CNCF)",
-		"NEVER slice sponsorship metrics",
 		"maintainer_key__cm_project_grandparents_slug",
 		"is_lf_project=true",
-		"health_metric_key__foundation_slug",
-		"IN (...) + group_by the same dimension",
-		"never total across spine groups",
 		"0 rows = misspelled literal",
-		// Window semantics must survive optional-parameter compaction.
-		"prior 365 complete UTC days",
-		">= start AND < today",
-		"YTD: >= 'YYYY-01-01'",
-		"Always state concrete dates used",
+		// The five eval-verified failure patterns (62 wrong answers in a
+		// 207-question replay traced overwhelmingly to these): bots on raw
+		// activity metrics, full-legal-name lookups, share denominators,
+		// unstated windows, and undiscovered COCOMO value metrics.
+		"member_is_bot",
+		"Insights default",
+		"International Business Machines Corporation",
+		"org-attributed base",
+		"default trailing 12 months",
+		"total_software_value",
+		"COCOMO",
+		"asset_id__end_date",
+		"future-dated",
+		// Struggling routes through the doctrine before the lens fallback.
+		"help('doctrine') BEFORE query_lfx_lens",
 		// The silent-zero-rows warning is only actionable if it names the way
 		// out; without this the model retries the same wrong literal.
 		"get_dimension_values",
@@ -440,6 +450,9 @@ func TestCriticalGuidanceSurvivesSchemaCompaction(t *testing.T) {
 		{"raw IDs", "grouping by an entity silently returns unusable output"},
 		{"get_dimension_values", "the only recovery from a wrong filter literal"},
 		{"zero rows", "a wrong literal is silent, so the model must be told to check first"},
+		{"member_is_bot", "unfiltered activity metrics inflate 1.4-1.9x with no error"},
+		{"International Business Machines", "short-name value searches silently miss legal-name accounts"},
+		{"help('doctrine')", "the overflow recipes are useless if nothing routes the model to them"},
 	} {
 		if !strings.Contains(surviving, tc.token) {
 			t.Errorf("%q reaches the model only via an optional parameter, where it gets summarised away (%s). Move it into the tool description or onto a required parameter.",
@@ -695,6 +708,9 @@ func TestHelpActionAndDescribeAlias(t *testing.T) {
 	for _, want := range []string{
 		"metric_time__year",
 		"There is no separate project parameter",
+		"project__foundation_slug",
+		"conformed lens",
+		"spine_hierarchy_level = 2",
 		"activity_project_id__project_spine_slug",
 		"asset_id__project_slug",
 		"registration_id__project_slug",
@@ -712,7 +728,9 @@ func TestHelpActionAndDescribeAlias(t *testing.T) {
 		"risc-v-international / riscv",
 		"cff / cloud-foundry",
 		"opensearch-foundation / opensearch-project",
-		`"Direct children of X" and "sub-foundations of X" are not expressible today`,
+		// Hierarchy walks became expressible with the spine dimensions; the
+		// old "not expressible today" disclaimer must be gone.
+		`"Direct children of X"`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("help query text missing %q", want)
@@ -731,9 +749,9 @@ func TestQueryLFXLensScopeIsContextNotBoundary(t *testing.T) {
 		"Find it via search_projects",
 		"For multiple foundations",
 		"name the others in input",
-		"compare cncf with lf-ai-foundation and openssf",
+		"name the others in input",
 		"LF-wide",
-		"project_slug='tlf' (The Linux Foundation)",
+		"project_slug='tlf'",
 	} {
 		if !strings.Contains(tool.Description, want) {
 			t.Errorf("query_lfx_lens description missing scope guidance %q", want)
@@ -778,7 +796,8 @@ func TestQueryLFXLensDoesNotClaimMemberships(t *testing.T) {
 			t.Errorf("query_lfx_lens description still claims memberships: %q", unwanted)
 		}
 	}
-	if !strings.Contains(tool.Description, "contributor, activity and membership questions belong to the semantic layer") {
+	if !strings.Contains(tool.Description, "Everything else - contributors, activities, memberships") ||
+		!strings.Contains(tool.Description, "belongs to explore_lfx_semantic_layer") {
 		t.Error("query_lfx_lens description should hand memberships to the semantic layer explicitly")
 	}
 
@@ -786,7 +805,7 @@ func TestQueryLFXLensDoesNotClaimMemberships(t *testing.T) {
 	if strings.Contains(input, "Always use for memberships") {
 		t.Errorf("query_lfx_lens input schema still claims memberships: %q", input)
 	}
-	if !strings.Contains(input, "Contributor, activity and membership questions belong to the semantic layer") {
+	if !strings.Contains(input, "membership, event, education and health questions belong to the semantic layer") {
 		t.Errorf("query_lfx_lens input schema should redirect memberships: %q", input)
 	}
 }
@@ -988,5 +1007,97 @@ func TestSemanticLayerToolsRegisterIndependently(t *testing.T) {
 					tc.name, tc.absent)
 			}
 		})
+	}
+}
+
+// TestDoctrineHelp pins the overflow doctrine: every recipe that the
+// 2048-byte descriptions cannot hold, verified against the live layer during
+// the August 2026 eval. If one of these tokens disappears, a failure pattern
+// that produced wrong answers in the 207-question replay loses its recipe.
+func TestDoctrineHelp(t *testing.T) {
+	setupLensTest(t)
+
+	res, _, err := handleExploreSemanticLayer(context.Background(), &mcp.CallToolRequest{}, ExploreSemanticLayerArgs{
+		Action: "help",
+		Target: "doctrine",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %s", resultText(t, res))
+	}
+	text := resultText(t, res)
+	for _, want := range []string{
+		// windows and membership parity
+		"trailing 12 months",
+		"asset_id__end_date",
+		"current_membership_count",
+		"future-dated",
+		// scoping and hierarchy
+		"project__foundation_slug",
+		"spine_hierarchy_level = 2",
+		"risc-v-international/riscv",
+		// bots
+		"member_is_bot",
+		"bot_activities",
+		"3,619,940",
+		// org shares and headcounts
+		"org-ATTRIBUTED",
+		"Individual - No Account",
+		"2-4x",
+		// name discovery
+		"International Business Machines Corporation",
+		"Red Hat LLC",
+		// tiers, health, value
+		"Premier Membership",
+		"Critical <20, Unsteady 20-39",
+		"total_software_value",
+		"COCOMO",
+		// populations, maintainers, regions
+		"total_contributors_with_collaboration",
+		"2000-01-01 sentinel",
+		"maintainer_key__is_lf_project",
+		"organization_lf_region",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("doctrine help missing %q", want)
+		}
+	}
+}
+
+// TestHelpNeverFails pins the help contract: help always returns guidance.
+// An IsError help result pushes the model toward guessing or a premature
+// query_lfx_lens fallback - the exact behaviors the doctrine exists to stop.
+func TestHelpNeverFails(t *testing.T) {
+	setupLensTest(t)
+
+	for _, tc := range []struct {
+		target string
+		want   string
+	}{
+		{"", "how to use it"},
+		{"overview", "how to use it"},
+		{"doctrine", "WORKED RECIPES"},
+		{"recipes", "WORKED RECIPES"},              // alias
+		{"bots", "member_is_bot"},                  // topic keyword routes to doctrine
+		{"windows", "trailing 12 months"},          // topic keyword routes to doctrine
+		{"metrics", "list_metrics"},                // action-ish keyword
+		{"total_bananas_metric", "WORKED RECIPES"}, // unknown: overview+doctrine, not an error
+	} {
+		res, _, err := handleExploreSemanticLayer(context.Background(), &mcp.CallToolRequest{}, ExploreSemanticLayerArgs{
+			Action: "help",
+			Target: tc.target,
+		})
+		if err != nil {
+			t.Fatalf("target %q: unexpected error: %v", tc.target, err)
+		}
+		if res.IsError {
+			t.Errorf("target %q: help returned an error result; it must always return guidance", tc.target)
+			continue
+		}
+		if text := resultText(t, res); !strings.Contains(text, tc.want) {
+			t.Errorf("target %q: help text missing %q", tc.target, text[:min(120, len(text))])
+		}
 	}
 }

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -752,9 +752,14 @@ func TestQueryLFXLensScopeIsContextNotBoundary(t *testing.T) {
 		"Find it via search_projects",
 		"For multiple foundations",
 		"name the others in input",
-		"name the others in input",
 		"LF-wide",
 		"project_slug='tlf'",
+		// Lens generates its own SQL and picks arbitrary windows when the
+		// question leaves them open — the description must carry the default
+		// window convention and require concrete dates in the question.
+		"default trailing 12 months",
+		"state concrete yyyy-mm-dd dates",
+		"the SQL picks its own",
 	} {
 		if !strings.Contains(tool.Description, want) {
 			t.Errorf("query_lfx_lens description missing scope guidance %q", want)

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -1067,6 +1067,12 @@ func TestDoctrineHelp(t *testing.T) {
 		"2000-01-01 sentinel",
 		"maintainer_key__is_lf_project",
 		"organization_lf_region",
+		// Recipe 15: governance rosters route to the committee tools - the
+		// eval's board/ambassador questions were answered "unavailable" or
+		// fabricated because nothing said where rosters live.
+		"search_committees",
+		"search_committee_members",
+		"Never infer a roster",
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("doctrine help missing %q", want)

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -1080,6 +1080,9 @@ func TestDoctrineHelp(t *testing.T) {
 		"search_committees",
 		"search_committee_members",
 		"Never infer a roster",
+		// Meetings route to the meeting tools the same way.
+		"search_past_meetings",
+		"not in this layer and\nnot in query_lfx_lens",
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("doctrine help missing %q", want)

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -359,8 +359,11 @@ func TestQuerySemanticLayerDescription(t *testing.T) {
 		// 207-question replay traced overwhelmingly to these): bots on raw
 		// activity metrics, full-legal-name lookups, share denominators,
 		// unstated windows, and undiscovered COCOMO value metrics.
-		"member_is_bot",
-		"Insights default",
+		"Bot exclusion is the Insights default",
+		"bot_activities",
+		"Share of work = activity volumes",
+		"DAILY snapshots",
+		"Critical <20",
 		"International Business Machines Corporation",
 		"org-attributed base",
 		"default trailing 12 months",
@@ -450,7 +453,7 @@ func TestCriticalGuidanceSurvivesSchemaCompaction(t *testing.T) {
 		{"raw IDs", "grouping by an entity silently returns unusable output"},
 		{"get_dimension_values", "the only recovery from a wrong filter literal"},
 		{"zero rows", "a wrong literal is silent, so the model must be told to check first"},
-		{"member_is_bot", "unfiltered activity metrics inflate 1.4-1.9x with no error"},
+		{"bot_activities", "the explicit bot view; bot exclusion became the metric default in lf-dbt"},
 		{"International Business Machines", "short-name value searches silently miss legal-name accounts"},
 		{"help('doctrine')", "the overflow recipes are useless if nothing routes the model to them"},
 	} {

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -285,7 +285,11 @@ func TestExploreSemanticLayerDescription(t *testing.T) {
 		"ALWAYS call it before a query_lfx_lens fallback",
 		"maintainer-contribution joins, social listening",
 		"'Asia Pacific' not 'APAC'",
-		"'Viet Nam' not 'Vietnam'",
+		// Governance rosters route to the committee tools: the eval's
+		// board/ambassador questions were declared unavailable or fabricated
+		// because neither semantic-layer description mentioned where rosters
+		// live. (The 'Viet Nam' second spelling example paid for this line.)
+		"Board/committee/ambassador rosters: committee tools",
 		// Either tool can be loaded without the other, so each states what the
 		// semantic layer is. Here the regional rule sits in COVERS, asserted
 		// above, rather than in the opening line.
@@ -760,6 +764,9 @@ func TestQueryLFXLensScopeIsContextNotBoundary(t *testing.T) {
 		"default trailing 12 months",
 		"state concrete yyyy-mm-dd dates",
 		"the SQL picks its own",
+		// Governance rosters are neither lens's lane nor the semantic
+		// layer's — the redirect must survive here too.
+		"Committee/board rosters: the committee tools",
 	} {
 		if !strings.Contains(tool.Description, want) {
 			t.Errorf("query_lfx_lens description missing scope guidance %q", want)

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -1056,7 +1056,7 @@ func TestDoctrineHelp(t *testing.T) {
 		// bots
 		"member_is_bot",
 		"bot_activities",
-		"3,619,940",
+		"roughly 1.8x",
 		// org shares and headcounts
 		"org-ATTRIBUTED",
 		"Individual - No Account",

--- a/internal/tools/meeting.go
+++ b/internal/tools/meeting.go
@@ -58,7 +58,7 @@ func RegisterSearchMeetings(server *mcp.Server, asGroups bool) {
 	if asGroups {
 		mcp.AddTool(server, &mcp.Tool{
 			Name:        "search_meetings",
-			Description: "Search for LFX meetings (group calls, also called committee calls, working group sessions) using the query service. IMPORTANT: When the user asks about events, or for event data (conferences, registrations, attendees, speakers, sponsorships), use query_lfx_semantic_layer (preferred) or query_lfx_lens if semantic layer struggles.",
+			Description: "Search for LFX meetings (group calls, also called committee calls, working group sessions) using the query service. Meetings, their occurrences, registrants, attendance and summaries live HERE - prefer these tools over the semantic layer or query_lfx_lens for meeting questions. IMPORTANT: When the user asks about events, or for event data (conferences, registrations, attendees, speakers, sponsorships), use query_lfx_semantic_layer (preferred) or query_lfx_lens if semantic layer struggles.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Search Meetings",
 				ReadOnlyHint: true,
@@ -68,7 +68,7 @@ func RegisterSearchMeetings(server *mcp.Server, asGroups bool) {
 	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_meetings",
-		Description: "Search for LFX meetings (committee calls, working group sessions) using the query service. IMPORTANT: When the user asks about events, or for event data (conferences, registrations, attendees, speakers, sponsorships), use query_lfx_semantic_layer (preferred) or query_lfx_lens if semantic layer struggles.",
+		Description: "Search for LFX meetings (committee calls, working group sessions) using the query service. Meetings, their occurrences, registrants, attendance and summaries live HERE - prefer these tools over the semantic layer or query_lfx_lens for meeting questions. IMPORTANT: When the user asks about events, or for event data (conferences, registrations, attendees, speakers, sponsorships), use query_lfx_semantic_layer (preferred) or query_lfx_lens if semantic layer struggles.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Meetings",
 			ReadOnlyHint: true,
@@ -182,7 +182,7 @@ func RegisterSearchPastMeetings(server *mcp.Server, asGroups bool) {
 	if asGroups {
 		mcp.AddTool(server, &mcp.Tool{
 			Name:        "search_past_meetings",
-			Description: "Search for LFX past meetings (v1_past_meeting) using the query service. Supports filtering by project, group (also known as committee), meeting ID, date range, and name.",
+			Description: "Search for LFX past meetings (v1_past_meeting) using the query service. Supports filtering by project, group (also known as committee), meeting ID, date range, and name. Past attendance and summaries live here, not in the semantic layer or query_lfx_lens.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Search Past Meetings",
 				ReadOnlyHint: true,
@@ -192,7 +192,7 @@ func RegisterSearchPastMeetings(server *mcp.Server, asGroups bool) {
 	}
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_past_meetings",
-		Description: "Search for LFX past meetings using the query service. Supports filtering by project, committee, meeting ID, date range, and name.",
+		Description: "Search for LFX past meetings using the query service. Supports filtering by project, committee, meeting ID, date range, and name. Past attendance and summaries live here, not in the semantic layer or query_lfx_lens.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Past Meetings",
 			ReadOnlyHint: true,

--- a/internal/tools/meeting_test.go
+++ b/internal/tools/meeting_test.go
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and contributors.
+// SPDX-License-Identifier: MIT
+
+// Package tools provides MCP tool implementations for the LFX MCP server.
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestMeetingToolsClaimMeetingQuestions guards the routing contract from the
+// meeting side. The semantic layer has no meeting metrics and lens is not
+// the meeting lane, so the meeting tools must claim ownership in both
+// terminology modes - otherwise a meeting question bounces between tools
+// that each disclaim it. The existing events redirect (meetings tool ->
+// semantic layer for conferences/registrations) must survive alongside the
+// ownership claim: the two route in opposite directions on purpose.
+func TestMeetingToolsClaimMeetingQuestions(t *testing.T) {
+	for _, tc := range []struct {
+		toolName string
+		register func(*mcp.Server)
+		wants    []string
+	}{
+		{
+			toolName: "search_meetings",
+			register: func(s *mcp.Server) { RegisterSearchMeetings(s, false) },
+			wants: []string{
+				"live HERE - prefer these tools over the semantic layer or query_lfx_lens",
+				// The opposite-direction redirect for event data must survive.
+				"use query_lfx_semantic_layer (preferred)",
+			},
+		},
+		{
+			toolName: "search_meetings",
+			register: func(s *mcp.Server) { RegisterSearchMeetings(s, true) },
+			wants: []string{
+				"live HERE - prefer these tools over the semantic layer or query_lfx_lens",
+				"use query_lfx_semantic_layer (preferred)",
+			},
+		},
+		{
+			toolName: "search_past_meetings",
+			register: func(s *mcp.Server) { RegisterSearchPastMeetings(s, false) },
+			wants: []string{
+				"live here, not in the semantic layer or query_lfx_lens",
+			},
+		},
+		{
+			toolName: "search_past_meetings",
+			register: func(s *mcp.Server) { RegisterSearchPastMeetings(s, true) },
+			wants: []string{
+				"live here, not in the semantic layer or query_lfx_lens",
+			},
+		},
+	} {
+		t.Run(tc.toolName, func(t *testing.T) {
+			tool := listRegisteredTool(t, tc.toolName, tc.register)
+			for _, want := range tc.wants {
+				if !strings.Contains(tool.Description, want) {
+					t.Errorf("%s description missing %q", tc.toolName, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this is

The semantic-layer tool guidance rebuilt from evidence: a 207-question evaluation of real agent sessions against expert reference answers, a root-cause triage of all 62 wrong answers, and a 41-question retest through this actual server (stdio, local lens) confirming which lines flip wrong answers to right ones.

## Changes

**Tool descriptions** (`explore_lfx_semantic_layer`, `query_lfx_semantic_layer`, `query_lfx_lens`) — rewritten around the failure patterns that actually produced wrong answers, in eval-impact order: bot exclusion, org-attributed share denominators, full-legal-name value discovery ('IBM' is stored as 'International Business Machines Corporation'), the default trailing-12-months window, foundation-scope dimensions (the `project_slug='cncf'` 40x silent undercount), COCOMO software value, daily-grain health scores, and committee-roster routing. Budgets: 2044 / 2043 / 2040 of 2048 bytes.

**`help('doctrine')`** — a rich, never-fail overflow surface: 15 worked recipes with live-verified figures (as-of membership, org shares and the 500-row percentile cap, hierarchy walks, tier literals, health latest-date, maintainer sentinel dates, region lenses, governance rosters). Unknown help targets return the overview plus doctrine instead of an error; both descriptions route "struggling" through it BEFORE any `query_lfx_lens` fallback.

**Routing contract** — lens keeps two positive lanes (maintainer×activity joins, social listening) plus a fallback that demands real discovery first; sponsorships/events/memberships explicitly belong to the semantic layer; governance rosters explicitly belong to the committee tools (eval questions about boards and ambassadors were answered "unavailable" or fabricated for lack of this one line).

**Window consistency** — one definition across all three surfaces (trailing 12 months = prior 365 complete UTC days, half-open bounds, YTD bounded at today because installs are future-dated), and lens now states the default and requires concrete yyyy-mm-dd dates in the question — lens generates its own SQL and was observed window-mismatching its own sub-queries when dates were left open.

**Bug fix** — `query_lfx_lens` panicked in stdio mode on nil `req.Extra` (SIGSEGV at lens.go:95); clients silently restart the server so a whole session can run with lens dead. One-line nil guard. (The same unguarded pattern exists in the other LFX API tool handlers — proposed separately as a shared-helper hardening, not expanded here.)

**Guard tests** — every load-bearing token in the descriptions and doctrine is pinned, including survival of critical guidance under client schema compaction.

## Verification

Retest through this server (real binary, cowork-style Sonnet driver): default-window cluster 5/5 flipped, COCOMO 3/4, name-discovery 7/11, health flipped to reference-exact after the in-description health line, one-offs 3/3. The org-share denominator cluster resolves via the lf-dbt side (see coupling below).

## ⚠️ Deploy coupling

The descriptions state "Bot exclusion is the Insights default" — true once lf-dbt #2823 (bot-exclusion baked into the activity metrics) is merged and its manifest deployed. **This PR should deploy together with or after lf-dbt #2823**, not before.

Part of LFXV2-2891 (migrate LFX MCP away from text-to-SQL):
https://linuxfoundation.atlassian.net/browse/LFXV2-2891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8coBfJuWNaikKT831DS6p
