### PR TITLE
feat(tools): route meeting totals to the semantic layer's occurrence and attendance metrics

### DIFF
--- a/internal/tools/guidance/semantic-layer.md
+++ b/internal/tools/guidance/semantic-layer.md
@@ -20,7 +20,7 @@ Dimension qualified_names are entity__field, prefix per metric — copy from exp
   counts as of a past date or by year, social listening aggregates, event,
   training and health figures, and people rankings (top contributors, top
   maintainers) are standard metrics, not lens questions.
-- Committee/board/ambassador rosters: committee tools. Meeting lists and one meeting's details: meeting tools. Counts of meetings and participants with the caller's visibility: count_lfx_resources and search_past_meeting_participants (recipe 12). Meeting ATTENDANCE aggregates are in this layer (recipe 12).
+- Committee/board/ambassador rosters: committee tools. Meeting lists and one meeting's details: meeting tools. Counts of meetings and participants with the caller's visibility: count_lfx_resources and search_past_meeting_participants (recipe 12). Meeting TOTALS over a period (occurrences, scheduled minutes, unique attendees, attendances) are in this layer (recipe 12).
 - How many projects a foundation or parent has: this layer's project metrics count the authoritative project directory; search_projects and count_lfx_resources count only projects onboarded into LFX v2 and can be lower — use the tools to resolve names and slugs, the layer for the number.
 - Where this layer and the standard metrics read differently (both are
   right; say which one you used): dates are UTC calendar days on the
@@ -245,26 +245,33 @@ PEOPLE is maintainer_contributions by=maintainer.
 12. ROSTERS AND MEETINGS. search_committees → search_committee_members (paginate;
 group-mode names: search_groups/search_group_members). Never infer a roster from
 membership or event data. Meeting LISTS and one meeting's details:
-search_meetings and search_past_meetings. Meeting ATTENDANCE aggregates
-(attendance by company, committee or meeting type, over a period) are in this
-layer, on the meeting attendance model: attendees_count (attendance records
-where the invitee attended), invited_count (invited records),
-unverified_attendee_count; time axis metric_time = the meeting date. GRAIN: one
-row per invitee per meeting occurrence, so attendees_count is attendance
-RECORDS, not unique people — one person at ten meetings counts ten; say
-"attendances", never "attendees", and attendance rate is attendees_count over
-invited_count on the same slice (walk-ins attend uninvited, so the rate can
-exceed 1 on a small slice). SLICES: primary_key__meeting_type (carries both a
-'None' literal and NULL — both are untyped), primary_key__committee_type,
+search_meetings and search_past_meetings. Meeting TOTALS over a period are in
+this layer on two models. OCCURRENCES (one row per meeting occurrence):
+meeting_occurrences (distinct occurrences held) and scheduled_meeting_minutes
+(sum of the scheduled duration — join and leave times are not recorded, so say
+"scheduled minutes", never time spent); meeting_and_occurrence_id__has_attendance
+= true keeps only occurrences with at least one attendee; time axis metric_time
+= the meeting date. ATTENDANCE (one row per invitee per meeting occurrence):
+unique_attendees (distinct PEOPLE who attended — identity is the LF user id,
+else the e-mail), attendees_count (attendance RECORDS where the invitee attended
+— one person at ten meetings counts ten), invited_count (invited records),
+unverified_attendee_count; time axis metric_time = the meeting date. Say
+"attendees" only for unique_attendees and "attendances" for attendees_count;
+attendance rate is attendees_count over invited_count on the same slice
+(walk-ins attend uninvited, so the rate can exceed 1 on a small slice). SLICES
+on the attendance model: primary_key__meeting_type (carries both a 'None'
+literal and NULL — both are untyped), primary_key__committee_type,
 primary_key__committee_name, primary_key__meeting_name, primary_key__invitee_role,
