### PR TITLE
[LFXV2-2891] mcp: query_lfx_lens takes an optional project_slugs list

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -216,17 +216,18 @@ sequenceDiagram
     Note over MCP: query_lfx_lens registered only when<br />read scope (read:all or manage:all) AND lf_staff=true
     MCP-->>Client: tools/list (includes query_lfx_lens)
 
-    User->>Client: invoke query_lfx_lens (project_slug="tlf")
+    User->>Client: invoke query_lfx_lens (input; project_slugs optional, omitted = LF-wide)
     Client->>MCP: tools/call {query_lfx_lens}<br />Authorization: Bearer {mcp_jwt}
 
     Note over MCP: lf_staff=true already verified at registration
     MCP->>Auth0: client_credentials grant<br />audience = Lens API resource server
     Auth0-->>MCP: Lens M2M token (no user identity, cached)
 
-    MCP->>Lens: POST /workflows/.../runs<br />Authorization: Bearer {lens_m2m_token}
+    MCP->>Lens: POST /workflows/.../runs<br />additional_data {"project_slugs": [...]}<br />Authorization: Bearer {lens_m2m_token}
     Lens->>Lens: verify JWT via JWKS
-    Lens-->>MCP: response
-    MCP-->>Client: tool result
+    Lens->>Lens: resolve slugs (unknown -> rejection, no query)
+    Lens-->>MCP: response (opens with **scope**, ends with **snapshot**)
+    MCP-->>Client: tool result (rejection -> IsError)
 ```
 
 ### Flow 3: End-user → MCP-brokered service API (with CTE + access-check)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,7 +226,7 @@ sequenceDiagram
     MCP->>Lens: POST /workflows/.../runs<br />additional_data {"project_slugs": [...]}<br />Authorization: Bearer {lens_m2m_token}
     Lens->>Lens: verify JWT via JWKS
     Lens->>Lens: resolve slugs (unknown -> rejection, no query)
-    Lens-->>MCP: response (opens with **scope**, ends with **snapshot**)
+    Lens-->>MCP: response (opens with **scope**)
     MCP-->>Client: tool result (rejection -> IsError)
 ```
 

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -44,7 +44,7 @@ Use this tool ONLY as a FALLBACK: switch here only when the semantic layer genui
 
 Everything else - contributors, activities, memberships, events and sponsorships, registrations, education, maintainer rosters/counts/names, health, social listening (mentions, sentiment, reach) - is a standard metric first (query_lfx_standard_metrics; inventory in read_lfx_standard_metrics_guidance), then explore_lfx_semantic_layer + query_lfx_semantic_layer when no family fits. Committee/board rosters: the committee tools.
 
