### PR TITLE
Add scope parameter to WWW-Authenticate auth challenges

### DIFF
--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -980,6 +980,7 @@ func runHTTPServer(cfg Config, otelCfg localOtel.Config, otelShutdown func(conte
 
 		authMiddleware := auth.RequireBearerToken(verifyToken, &auth.RequireBearerTokenOptions{
 			ResourceMetadataURL: resourceMetadataURL,
+			Scopes:              tools.EnforcedScopes(),
 		})
 		mcpHandler = authMiddleware(handler)
 		logger.Info("OAuth bearer token verification enabled for /mcp endpoint", "audience", audience)

--- a/cmd/lfx-mcp-server/main.go
+++ b/cmd/lfx-mcp-server/main.go
@@ -891,6 +891,20 @@ func runHTTPServer(cfg Config, otelCfg localOtel.Config, otelShutdown func(conte
 		logger.Info("static API-key authentication enabled (TEMPORARY)")
 	}
 
+	// Resolve the advertised scope set once. The same value is used for the
+	// WWW-Authenticate challenge and the Protected Resource Metadata document
+	// so the two can never drift.
+	var scopesSupported []string
+	if len(cfg.MCPAPI.AuthServers) > 0 {
+		// Use defaults when no scopes are configured, then validate to ensure
+		// the enforced scopes are always present and warn about unknown ones.
+		scopesSupported = cfg.MCPAPI.Scopes
+		if len(scopesSupported) == 0 {
+			scopesSupported = tools.DefaultScopes()
+		}
+		scopesSupported = tools.ValidateScopes(scopesSupported, logger.Warn)
+	}
+
 	// Apply auth middleware to the /mcp handler.
 	var mcpHandler http.Handler = handler
 	if len(cfg.MCPAPI.AuthServers) > 0 {
@@ -980,9 +994,13 @@ func runHTTPServer(cfg Config, otelCfg localOtel.Config, otelShutdown func(conte
 
 		authMiddleware := auth.RequireBearerToken(verifyToken, &auth.RequireBearerTokenOptions{
 			ResourceMetadataURL: resourceMetadataURL,
-			Scopes:              tools.EnforcedScopes(),
 		})
-		mcpHandler = authMiddleware(handler)
+		// Note: RequireBearerTokenOptions.Scopes is deliberately left unset. It is
+		// not challenge-only: the SDK requires every listed scope to be present,
+		// which would reject valid read:all-only and manage:all-only tokens and
+		// bypass the OR/implication logic in newServer(). The challenge scopes are
+		// added by withChallengeScopes instead.
+		mcpHandler = withChallengeScopes(authMiddleware(handler), scopesSupported)
 		logger.Info("OAuth bearer token verification enabled for /mcp endpoint", "audience", audience)
 	}
 
@@ -1001,14 +1019,6 @@ func runHTTPServer(cfg Config, otelCfg localOtel.Config, otelShutdown func(conte
 		if resourceURL == "" {
 			resourceURL = fmt.Sprintf("http://%s:%d/mcp", cfg.HTTP.Host, cfg.HTTP.Port)
 		}
-
-		// Use defaults when no scopes are configured, then validate to ensure
-		// the enforced scopes are always present and warn about unknown ones.
-		scopesSupported := cfg.MCPAPI.Scopes
-		if len(scopesSupported) == 0 {
-			scopesSupported = tools.DefaultScopes()
-		}
-		scopesSupported = tools.ValidateScopes(scopesSupported, logger.Warn)
 
 		metadata := &oauthex.ProtectedResourceMetadata{
 			Resource:             resourceURL,
@@ -1110,4 +1120,61 @@ func localhostOnly(h http.Handler) http.Handler {
 		}
 		h.ServeHTTP(w, r)
 	})
+}
+
+// withChallengeScopes wraps h and appends a "scope" parameter to the
+// WWW-Authenticate header on 401 and 403 responses, as recommended by RFC 6750
+// section 3 and the MCP authorization spec's scope selection strategy. Clients
+// treat this value as authoritative and fall back to the Protected Resource
+// Metadata scopes_supported field only when it is absent, so the same scope set
+// is used for both.
+//
+// This is done here rather than via RequireBearerTokenOptions.Scopes because
+// that option also enforces the scopes, requiring all of them to be present on
+// the token. The server grants read access to manage:all tokens and registers
+// tools per scope in newServer(), so enforcing both scopes at the HTTP layer
+// would reject tokens that are valid for a subset of the tools.
+func withChallengeScopes(h http.Handler, scopes []string) http.Handler {
+	if len(scopes) == 0 {
+		return h
+	}
+	scopeParam := fmt.Sprintf("scope=%q", strings.Join(scopes, " "))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(&challengeScopeWriter{ResponseWriter: w, scopeParam: scopeParam}, r)
+	})
+}
+
+// challengeScopeWriter appends the scope parameter to any WWW-Authenticate
+// header set on an auth challenge response.
+type challengeScopeWriter struct {
+	http.ResponseWriter
+	scopeParam string
+}
+
+func (w *challengeScopeWriter) WriteHeader(code int) {
+	if code == http.StatusUnauthorized || code == http.StatusForbidden {
+		header := w.Header()
+		key := http.CanonicalHeaderKey("WWW-Authenticate")
+		if challenges := header.Values(key); len(challenges) > 0 {
+			updated := make([]string, len(challenges))
+			for i, challenge := range challenges {
+				// Only Bearer challenges take a scope parameter, and it must not
+				// be added twice if an inner handler already set one.
+				if strings.HasPrefix(challenge, "Bearer") && !strings.Contains(challenge, "scope=") {
+					challenge += ", " + w.scopeParam
+				}
+				updated[i] = challenge
+			}
+			header[key] = updated
+		}
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+// Flush implements http.Flusher so that the streamable HTTP transport can send
+// server-sent events through this wrapper.
+func (w *challengeScopeWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }

--- a/cmd/lfx-mcp-server/main_test.go
+++ b/cmd/lfx-mcp-server/main_test.go
@@ -7,8 +7,11 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/linuxfoundation/lfx-mcp/internal/tools"
 	"github.com/modelcontextprotocol/go-sdk/auth"
@@ -157,5 +160,225 @@ func TestNewServer_LensToolsAreStaffOnly(t *testing.T) {
 		if !forStaff[name] {
 			t.Errorf("%s is not listed for a staff reader", name)
 		}
+	}
+}
+
+// challengeScopes are the scopes the server advertises. They mirror what
+// runHTTPServer passes to withChallengeScopes, which is the same slice it
+// hands the Protected Resource Metadata document.
+var challengeScopes = []string{"openid", "profile", "email", tools.ScopeRead, tools.ScopeManage}
+
+// authChain builds the /mcp middleware stack exactly as runHTTPServer does:
+// bearer verification, then the challenge-scope wrapper. The verifier accepts
+// any token whose name is a key in scopesByToken.
+func authChain(handler http.Handler, scopesByToken map[string][]string) http.Handler {
+	verify := func(_ context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
+		scopes, ok := scopesByToken[token]
+		if !ok {
+			return nil, auth.ErrInvalidToken
+		}
+		return &auth.TokenInfo{
+			UserID:     "test-user",
+			Scopes:     scopes,
+			Expiration: time.Now().Add(time.Hour),
+		}, nil
+	}
+	middleware := auth.RequireBearerToken(verify, &auth.RequireBearerTokenOptions{
+		ResourceMetadataURL: "https://mcp.example.com/.well-known/oauth-protected-resource",
+	})
+	return withChallengeScopes(middleware(handler), challengeScopes)
+}
+
+// TestChallengeScopes_TokensReachHandler pins the authorization behaviour that
+// the challenge scopes must not disturb. read:all and manage:all are alternative
+// grants, not a required pair — newServer decides per tool which one applies, and
+// manage:all implies read. Advertising both scopes on the challenge must not turn
+// them into a conjunction at the HTTP layer, which is what setting them on
+// RequireBearerTokenOptions.Scopes would do.
+func TestChallengeScopes_TokensReachHandler(t *testing.T) {
+	tests := []struct {
+		name   string
+		token  string
+		scopes []string
+	}{
+		{name: "read-only token", token: "reader", scopes: []string{tools.ScopeRead}},
+		{name: "manage-only token", token: "manager", scopes: []string{tools.ScopeManage}},
+		{name: "both scopes", token: "both", scopes: []string{tools.ScopeRead, tools.ScopeManage}},
+	}
+
+	byToken := make(map[string][]string, len(tests))
+	for _, tt := range tests {
+		byToken[tt.token] = tt.scopes
+	}
+
+	var reached bool
+	handler := authChain(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}), byToken)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reached = false
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			req.Header.Set("Authorization", "Bearer "+tt.token)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d; %s was rejected before reaching the handler",
+					rec.Code, http.StatusOK, tt.name)
+			}
+			if !reached {
+				t.Error("handler was not reached")
+			}
+			if got := rec.Header().Get("WWW-Authenticate"); got != "" {
+				t.Errorf("WWW-Authenticate = %q on a successful response, want none", got)
+			}
+		})
+	}
+}
+
+// TestChallengeScopes_Challenge pins the scope parameter onto the challenge an
+// unauthenticated caller receives. Clients treat it as authoritative and only
+// fall back to the metadata document when it is absent, so it has to carry the
+// full advertised set rather than just the enforced ones.
+func TestChallengeScopes_Challenge(t *testing.T) {
+	handler := authChain(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), map[string][]string{"reader": {tools.ScopeRead}})
+
+	for _, tt := range []struct {
+		name       string
+		authHeader string
+	}{
+		{name: "no token"},
+		{name: "unknown token", authHeader: "Bearer nope"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+			}
+			// A duplicate header would leave a client parsing two conflicting
+			// challenges, so the wrapper must rewrite in place rather than add.
+			challenges := rec.Header().Values("WWW-Authenticate")
+			if len(challenges) != 1 {
+				t.Fatalf("got %d WWW-Authenticate headers, want 1: %q", len(challenges), challenges)
+			}
+			want := `Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", scope="openid profile email read:all manage:all"`
+			if challenges[0] != want {
+				t.Errorf("WWW-Authenticate =\n  %q\nwant\n  %q", challenges[0], want)
+			}
+		})
+	}
+}
+
+// TestWithChallengeScopes pins the wrapper itself against the cases the
+// middleware stack does not exercise: challenges the SDK does not emit, and
+// responses that must be left alone.
+func TestWithChallengeScopes(t *testing.T) {
+	const scopeParam = `scope="read:all manage:all"`
+
+	tests := []struct {
+		name     string
+		code     int
+		existing []string
+		want     []string
+	}{
+		{
+			name:     "401 gains the scope parameter",
+			code:     http.StatusUnauthorized,
+			existing: []string{`Bearer realm="mcp"`},
+			want:     []string{`Bearer realm="mcp", ` + scopeParam},
+		},
+		{
+			// Insufficient-scope errors carry the same guidance as a 401.
+			name:     "403 gains the scope parameter",
+			code:     http.StatusForbidden,
+			existing: []string{`Bearer error="insufficient_scope"`},
+			want:     []string{`Bearer error="insufficient_scope", ` + scopeParam},
+		},
+		{
+			// The SDK sets scope itself when configured to enforce scopes.
+			// Appending a second one would make the challenge ambiguous.
+			name:     "existing scope parameter is left alone",
+			code:     http.StatusUnauthorized,
+			existing: []string{`Bearer scope="read:all"`},
+			want:     []string{`Bearer scope="read:all"`},
+		},
+		{
+			// scope is defined for Bearer; other schemes have their own grammar.
+			name:     "non-Bearer challenge is left alone",
+			code:     http.StatusUnauthorized,
+			existing: []string{`Basic realm="mcp"`},
+			want:     []string{`Basic realm="mcp"`},
+		},
+		{
+			name:     "success response is left alone",
+			code:     http.StatusOK,
+			existing: nil,
+			want:     nil,
+		},
+		{
+			name:     "challenge-less 401 stays challenge-less",
+			code:     http.StatusUnauthorized,
+			existing: nil,
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := withChallengeScopes(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				for _, challenge := range tt.existing {
+					w.Header().Add("WWW-Authenticate", challenge)
+				}
+				w.WriteHeader(tt.code)
+			}), []string{tools.ScopeRead, tools.ScopeManage})
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+
+			if rec.Code != tt.code {
+				t.Errorf("status = %d, want %d", rec.Code, tt.code)
+			}
+			if got := rec.Header().Values("WWW-Authenticate"); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WWW-Authenticate = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWithChallengeScopes_NoScopes pins the empty case: with nothing to
+// advertise the wrapper returns the handler untouched, so a deployment without
+// configured scopes behaves as it did before.
+func TestWithChallengeScopes_NoScopes(t *testing.T) {
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	if got := withChallengeScopes(handler, nil); reflect.ValueOf(got).Pointer() != reflect.ValueOf(handler).Pointer() {
+		t.Error("withChallengeScopes wrapped the handler despite having no scopes to advertise")
+	}
+}
+
+// TestChallengeScopeWriter_Flush pins Flusher support. The streamable HTTP
+// transport sends server-sent events, so a wrapper that hides Flush from it
+// would stall responses.
+func TestChallengeScopeWriter_Flush(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var w http.ResponseWriter = &challengeScopeWriter{ResponseWriter: rec, scopeParam: `scope="read:all"`}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("challengeScopeWriter does not implement http.Flusher")
+	}
+	flusher.Flush()
+	if !rec.Flushed {
+		t.Error("Flush did not reach the underlying ResponseWriter")
 	}
 }