-primary_key__invitee_voting_status. PROJECTS through the conformed entity:
-project__foundation_slug for a foundation, project__slug for one project,
-project__project_path LIKE '%/<slug>/%' for a subtree. ORGANIZATIONS:
-primary_key__account_name is the invitee's account as the source spelled it —
-there is no account entity, so no rollup, no subsidiaries, and recipe 6's
-acronym trap applies; two buckets are not companies: '' (no account) and
-'Individual - No Account' — report both as unattributed. No standard metric
-covers meetings: compose them here and label the figure ad hoc. TWO ROUTES, TWO DEFINITIONS. search_past_meetings returns a paged listing. count_lfx_resources provides meeting counts and search_past_meeting_participants with count_only=true provides participant counts; both count what the caller's identity may see, the same visibility as LFX Self Serve, and say whether the count is complete; this layer's attendance model counts attendance records across every meeting in the warehouse with no per-caller visibility. The two differ by design and neither is wrong. Cite a tool figure as 'meetings (or participants) visible to you' and a layer figure as 'attendances, all meetings, interim'; never reconcile one against the other; prefer the tools for any question about a project's or committee's own meetings, and the layer only for an aggregate by company, committee type or meeting type over a period. The meeting tools take date_from and date_to, inclusive, with date-only values read as UTC day boundaries; the standard metrics say the same thing as start_date and end_date. Seats for an organisation come from get_org_committee_seats, complete for the scope and gated on the organisation grant; the committee models in this layer carry no per-user access and are not the route for an organisation's seats.
+primary_key__invitee_voting_status. PROJECTS on both models through the
+conformed entity: project__foundation_slug for a foundation, project__slug for
+one project, project__project_path LIKE '%/<slug>/%' for a subtree; an
+occurrence shared by several projects is attributed to one of them.
+ORGANIZATIONS (attendance model only): primary_key__account_name is the
+invitee's account as the source spelled it — there is no account entity, so no rollup,
+no subsidiaries, and recipe 6's acronym trap applies; two buckets are not
+companies: '' (no account) and 'Individual - No Account' — report both as
+unattributed. No standard metric covers meetings: compose them here with these
+names. TWO ROUTES, TWO DEFINITIONS. search_past_meetings returns a paged listing. count_lfx_resources provides meeting counts and search_past_meeting_participants with count_only=true provides participant counts; both count what the caller's identity may see, the same visibility as LFX Self Serve, and say whether the count is complete; this layer's meeting models count every meeting in the warehouse with no per-caller visibility. The two differ by design and neither is wrong. Cite a tool figure as 'meetings (or participants) visible to you' and a layer figure as 'all meetings in the warehouse'; never reconcile one against the other; prefer the tools for a project's or committee's own meeting list, details and caller-visible counts, and the layer for totals over a period — occurrences, scheduled minutes, attendees, attendances — LF-wide or by foundation, project subtree, company, committee type or meeting type. The meeting tools take date_from and date_to, inclusive, with date-only values read as UTC day boundaries; the standard metrics say the same thing as start_date and end_date. Seats for an organisation come from get_org_committee_seats, complete for the scope and gated on the organisation grant; the committee models in this layer carry no per-user access and are not the route for an organisation's seats.
 
 13. REGIONS. country__* follows the person; organization_lf_region etc. follow the org's HQ.
 