-project_slug is required default context, NOT a scope boundary. Find it via search_projects. For multiple foundations, pass one slug and name the others in input. project_slug is a required CONTEXT field of this tool only, not a scope: for an LF-wide question pass 'tlf' here and say LF-wide in input. On every other tool the LF-wide scope is NO project at all, and 'tlf' is the Linux Foundation's own bucket, not the LF-wide scope.
+project_slugs is optional. Omit it for LF-wide questions: no project or foundation filter is applied. Pass exact slugs from search_projects to scope to them; several slugs are combined, so a JDF series plus its -fund parent, or a multi-foundation comparison, is one call. Unknown slugs are rejected. Every answer opens with the scope it ran with.
 
 Runs synchronously; wait 15-30 seconds without retrying. Returns <=200 rows; request explicit pagination ("page 2", or stable ORDER BY with LIMIT/OFFSET). Windows: default trailing 12 months; state concrete yyyy-mm-dd dates or the SQL picks its own.`,
 		Annotations: &mcp.ToolAnnotations{
@@ -55,18 +55,33 @@ Runs synchronously; wait 15-30 seconds without retrying. Returns <=200 rows; req
 }
 
 // QueryLFXLensArgs defines the input for query_lfx_lens.
+//
+// project_slugs is an optional list, not a required default: a required
+// "context" slug documented as "not a scope boundary" was read by the lens
+// agent as its compulsory scope, so LF-wide questions silently became one
+// bucket's figures (the 'tlf' catch-all is about a quarter of memberships, not
+// the LF root). With no slugs the lens applies no project or foundation filter
+// at all; with slugs it scopes to exactly those, OR'd; unknown slugs are
+// rejected by name resolution before any query runs. The old project_slug
+// field is gone rather than mapped: a stale client sending it gets a visible
+// schema error instead of a silently rescoped answer.
 type QueryLFXLensArgs struct {
-	ProjectSlug string `json:"project_slug" jsonschema:"Required default context slug from search_projects, not a scope boundary. For multiple foundations, pass one here and name the others in input. A context field of this tool only: for an LF-wide question pass 'tlf' here and say LF-wide in input; on every other tool 'tlf' is the Linux Foundation's own bucket, not the LF-wide scope."`
-	Input       string `json:"input" jsonschema:"Natural language question. Use for cross-domain joins and shapes no standard metric expresses; membership counts on any date or by year are the memberships standard metric, and the standard metrics already rank people (top contributors, top maintainers). Contributor, activity, membership, event, education, health and social listening questions belong to the semantic layer and its standard metrics - read read_lfx_semantic_layer_guidance before falling back here. Takes 15-30s. (required)"`
+	ProjectSlugs []string `json:"project_slugs,omitempty" jsonschema:"Optional. Exact project slugs from search_projects. Omit for LF-wide questions: no project or foundation filter is applied. Several slugs are combined (OR): a JDF series plus its -fund parent, or several foundations to compare, is one call. Unknown slugs are rejected before any query runs."`
+	Input        string   `json:"input" jsonschema:"Natural language question. Use for cross-domain joins and shapes no standard metric expresses; membership counts on any date or by year are the memberships standard metric, and the standard metrics already rank people (top contributors, top maintainers). Contributor, activity, membership, event, education, health and social listening questions belong to the semantic layer and its standard metrics - read read_lfx_semantic_layer_guidance before falling back here. Takes 15-30s. (required)"`
 }
 
+// lensWorkflowAdditional is the additional_data the lens MCP workflow reads.
+// project_slugs is always present — [] for LF-wide — so the lens never has to
+// guess whether an absent key means "no scope" or "old client".
 type lensWorkflowAdditional struct {
-	Foundation lensFoundation `json:"foundation"`
+	ProjectSlugs []string `json:"project_slugs"`
 }
 
-type lensFoundation struct {
-	Slug string `json:"slug"`
-}
+// lensUnknownSlugPrefix opens the lens's rejection when a slug has no
+// PROJECT_SPINE row. The lens completes the run (status COMPLETED) with that
+// text as its whole content, so the prefix is how this side tells a rejection
+// from an answer. Pinned by tests on both sides.
+const lensUnknownSlugPrefix = "Unknown project slug"
 
 type lensQueryResponse struct {
 	Content    string `json:"content,omitempty"`
@@ -83,8 +98,8 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		return nil, nil, fmt.Errorf("LFX Lens tools not configured")
 	}
 
-	if args.ProjectSlug == "" || args.Input == "" {
-		return nil, nil, fmt.Errorf("project_slug and input are required")
+	if strings.TrimSpace(args.Input) == "" {
+		return nil, nil, fmt.Errorf("input is required")
 	}
 
 	userID := AnonymousUserID
@@ -95,7 +110,7 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 	sessionID := userID + "-" + time.Now().UTC().Format("2006-01-02T15:04:05Z")
 
 	additionalData, err := json.Marshal(lensWorkflowAdditional{
-		Foundation: lensFoundation{Slug: args.ProjectSlug},
+		ProjectSlugs: normalizeSlugs(args.ProjectSlugs),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal additional_data: %w", err)
@@ -129,9 +144,40 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		}, nil, nil
 	}
 
+	// An unknown slug is not an answer: the lens stopped before the agent ran
+	// and no query executed. Surface it as an error, text unchanged, so the
+	// caller re-resolves the slug instead of reading the message as data.
+	if strings.HasPrefix(strings.TrimSpace(resp.Content), lensUnknownSlugPrefix) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: resp.Content}},
+			IsError: true,
+		}, nil, nil
+	}
+
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: resp.Content}},
 	}, nil, nil
+}
+
+// normalizeSlugs trims, drops empties and de-duplicates preserving order. No
+// case folding and no fuzzy matching: stored slugs are exact and
+// search_projects is the resolver. Always returns a non-nil slice so the JSON
+// carries [] rather than null.
+func normalizeSlugs(slugs []string) []string {
+	out := make([]string, 0, len(slugs))
+	seen := make(map[string]struct{}, len(slugs))
+	for _, s := range slugs {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/linuxfoundation/lfx-mcp/internal/serviceapi"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -77,11 +78,26 @@ type lensWorkflowAdditional struct {
 	ProjectSlugs []string `json:"project_slugs"`
 }
 
-// lensUnknownSlugPrefix opens the lens's rejection when a slug has no
-// PROJECT_SPINE row. The lens completes the run (status COMPLETED) with that
-// text as its whole content, so the prefix is how this side tells a rejection
-// from an answer. Pinned by tests on both sides.
-const lensUnknownSlugPrefix = "Unknown project slug"
+// lensRejectionPrefixes open the lens's scope rejections: a slug with no
+// PROJECT_SPINE row, a malformed list, or a failed warehouse lookup. The lens
+// completes such a run (status COMPLETED) with the rejection as its whole
+// content — no agent ran, no query executed — so the prefix is how this side
+// tells a rejection from an answer. Kept as three so a caller can tell "your
+// slug is wrong" from "the warehouse was down; retry". Pinned by tests on both
+// sides (lfx-lens resolve_lfx_lens_mcp_scope.REJECTION_PREFIXES).
+var lensRejectionPrefixes = []string{
+	"Unknown project slug",
+	"Invalid project_slugs",
+	"Project scope could not be resolved",
+}
+
+// Bounds on project_slugs, applied here so an oversized list never reaches
+// the lens: every slug costs it warehouse work. The largest legitimate scope
+// is a handful of foundations to compare. The lens enforces the same limits.
+const (
+	maxLensProjectSlugs = 25
+	maxLensSlugLength   = 128
+)
 
 type lensQueryResponse struct {
 	Content    string `json:"content,omitempty"`
@@ -102,6 +118,11 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		return nil, nil, fmt.Errorf("input is required")
 	}
 
+	slugs, err := normalizeSlugs(args.ProjectSlugs)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	userID := AnonymousUserID
 	if req.Extra != nil && req.Extra.TokenInfo != nil && req.Extra.TokenInfo.UserID != "" {
 		userID = req.Extra.TokenInfo.UserID
@@ -110,7 +131,7 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 	sessionID := userID + "-" + time.Now().UTC().Format("2006-01-02T15:04:05Z")
 
 	additionalData, err := json.Marshal(lensWorkflowAdditional{
-		ProjectSlugs: normalizeSlugs(args.ProjectSlugs),
+		ProjectSlugs: slugs,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal additional_data: %w", err)
@@ -144,10 +165,11 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 		}, nil, nil
 	}
 
-	// An unknown slug is not an answer: the lens stopped before the agent ran
-	// and no query executed. Surface it as an error, text unchanged, so the
-	// caller re-resolves the slug instead of reading the message as data.
-	if strings.HasPrefix(strings.TrimSpace(resp.Content), lensUnknownSlugPrefix) {
+	// A scope rejection is not an answer: the lens stopped before the agent
+	// ran and no query executed. Surface it as an error, text unchanged, so
+	// the caller re-resolves the slug (or retries) instead of reading the
+	// message as data.
+	if isLensRejection(resp.Content) {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: resp.Content}},
 			IsError: true,
@@ -159,11 +181,26 @@ func handleQueryLFXLens(ctx context.Context, req *mcp.CallToolRequest, args Quer
 	}, nil, nil
 }
 
+// isLensRejection reports whether lens content is a scope rejection rather
+// than an answer. Real answers open with "**scope**:", so a prefix match on
+// the rejection openers cannot mistake one for the other.
+func isLensRejection(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	for _, prefix := range lensRejectionPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // normalizeSlugs trims, drops empties and de-duplicates preserving order. No
 // case folding and no fuzzy matching: stored slugs are exact and
 // search_projects is the resolver. Always returns a non-nil slice so the JSON
-// carries [] rather than null.
-func normalizeSlugs(slugs []string) []string {
+// carries [] rather than null. An over-long list, an over-long slug or a slug
+// with control characters is an argument error; the offending value is not
+// echoed.
+func normalizeSlugs(slugs []string) ([]string, error) {
 	out := make([]string, 0, len(slugs))
 	seen := make(map[string]struct{}, len(slugs))
 	for _, s := range slugs {
@@ -171,13 +208,22 @@ func normalizeSlugs(slugs []string) []string {
 		if s == "" {
 			continue
 		}
+		if len(s) > maxLensSlugLength {
+			return nil, fmt.Errorf("project_slugs: a slug exceeds %d bytes", maxLensSlugLength)
+		}
+		if strings.ContainsFunc(s, unicode.IsControl) {
+			return nil, fmt.Errorf("project_slugs: a slug contains control characters")
+		}
 		if _, dup := seen[s]; dup {
 			continue
 		}
 		seen[s] = struct{}{}
 		out = append(out, s)
 	}
-	return out
+	if len(out) > maxLensProjectSlugs {
+		return nil, fmt.Errorf("project_slugs: at most %d slugs per call (%d given)", maxLensProjectSlugs, len(out))
+	}
+	return out, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -45,7 +45,7 @@ Use this tool ONLY as a FALLBACK: switch here only when the semantic layer genui
 
 Everything else - contributors, activities, memberships, events and sponsorships, registrations, education, maintainer rosters/counts/names, health, social listening (mentions, sentiment, reach) - is a standard metric first (query_lfx_standard_metrics; inventory in read_lfx_standard_metrics_guidance), then explore_lfx_semantic_layer + query_lfx_semantic_layer when no family fits. Committee/board rosters: the committee tools.
 
-project_slugs is optional. Omit it for LF-wide questions: no project or foundation filter is applied. Pass exact slugs from search_projects to scope to them; several slugs are combined, so a JDF series plus its -fund parent, or a multi-foundation comparison, is one call. Unknown slugs are rejected. Every answer opens with the scope it ran with.
+project_slugs is optional. Omit it for LF-wide questions: no project or foundation filter is applied. Pass exact slugs from search_projects to scope to them; several slugs are combined, so a JDF series plus its -fund parent, or a multi-foundation comparison, is one call. Unknown slugs are rejected. Every answer opens with the scope the caller gave.
 
 Runs synchronously; wait 15-30 seconds without retrying. Returns <=200 rows; request explicit pagination ("page 2", or stable ORDER BY with LIMIT/OFFSET). Windows: default trailing 12 months; state concrete yyyy-mm-dd dates or the SQL picks its own.`,
 		Annotations: &mcp.ToolAnnotations{
@@ -201,9 +201,20 @@ func isLensRejection(content string) bool {
 // with control characters is an argument error; the offending value is not
 // echoed.
 func normalizeSlugs(slugs []string) ([]string, error) {
+	// Bound the raw caller list before iteration or de-duplication: a huge
+	// list of one repeated slug is still huge input and must not bypass the cap.
+	if len(slugs) > maxLensProjectSlugs {
+		return nil, fmt.Errorf("project_slugs: more than %d entries (%d given)", maxLensProjectSlugs, len(slugs))
+	}
+
 	out := make([]string, 0, len(slugs))
 	seen := make(map[string]struct{}, len(slugs))
 	for _, s := range slugs {
+		// Check before TrimSpace: a trailing newline is a control character,
+		// not harmless whitespace that should become a valid stored slug.
+		if strings.ContainsFunc(s, unicode.IsControl) {
+			return nil, fmt.Errorf("project_slugs: a slug contains control characters")
+		}
 		s = strings.TrimSpace(s)
 		if s == "" {
 			continue
@@ -211,17 +222,11 @@ func normalizeSlugs(slugs []string) ([]string, error) {
 		if len(s) > maxLensSlugLength {
 			return nil, fmt.Errorf("project_slugs: a slug exceeds %d bytes", maxLensSlugLength)
 		}
-		if strings.ContainsFunc(s, unicode.IsControl) {
-			return nil, fmt.Errorf("project_slugs: a slug contains control characters")
-		}
 		if _, dup := seen[s]; dup {
 			continue
 		}
 		seen[s] = struct{}{}
 		out = append(out, s)
-	}
-	if len(out) > maxLensProjectSlugs {
-		return nil, fmt.Errorf("project_slugs: at most %d slugs per call (%d given)", maxLensProjectSlugs, len(out))
 	}
 	return out, nil
 }

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -690,6 +691,77 @@ func schemaPropertyDescription(t *testing.T, tool *mcp.Tool, property string) st
 	return prop.Description
 }
 
+// schemaPropertyType returns the JSON-schema type of one input property. The
+// SDK emits an optional slice as type ["null","array"]; the non-null member is
+// what a client reads, so that is what this returns.
+func schemaPropertyType(t *testing.T, tool *mcp.Tool, property string) string {
+	t.Helper()
+	return schemaProperty(t, tool, property).Type.nonNull()
+}
+
+// schemaArrayItemType returns the item type of an array-typed input property.
+func schemaArrayItemType(t *testing.T, tool *mcp.Tool, property string) string {
+	t.Helper()
+	prop := schemaProperty(t, tool, property)
+	if prop.Items == nil {
+		t.Fatalf("input schema property %q has no items", property)
+	}
+	return prop.Items.Type.nonNull()
+}
+
+// schemaType accepts both the scalar ("string") and list (["null","array"])
+// spellings of a JSON-schema type.
+type schemaType []string
+
+func (st *schemaType) UnmarshalJSON(b []byte) error {
+	var one string
+	if err := json.Unmarshal(b, &one); err == nil {
+		*st = schemaType{one}
+		return nil
+	}
+	var many []string
+	if err := json.Unmarshal(b, &many); err != nil {
+		return err
+	}
+	*st = schemaType(many)
+	return nil
+}
+
+func (st schemaType) nonNull() string {
+	for _, v := range st {
+		if v != "null" {
+			return v
+		}
+	}
+	return ""
+}
+
+type schemaPropertyShape struct {
+	Type  schemaType `json:"type"`
+	Items *struct {
+		Type schemaType `json:"type"`
+	} `json:"items"`
+}
+
+func schemaProperty(t *testing.T, tool *mcp.Tool, property string) schemaPropertyShape {
+	t.Helper()
+	raw, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("failed to marshal input schema: %v", err)
+	}
+	var schema struct {
+		Properties map[string]schemaPropertyShape `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("failed to parse input schema: %v", err)
+	}
+	prop, ok := schema.Properties[property]
+	if !ok {
+		t.Fatalf("input schema has no %q property", property)
+	}
+	return prop
+}
+
 func TestRegisterSemanticLayer_Schema(t *testing.T) {
 	explore := listExploreTool(t)
 	query := listQueryTool(t)
@@ -825,8 +897,8 @@ func TestQueryLFXLens_StdioNilExtraUsesAnonymous(t *testing.T) {
 	captured := setupLensTest(t)
 
 	res, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
-		ProjectSlug: "cncf",
-		Input:       "how many contributors last year?",
+		ProjectSlugs: []string{"cncf"},
+		Input:        "how many contributors last year?",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -839,19 +911,24 @@ func TestQueryLFXLens_StdioNilExtraUsesAnonymous(t *testing.T) {
 	}
 }
 
-// TestQueryLFXLensScopeIsContextNotBoundary pins the staff-only cross-project
-// contract. project_slug remains required as a default context for the Lens
-// workflow, but it must not be described as an authorization or scope boundary.
-func TestQueryLFXLensScopeIsContextNotBoundary(t *testing.T) {
+// TestQueryLFXLensScopeIsOptionalAndExplicit pins the scope contract that
+// replaced the required "default context" slug. That parameter, documented as
+// "not a scope boundary" with 'tlf' recommended for LF-wide questions, was
+// read by the lens agent as its compulsory scope: an LF-wide country count
+// became the 'tlf' bucket's 96 countries instead of 140. project_slugs is now
+// optional; omitted means no project or foundation filter at all, several
+// slugs are one OR'd scope, unknown slugs are rejected, and nothing here names
+// tlf.
+func TestQueryLFXLensScopeIsOptionalAndExplicit(t *testing.T) {
 	tool := listRegisteredTool(t, "query_lfx_lens", RegisterQueryLFXLens)
 
 	for _, want := range []string{
-		"project_slug is required default context, NOT a scope boundary",
-		"Find it via search_projects",
-		"For multiple foundations",
-		"name the others in input",
-		"LF-wide",
-		"pass 'tlf' here and say LF-wide in input",
+		"project_slugs is optional",
+		"Omit it for LF-wide",
+		"no project or foundation filter",
+		"several slugs are combined",
+		"Unknown slugs are rejected",
+		"Every answer opens with the scope it ran with",
 		// Lens generates its own SQL and picks arbitrary windows when the
 		// question leaves them open — the description must carry the default
 		// window convention and require concrete dates in the question.
@@ -868,23 +945,214 @@ func TestQueryLFXLensScopeIsContextNotBoundary(t *testing.T) {
 	}
 
 	required := schemaRequired(t, tool)
-	for _, want := range []string{"project_slug", "input"} {
-		if !contains(required, want) {
-			t.Errorf("query_lfx_lens required = %v; expected %s to remain compulsory", required, want)
+	if len(required) != 1 || required[0] != "input" {
+		t.Errorf("query_lfx_lens required = %v; want exactly [input]", required)
+	}
+	if contains(schemaProperties(t, tool), "project_slug") {
+		t.Error("query_lfx_lens still exposes project_slug; a stale client must get a schema error, not a silent rescope")
+	}
+	if !contains(schemaProperties(t, tool), "project_slugs") {
+		t.Fatal("query_lfx_lens schema lacks project_slugs")
+	}
+	if got := schemaPropertyType(t, tool, "project_slugs"); got != "array" {
+		t.Errorf("project_slugs type = %q; want array", got)
+	}
+	if got := schemaArrayItemType(t, tool, "project_slugs"); got != "string" {
+		t.Errorf("project_slugs items type = %q; want string", got)
+	}
+
+	slugs := schemaPropertyDescription(t, tool, "project_slugs")
+	for _, want := range []string{
+		"Optional",
+		"Exact project slugs from search_projects",
+		"Omit for LF-wide questions",
+		"no project or foundation filter is applied",
+		"combined (OR)",
+		"Unknown slugs are rejected",
+	} {
+		if !strings.Contains(slugs, want) {
+			t.Errorf("project_slugs schema description missing %q: %q", want, slugs)
 		}
 	}
 
-	slug := schemaPropertyDescription(t, tool, "project_slug")
-	for _, want := range []string{
-		"Required default context slug",
-		"not a scope boundary",
-		"name the others in input",
-		"not the LF-wide scope",
+	input := schemaPropertyDescription(t, tool, "input")
+	for name, text := range map[string]string{
+		"description":   tool.Description,
+		"project_slugs": slugs,
+		"input":         input,
 	} {
-		if !strings.Contains(slug, want) {
-			t.Errorf("project_slug schema description missing %q: %q", want, slug)
+		for _, unwanted := range []string{"tlf", "default context", "scope boundary", "project_slug="} {
+			if strings.Contains(text, unwanted) {
+				t.Errorf("query_lfx_lens %s still carries %q", name, unwanted)
+			}
 		}
 	}
+}
+
+// TestQueryLFXLensNoSlugsSendsAnEmptyList: LF-wide is an explicit empty list
+// in additional_data, never an absent key the lens might fill with a default.
+func TestQueryLFXLensNoSlugsSendsAnEmptyList(t *testing.T) {
+	captured := setupLensTest(t)
+
+	res, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+		Input: "How many countries have active member organisations?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %s", resultText(t, res))
+	}
+
+	additional := lensAdditionalData(t, captured)
+	if additional != `{"project_slugs":[]}` {
+		t.Errorf("additional_data = %s; want {\"project_slugs\":[]}", additional)
+	}
+	if strings.Contains(additional, "foundation") || strings.Contains(additional, "tlf") {
+		t.Errorf("additional_data still carries the legacy foundation shape or tlf: %s", additional)
+	}
+}
+
+// TestQueryLFXLensNormalisesTheSlugList: whitespace trimmed, empties dropped,
+// duplicates removed, order kept, case untouched (stored slugs are exact).
+func TestQueryLFXLensNormalisesTheSlugList(t *testing.T) {
+	captured := setupLensTest(t)
+
+	_, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+		ProjectSlugs: []string{" c2pa ", "", "c2pa-fund", "c2pa", "  ", "CNCF"},
+		Input:        "How many active memberships does C2PA have?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := lensAdditionalData(t, captured); got != `{"project_slugs":["c2pa","c2pa-fund","CNCF"]}` {
+		t.Errorf("additional_data = %s", got)
+	}
+}
+
+func TestQueryLFXLensSixSlugsPassThrough(t *testing.T) {
+	captured := setupLensTest(t)
+
+	slugs := []string{"cncf", "lf-ai-foundation", "openssf", "lfedge", "lfenergy", "openjs"}
+	if _, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+		ProjectSlugs: slugs,
+		Input:        "How many active memberships does each have?",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got lensWorkflowAdditional
+	if err := json.Unmarshal([]byte(lensAdditionalData(t, captured)), &got); err != nil {
+		t.Fatalf("additional_data is not JSON: %v", err)
+	}
+	if strings.Join(got.ProjectSlugs, ",") != strings.Join(slugs, ",") {
+		t.Errorf("project_slugs = %v; want %v", got.ProjectSlugs, slugs)
+	}
+}
+
+func TestQueryLFXLensRequiresInputOnly(t *testing.T) {
+	setupLensTest(t)
+
+	if _, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+		ProjectSlugs: []string{"cncf"},
+		Input:        "   ",
+	}); err == nil || !strings.Contains(err.Error(), "input is required") {
+		t.Errorf("expected an input-required error, got %v", err)
+	}
+}
+
+// TestQueryLFXLensUnknownSlugIsAnError: the lens completes the run (status
+// COMPLETED) with the rejection as its whole content and no query executed.
+// That must reach the caller as an error with the lens text unchanged, not as
+// an answer.
+func TestQueryLFXLensUnknownSlugIsAnError(t *testing.T) {
+	const rejection = "Unknown project slug(s): no-such-slug-xyz. Pass exact slugs from search_projects, or omit project_slugs for an LF-wide answer."
+	setupLensTestResponding(t, `{"content":`+strconv.Quote(rejection)+`,"status":"COMPLETED","session_id":"s"}`)
+
+	res, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+		ProjectSlugs: []string{"c2pa", "no-such-slug-xyz"},
+		Input:        "How many active memberships does C2PA have?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected an IsError result for an unknown slug")
+	}
+	if got := resultText(t, res); got != rejection {
+		t.Errorf("rejection text changed:\n got: %q\nwant: %q", got, rejection)
+	}
+}
+
+// A normal completed answer, scope line and all, is not an error.
+func TestQueryLFXLensCompletedAnswerIsNotAnError(t *testing.T) {
+	const answer = "**scope**: LF-wide — no project filter applied.\n\n### Countries\n| N |\n| --- |\n| 140 |"
+	setupLensTestResponding(t, `{"content":`+strconv.Quote(answer)+`,"status":"COMPLETED","session_id":"s"}`)
+
+	res, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+		Input: "How many countries have active member organisations?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %s", resultText(t, res))
+	}
+	if got := resultText(t, res); got != answer {
+		t.Errorf("answer changed: %q", got)
+	}
+}
+
+// lensAdditionalData returns the additional_data multipart field of the
+// captured workflow request.
+func lensAdditionalData(t *testing.T, captured *capturedLensRequest) string {
+	t.Helper()
+	body := string(captured.Body)
+	marker := "name=\"additional_data\""
+	i := strings.Index(body, marker)
+	if i < 0 {
+		t.Fatalf("no additional_data field in body: %s", body)
+	}
+	rest := body[i+len(marker):]
+	// Skip the header/body separator, then read to the next boundary.
+	rest = rest[strings.Index(rest, "\r\n\r\n")+4:]
+	end := strings.Index(rest, "\r\n--")
+	if end < 0 {
+		t.Fatalf("unterminated additional_data field: %s", body)
+	}
+	return rest[:end]
+}
+
+// setupLensTestResponding is setupLensTest with a chosen JSON response body.
+func setupLensTestResponding(t *testing.T, response string) *capturedLensRequest {
+	t.Helper()
+
+	captured := &capturedLensRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		captured.Body = body
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := serviceapi.NewClient(serviceapi.Config{
+		BaseURL:     srv.URL,
+		TokenSource: stubTokenSource{},
+	})
+	if err != nil {
+		t.Fatalf("failed to create service API client: %v", err)
+	}
+
+	prev := lensConfig
+	SetLensConfig(&LensConfig{ServiceClient: client})
+	t.Cleanup(func() { lensConfig = prev })
+
+	return captured
 }
 
 // TestQueryLFXLensDoesNotClaimMemberships guards the other half of the routing

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -531,6 +531,32 @@ func TestEveryClientTextSaysTlfIsNotTheLFWideScope(t *testing.T) {
 	}
 }
 
+// Project discovery must not send Lens callers back to the removed mandatory
+// slug contract, even while the query tool itself advertises the new schema.
+func TestSearchProjectsIncludesLensInOptionalScopeContract(t *testing.T) {
+	tool := listRegisteredTool(t, "search_projects", RegisterSearchProjects)
+	for _, want := range []string{
+		"LF-wide questions take no project on the query tools",
+		"query_lfx_lens included (omit project_slugs)",
+		"pass project_slugs only to restrict to named projects",
+	} {
+		if !strings.Contains(tool.Description, want) {
+			t.Errorf("search_projects description missing %q", want)
+		}
+	}
+	for _, banned := range []string{
+		"query_lfx_lens is the exception", "project_slug is required",
+		"pass tlf there", "required context",
+	} {
+		if strings.Contains(strings.ToLower(tool.Description), banned) {
+			t.Errorf("search_projects still teaches the removed Lens scope contract: %q", banned)
+		}
+	}
+	if len(tool.Description) > 2048 {
+		t.Errorf("search_projects description exceeds 2048 bytes: %d", len(tool.Description))
+	}
+}
+
 func TestNoToolCallsMembershipsATodayOnlySnapshot(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -6,6 +6,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -38,6 +39,12 @@ type capturedLensRequest struct {
 // lensConfig is a package-level global.
 func setupLensTest(t *testing.T) *capturedLensRequest {
 	t.Helper()
+	return setupLensTestResponding(t, `{"ok": true}`)
+}
+
+// setupLensTestResponding is setupLensTest with a chosen JSON response body.
+func setupLensTestResponding(t *testing.T, response string) *capturedLensRequest {
+	t.Helper()
 
 	captured := &capturedLensRequest{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +55,7 @@ func setupLensTest(t *testing.T) *capturedLensRequest {
 		captured.Body = body
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ok": true}`))
+		_, _ = w.Write([]byte(response))
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1085,6 +1092,76 @@ func TestQueryLFXLensUnknownSlugIsAnError(t *testing.T) {
 	}
 }
 
+// The other two rejections the lens can return are errors too, and a caller
+// can tell them apart by their opener.
+func TestQueryLFXLensOtherRejectionsAreErrors(t *testing.T) {
+	for _, rejection := range []string{
+		"Invalid project_slugs: at most 25 slugs per call (30 given). Pass a list of exact slugs from search_projects, or omit project_slugs for an LF-wide answer.",
+		"Project scope could not be resolved: the warehouse lookup failed (OperationalError). The slugs may be correct; retry, or omit project_slugs for an LF-wide answer.",
+	} {
+		setupLensTestResponding(t, `{"content":`+strconv.Quote(rejection)+`,"status":"COMPLETED","session_id":"s"}`)
+
+		res, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+			ProjectSlugs: []string{"cncf"},
+			Input:        "How many members do we have?",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !res.IsError {
+			t.Errorf("expected IsError for %q", rejection[:30])
+		}
+		if got := resultText(t, res); got != rejection {
+			t.Errorf("rejection text changed: %q", got)
+		}
+	}
+}
+
+// Oversized or malformed lists are argument errors here, before the lens is
+// called, and the offending value is not echoed back.
+func TestQueryLFXLensRejectsOversizedSlugLists(t *testing.T) {
+	captured := setupLensTest(t)
+
+	tooMany := make([]string, 0, maxLensProjectSlugs+1)
+	for i := 0; i <= maxLensProjectSlugs; i++ {
+		tooMany = append(tooMany, fmt.Sprintf("slug-%d", i))
+	}
+	cases := map[string][]string{
+		"too many":      tooMany,
+		"too long":      {strings.Repeat("x", maxLensSlugLength+1)},
+		"control chars": {"cncf\nDROP"},
+		"tab in slug":   {"cn\tcf"},
+	}
+	for name, slugs := range cases {
+		_, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+			ProjectSlugs: slugs,
+			Input:        "How many members?",
+		})
+		if err == nil || !strings.HasPrefix(err.Error(), "project_slugs:") {
+			t.Errorf("%s: expected a project_slugs argument error, got %v", name, err)
+		}
+		if strings.Contains(err.Error(), "xxxx") || strings.Contains(err.Error(), "DROP") {
+			t.Errorf("%s: error echoes the offending value: %q", name, err)
+		}
+		if captured.Body != nil {
+			t.Errorf("%s: the lens was called with an invalid list", name)
+		}
+	}
+
+	// exactly the cap, with duplicates that collapse under it, is fine
+	atCap := make([]string, 0, maxLensProjectSlugs+2)
+	for i := 0; i < maxLensProjectSlugs; i++ {
+		atCap = append(atCap, fmt.Sprintf("slug-%d", i))
+	}
+	atCap = append(atCap, "slug-0", " slug-1 ")
+	if _, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
+		ProjectSlugs: atCap,
+		Input:        "How many members?",
+	}); err != nil {
+		t.Errorf("a list at the cap must pass, got %v", err)
+	}
+}
+
 // A normal completed answer, scope line and all, is not an error.
 func TestQueryLFXLensCompletedAnswerIsNotAnError(t *testing.T) {
 	const answer = "**scope**: LF-wide — no project filter applied.\n\n### Countries\n| N |\n| --- |\n| 140 |"
@@ -1116,43 +1193,16 @@ func lensAdditionalData(t *testing.T, captured *capturedLensRequest) string {
 	}
 	rest := body[i+len(marker):]
 	// Skip the header/body separator, then read to the next boundary.
-	rest = rest[strings.Index(rest, "\r\n\r\n")+4:]
+	sep := strings.Index(rest, "\r\n\r\n")
+	if sep < 0 {
+		t.Fatalf("additional_data field has no header/body separator: %s", body)
+	}
+	rest = rest[sep+4:]
 	end := strings.Index(rest, "\r\n--")
 	if end < 0 {
 		t.Fatalf("unterminated additional_data field: %s", body)
 	}
 	return rest[:end]
-}
-
-// setupLensTestResponding is setupLensTest with a chosen JSON response body.
-func setupLensTestResponding(t *testing.T, response string) *capturedLensRequest {
-	t.Helper()
-
-	captured := &capturedLensRequest{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		captured.Method = r.Method
-		captured.Path = r.URL.Path
-		body, _ := io.ReadAll(r.Body)
-		captured.Body = body
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(response))
-	}))
-	t.Cleanup(srv.Close)
-
-	client, err := serviceapi.NewClient(serviceapi.Config{
-		BaseURL:     srv.URL,
-		TokenSource: stubTokenSource{},
-	})
-	if err != nil {
-		t.Fatalf("failed to create service API client: %v", err)
-	}
-
-	prev := lensConfig
-	SetLensConfig(&LensConfig{ServiceClient: client})
-	t.Cleanup(func() { lensConfig = prev })
-
-	return captured
 }
 
 // TestQueryLFXLensDoesNotClaimMemberships guards the other half of the routing