--- a/internal/tools/scopes.go
+++ b/internal/tools/scopes.go
@@ -22,18 +22,6 @@ func DefaultScopes() []string {
 	return []string{"openid", "profile", "email", ScopeRead, ScopeManage}
 }
 
-// EnforcedScopes returns the scopes actually checked by the server when
-// gating tool registration (see newServer() in cmd/lfx-mcp-server/main.go).
-// Unlike DefaultScopes, this excludes standard OIDC identity scopes (openid,
-// profile, email) since those aren't required for resource access. It's used
-// to populate the "scope" parameter on the WWW-Authenticate challenge per the
-// MCP authorization spec's "Scope Selection Strategy", giving clients
-// immediate guidance on which scopes to request instead of only discovering
-// them via the Protected Resource Metadata's scopes_supported field.
-func EnforcedScopes() []string {
-	return []string{ScopeRead, ScopeManage}
-}
-
 // ValidateScopes checks a configured scope list for unrecognised entries and
 // returns it unchanged. It logs a warning for any scope that is neither an
 // enforced scope nor a standard OIDC scope — those will be advertised via the

--- a/internal/tools/scopes.go
+++ b/internal/tools/scopes.go
@@ -22,6 +22,18 @@ func DefaultScopes() []string {
 	return []string{"openid", "profile", "email", ScopeRead, ScopeManage}
 }
 