--- a/internal/tools/guidance_test.go
+++ b/internal/tools/guidance_test.go
@@ -159,7 +159,9 @@ func TestSemanticLayerGuidanceContent(t *testing.T) {
 		"search_committee_members",
 		"Never infer a roster",
 		"search_past_meetings",
-		"attendance\nRECORDS, not unique people",
+		"meeting_occurrences (distinct occurrences held) and scheduled_meeting_minutes\n(sum of the scheduled duration",
+		"unique_attendees (distinct PEOPLE who attended",
+		"attendees_count (attendance RECORDS where the invitee attended",
 		"'Individual - No Account'",
 		"there is no account entity, so no rollup",
 		// events/training/sponsorships account entities and tiers

--- a/internal/tools/lens.go
+++ b/internal/tools/lens.go
@@ -43,7 +43,7 @@ func RegisterQueryLFXLens(server *mcp.Server) {
 
 Use this tool ONLY as a FALLBACK: switch here only when the semantic layer genuinely cannot express the question - after discovery (list_metrics, get_dimensions, get_dimension_values), the read_lfx_semantic_layer_guidance recipes, and two differently-formulated queries have failed - or when a guidance document routes the question here directly (a cross-domain join; an org breakdown on a standard-metric family that rejects org: one query, as the guidance says). Zero rows or an unknown-name error is a discovery failure, not a reason to switch. Membership counts on any date or by year are the memberships standard metric (start_date/end_date/period), not this tool.
 
-Everything else - contributors, activities, memberships, events and sponsorships, registrations, education, maintainer rosters/counts/names, health, social listening (mentions, sentiment, reach) - is a standard metric first (query_lfx_standard_metrics; inventory in read_lfx_standard_metrics_guidance), then explore_lfx_semantic_layer + query_lfx_semantic_layer when no family fits. Committee/board rosters: the committee tools.
+Everything else - contributors, activities, memberships, events and sponsorships, registrations, education, maintainer rosters/counts/names, health, social listening (mentions, sentiment, reach), meeting totals (occurrences, scheduled minutes, attendees) - is a standard metric first (query_lfx_standard_metrics; inventory in read_lfx_standard_metrics_guidance), then explore_lfx_semantic_layer + query_lfx_semantic_layer when no family fits. Committee/board rosters: the committee tools.
 
 project_slugs is optional. Omit it for LF-wide questions: no project or foundation filter is applied. Pass exact slugs from search_projects to scope to them; several slugs are combined, so a JDF series plus its -fund parent, or a multi-foundation comparison, is one call. Unknown slugs are rejected. Every answer opens with the scope the caller gave.
 
@@ -250,7 +250,7 @@ func normalizeSlugs(slugs []string) ([]string, error) {
 // there before its first query.
 const exploreSemanticLayerDescription = `If a standard metric answers the question (inventory: read_lfx_standard_metrics_guidance), call query_lfx_standard_metrics and do not explore first.
 
-The LFX Semantic Layer is the query tool for LF data: contributor, contribution, membership, revenue, event, registration, speaker, sponsorship, enrollment, certification, maintainer, health, project and social listening (mentions, sentiment, reach) metrics, sliceable by country, region, parent organization or project tree. This discovers what can be measured; query_lfx_semantic_layer runs it. Start here unless exact names are known.
+The LFX Semantic Layer is the query tool for LF data: contributor, contribution, membership, revenue, event, registration, speaker, sponsorship, enrollment, certification, maintainer, health, project, meeting (occurrences, scheduled minutes, attendees) and social listening (mentions, sentiment, reach) metrics, sliceable by country, region, parent organization or project tree. This discovers what can be measured; query_lfx_semantic_layer runs it. Start here unless exact names are known.
 
 If you have not read read_lfx_semantic_layer_guidance yet this session, read it BEFORE using this tool; one read also covers query_lfx_semantic_layer.
 


### PR DESCRIPTION
## What

Guidance and tool-description update for the three meeting metrics that landed on the semantic layer with lf-dbt #2892 and are allowlisted by the companion lfx-lens PR:

- `semantic-layer.md` recipe 12 now describes two models: occurrences (`meeting_occurrences`, `scheduled_meeting_minutes`, the `meeting_and_occurrence_id__has_attendance` filter) and attendance (`unique_attendees` beside `attendees_count`, `invited_count`, `unverified_attendee_count`). It keeps the two distinctions that make the answers honest: scheduled minutes are not time spent (join and leave times are not recorded), and `unique_attendees` counts people while `attendees_count` counts attendance records. The routing bullet at the top and the "two routes, two definitions" paragraph say the same thing: tools for a project's or committee's own meeting list, details and caller-visible counts; the layer for totals over a period.
- `explore_lfx_semantic_layer` and `query_lfx_lens` descriptions list meeting totals among the layer's domains so callers stop routing them to text-to-SQL.
- Guidance content pins in `guidance_test.go` follow the new wording.

## Newly answerable through the MCP

How many meetings a foundation or the whole LF held over a period, how many scheduled minutes, and how many distinct people attended, as governed metrics rather than generated SQL.

## Verification

`gofmt`, `go vet` and `go test ./internal/tools/` clean. The metric and dimension names in the guidance were verified against the production semantic layer (the three metrics answer for the deck window with the figures accepted on lf-dbt #2892).

## Deployment order

After the lfx-lens allowlist PR; this guidance names metrics the lens rejects until that one is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