--- a/internal/tools/lens_test.go
+++ b/internal/tools/lens_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -482,16 +483,24 @@ func TestLayerToolsRouteToTheStandardMetricsFirst(t *testing.T) {
 // TestEveryClientTextSaysTlfIsNotTheLFWideScope pins R44: the foundation's own
 // slug is a bucket, and every tool that hands it over or accepts it says so in
 // the same words, so a client never adds tlf when the question is LF-wide.
-// query_lfx_lens is the one tool whose project_slug is required: tlf goes
-// there as context and the LF-wide scope is said in the input; no client text
-// may read as "tlf gives LF-wide".
+// query_lfx_lens no longer needs the exception R44 gave its required
+// project_slug: its optional project_slugs list represents LF-wide as []. Its
+// description and schema therefore must not mention tlf at all.
 func TestEveryClientTextSaysTlfIsNotTheLFWideScope(t *testing.T) {
+	lens := listRegisteredTool(t, "query_lfx_lens", RegisterQueryLFXLens)
+	lensSchema, err := json.Marshal(lens.InputSchema)
+	if err != nil {
+		t.Fatalf("query_lfx_lens: marshal schema: %v", err)
+	}
+	if strings.Contains(strings.ToLower(lens.Description+string(lensSchema)), "tlf") {
+		t.Error("query_lfx_lens still mentions tlf instead of representing LF-wide as []")
+	}
+
 	const phrase = "not the LF-wide scope"
 	for _, tc := range []struct {
 		name     string
 		register func(*mcp.Server)
 	}{
-		{"query_lfx_lens", RegisterQueryLFXLens},
 		{"query_lfx_semantic_layer", RegisterQuerySemanticLayer},
 		{"query_lfx_standard_metrics", RegisterStandardMetrics},
 		{"search_projects", RegisterSearchProjects},
@@ -935,7 +944,7 @@ func TestQueryLFXLensScopeIsOptionalAndExplicit(t *testing.T) {
 		"no project or foundation filter",
 		"several slugs are combined",
 		"Unknown slugs are rejected",
-		"Every answer opens with the scope it ran with",
+		"Every answer opens with the scope the caller gave",
 		// Lens generates its own SQL and picks arbitrary windows when the
 		// question leaves them open — the description must carry the default
 		// window convention and require concrete dates in the question.
@@ -1127,10 +1136,12 @@ func TestQueryLFXLensRejectsOversizedSlugLists(t *testing.T) {
 		tooMany = append(tooMany, fmt.Sprintf("slug-%d", i))
 	}
 	cases := map[string][]string{
-		"too many":      tooMany,
-		"too long":      {strings.Repeat("x", maxLensSlugLength+1)},
-		"control chars": {"cncf\nDROP"},
-		"tab in slug":   {"cn\tcf"},
+		"too many":         tooMany,
+		"duplicate flood":  slices.Repeat([]string{"cncf"}, maxLensProjectSlugs+1),
+		"too long":         {strings.Repeat("x", maxLensSlugLength+1)},
+		"control chars":    {"cncf\nDROP"},
+		"trailing newline": {"cncf\n"},
+		"tab in slug":      {"cn\tcf"},
 	}
 	for name, slugs := range cases {
 		_, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{
@@ -1148,9 +1159,9 @@ func TestQueryLFXLensRejectsOversizedSlugLists(t *testing.T) {
 		}
 	}
 
-	// exactly the cap, with duplicates that collapse under it, is fine
-	atCap := make([]string, 0, maxLensProjectSlugs+2)
-	for i := 0; i < maxLensProjectSlugs; i++ {
+	// Exactly the raw cap is fine; de-duplication still preserves first order.
+	atCap := make([]string, 0, maxLensProjectSlugs)
+	for i := 0; i < maxLensProjectSlugs-2; i++ {
 		atCap = append(atCap, fmt.Sprintf("slug-%d", i))
 	}
 	atCap = append(atCap, "slug-0", " slug-1 ")
@@ -1164,7 +1175,7 @@ func TestQueryLFXLensRejectsOversizedSlugLists(t *testing.T) {
 
 // A normal completed answer, scope line and all, is not an error.
 func TestQueryLFXLensCompletedAnswerIsNotAnError(t *testing.T) {
-	const answer = "**scope**: LF-wide — no project filter applied.\n\n### Countries\n| N |\n| --- |\n| 140 |"
+	const answer = "**scope**: LF-wide — no project filter from the caller; a project named in the question is filtered as asked (see compiled_sql).\n\n### Countries\n| N |\n| --- |\n| 140 |"
 	setupLensTestResponding(t, `{"content":`+strconv.Quote(answer)+`,"status":"COMPLETED","session_id":"s"}`)
 
 	res, _, err := handleQueryLFXLens(context.Background(), &mcp.CallToolRequest{}, QueryLFXLensArgs{

--- a/internal/tools/project.go
+++ b/internal/tools/project.go
@@ -48,7 +48,7 @@ type projectGetResult struct {
 func RegisterSearchProjects(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_projects",
-		Description: "Search for LFX projects by name or by parent project UID using the LFX query service. The Linux Foundation's own entry (slug tlf) is one project bucket, not the LF-wide scope: LF-wide questions take no project on the query tools; query_lfx_lens is the exception only because its project_slug is required — pass tlf there as context and say LF-wide in the input; the lens reads the scope from the input, not from the slug.",
+		Description: "Search for LFX projects by name or by parent project UID using the LFX query service. The Linux Foundation's own entry (slug tlf) is one project bucket, not the LF-wide scope. LF-wide questions take no project on the query tools, query_lfx_lens included (omit project_slugs); pass project_slugs only to restrict to named projects.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Search Projects",
 			ReadOnlyHint: true,


### PR DESCRIPTION
## Summary

**SM-2 is the optional project-scope contract only.** Companion: linuxfoundation/lfx-lens#37.

- `query_lfx_lens.project_slugs` is an optional string list. Omit it for LF-wide questions; pass exact slugs from `search_projects` only to restrict the caller's scope. Several slugs are combined in one request.
- Remove singular `project_slug` without an alias. The closed request schema rejects stale callers instead of silently changing their scope.
- Trim and deduplicate in order without case folding. Bound the raw list before normalization: at most 25 entries, 128 bytes per slug, and no control characters. Blank input is an argument error.
- Always forward `additional_data: {"project_slugs": [...]}`, including an empty list when no scope is supplied. Forward the three Lens scope-rejection prefixes as `IsError`, with their text unchanged.
- Correct both query and discovery descriptions: `search_projects` no longer tells callers the Lens tool requires a slug or recommends `tlf` for LF-wide requests. The answer's opening scope line describes the caller-supplied scope; compiled SQL remains the authority for filters explicitly requested in the question.
- Update the architecture diagram to describe the opening scope line only. L3 is deferred to SM-4 and is not part of this delivery.

Staff registration, guidance files and tool implementation are unchanged by the final documentation-only cleanup. No AWS or ArgoCD values are changed.

## Release order

**Release linuxfoundation/lfx-lens#37 first.** Lens temporarily accepts both the optional-list shape and the legacy foundation shape, so the currently deployed caller remains compatible while the new contract is rolled out.

## Validation

- Final cleanup commit: `361be9b8c4eb986a206f432c3a14fcc7146da38e`; its only source change is one architecture-diagram line.
- `go build ./...`, `go vet ./...`, `go test ./...` and `make check` pass installed checks. Optional golangci-lint and revive were unavailable and skipped.
- Existing regressions cover optional scope, normalization/bounds, rejection forwarding, closed-schema shape, description budgets and cross-tool discovery guidance.
- A real SDK `tools/call` with stale `project_slug` returns `unexpected additional properties ["project_slug"]` before the handler; no Lens client was configured for that probe.
- Fresh companion Lens runs cover LF-wide, two-slug and legacy-foundation scope and preserve existing compiled SQL. Those author checks used the real workflow in-process, not a new end-to-end Auth0 or independent rig cycle.

The earlier x/crypto finding was fixed upstream and inherited through the rebase onto main; this PR does not carry a dependency change relative to that base.

## Follow-ups

Remove the Lens legacy foundation shape after its compatibility release. Consider a structured scope-error signal separately. Neither is required to remove the old required-slug contract.

Jira: https://linuxfoundation.atlassian.net/browse/LFXV2-2891

🤖 Generated with [Claude Code](https://claude.com/claude-code) on Pi

Pi-Session: oas://semantic-layer-engineer/semantic-layer-engineer-sm2-lens-scope