+// EnforcedScopes returns the scopes actually checked by the server when
+// gating tool registration (see newServer() in cmd/lfx-mcp-server/main.go).
+// Unlike DefaultScopes, this excludes standard OIDC identity scopes (openid,
+// profile, email) since those aren't required for resource access. It's used
+// to populate the "scope" parameter on the WWW-Authenticate challenge per the
+// MCP authorization spec's "Scope Selection Strategy", giving clients
+// immediate guidance on which scopes to request instead of only discovering
+// them via the Protected Resource Metadata's scopes_supported field.
+func EnforcedScopes() []string {
+	return []string{ScopeRead, ScopeManage}
+}
+
 // ValidateScopes checks a configured scope list for unrecognised entries and
 // returns it unchanged. It logs a warning for any scope that is neither an
 // enforced scope nor a standard OIDC scope — those will be advertised via the


### PR DESCRIPTION
## Summary

Adds a `scope` parameter to the `WWW-Authenticate` header returned on auth challenges from `/mcp`, per [RFC 6750 §3](https://datatracker.ietf.org/doc/html/rfc6750#section-3) and the MCP authorization spec's Scope Selection Strategy ([2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#scope-selection-strategy), [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#scope-selection-strategy) — both specs word this identically).

This gives clients the scopes to request during the initial authorization handshake without a second round-trip to the Protected Resource Metadata document.

## Why a wrapper rather than the SDK option

`auth.RequireBearerTokenOptions.Scopes` looks like the obvious home for this, but it is **not challenge-only** — the SDK also enforces it, requiring *every* listed scope to be present ([`auth.go` in v1.6.1](https://github.com/modelcontextprotocol/go-sdk/blob/v1.6.1/auth/auth.go#L121-L129)):

```go
// Check scopes. All must be present.
for _, s := range opts.Scopes {
    if !slices.Contains(tokenInfo.Scopes, s) { return nil, "insufficient scope", 403 }
}
```

Our scopes are alternatives, not a required pair: `newServer()` gates each tool on `canRead` or `canManage`, and `manage:all` implies read. Passing both to the SDK would 403 every real single-scope token; passing either one alone would 403 the other. The behaviour is unchanged in every released SDK version through `v1.8.0-pre.2`.

So `Scopes` is left unset and the parameter is added by a `withChallengeScopes` response wrapper, leaving authorization behaviour byte-for-byte identical.

## Why the full scope set

The challenge carries `openid profile email read:all manage:all` — the same set as `scopes_supported`, not just the two enforced scopes.

Clients treat the challenge as authoritative and fall back to `scopes_supported` *only when it is absent* — the header replaces the document, it does not supplement it. Advertising only the enforced scopes would therefore cause compliant clients to stop requesting the OIDC scopes, breaking the identity claims the server reads (`ExtractUsername`, `ClaimLFStaff`).

Both values now come from one resolved variable, so they cannot drift.

## Verification

401 with no token, and the metadata document, from a local build:

```
Www-Authenticate: Bearer resource_metadata="http://localhost:18082/.well-known/oauth-protected-resource", scope="openid profile email read:all manage:all"
scopes_supported: ["openid","profile","email","read:all","manage:all"]
```

Current dev deployment (pre-fix baseline):

```
www-authenticate: Bearer resource_metadata="https://lfx-mcp.dev.v2.cluster.linuxfound.info/.well-known/oauth-protected-resource"
```

Tests cover read-only, manage-only, and both-scope tokens reaching the handler; the challenge contents; and that a success response, a non-Bearer challenge, and a pre-existing `scope` parameter are all left alone. Reintroducing the SDK-enforcement approach fails `TestChallengeScopes_TokensReachHandler` with 403s on the single-scope tokens.

## Follow-ups (not in this PR)

- Dev's deployed `LFXMCP_MCP_API_SCOPES` is `openid profile offline_access read:all manage:all` — it includes `offline_access`, which both specs say servers **SHOULD NOT** advertise, and omits `email`. Worth reconciling with `DefaultScopes()` when dev is updated.
- `ValidateScopes` warns on unrecognized scopes but does not reject characters outside the RFC 6749 `scope-token` grammar.

## Notes

- No README changes here — held for #127 until dev is updated and validated with this live.
- Related: linuxfoundation/lfx-mcp#126

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)